### PR TITLE
[init] Remove annoying error.

### DIFF
--- a/sortinghat/cmd/init.py
+++ b/sortinghat/cmd/init.py
@@ -97,7 +97,6 @@ class Init(Command):
             Database.create(user, password, name, host, port)
             # Try to access and create schema
             db = Database(user, password, name, host, port)
-            self.error("db assigned")
             # Load countries list
             self.__load_countries(db)
         except DatabaseExists as e:


### PR DESCRIPTION
This line caused an error message to show up, in case when no error was really happening (just the database was initialized). That caused users to think something was wrong.