### PR TITLE
[tests] Fix non-deterministic tests

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -919,7 +919,9 @@ def match_identities(db, uuid, matcher):
             raise NotFoundError(entity=uuid)
 
         # Get all identities expect of the one requested one query above (uid)
-        candidates = session.query(UniqueIdentity).filter(UniqueIdentity.uuid != uuid).all()
+        candidates = session.query(UniqueIdentity).\
+            filter(UniqueIdentity.uuid != uuid).\
+            order_by(UniqueIdentity.uuid)
 
         for candidate in candidates:
             if not matcher.match(uid, candidate):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1682,7 +1682,8 @@ class TestMergeEnrollments(TestAPICaseBase):
             enrollments = session.query(Enrollment).\
                 join(UniqueIdentity, Organization).\
                 filter(UniqueIdentity.uuid == 'John Doe',
-                       Organization.name == 'Example').all()
+                       Organization.name == 'Example').\
+                order_by(Enrollment.start).all()
             self.assertEqual(len(enrollments), 2)
 
             rol0 = enrollments[0]
@@ -1700,7 +1701,8 @@ class TestMergeEnrollments(TestAPICaseBase):
             enrollments = session.query(Enrollment).\
                 join(UniqueIdentity, Organization).\
                 filter(UniqueIdentity.uuid == 'Jane Rae',
-                       Organization.name == 'Bitergia').all()
+                       Organization.name == 'Bitergia').\
+                order_by(Enrollment.start).all()
             self.assertEqual(len(enrollments), 2)
 
             rol0 = enrollments[0]


### PR DESCRIPTION
Some tests are not deterministic due to how results are ordered
after having searched them.