### PR TITLE
[autoprofile] Avoid exception when no id in selected data sources

### DIFF
--- a/sortinghat/cmd/autoprofile.py
+++ b/sortinghat/cmd/autoprofile.py
@@ -112,6 +112,10 @@ class AutoProfile(Command):
             except (NotFoundError, WrappedValueError) as e:
                 self.error(str(e))
                 return e.code
+            except UnboundLocalError as e:
+                self.display('autoprofile.tmpl',
+                             identity={'uuid': uuid, 'source': 'Not Found'}
+                             )
 
         return CMD_SUCCESS
 


### PR DESCRIPTION
Fixes #122

In some cases, a uuid has only ids for data sources which are not among those selected for autoprofiling. In this case, it may happen that one of those uuids is selected for autoprofiling, and no id is going to be found (because only those corresponding to the selected data sources are considered). This patch catches the exception that is raised in that case.

A better fix is described in #122.