### PR TITLE
[parsing:sh] Make gender profile info not required

### DIFF
--- a/sortinghat/parsing/sh.py
+++ b/sortinghat/parsing/sh.py
@@ -207,7 +207,12 @@ class SortingHatParser(object):
 
                     is_bot = profile['is_bot']
 
-                    gender_acc = profile['gender_acc']
+                    gender = profile.get('gender', None)
+
+                    if gender is not None:
+                        gender = self.__encode(gender)
+
+                    gender_acc = profile.get('gender_acc', None)
 
                     if gender_acc is not None:
                         if type(gender_acc) != int:
@@ -219,7 +224,6 @@ class SortingHatParser(object):
 
                     name = self.__encode(profile['name'])
                     email = self.__encode(profile['email'])
-                    gender = self.__encode(profile['gender'])
 
                     prf = Profile(uuid=uuid, name=name, email=email,
                                   gender=gender, gender_acc=gender_acc,

--- a/tests/data/sortinghat_valid_no_gender.json
+++ b/tests/data/sortinghat_valid_no_gender.json
@@ -1,0 +1,78 @@
+{
+    "source": null,
+    "time": "2015-01-14 13:31:19.507613",
+    "blacklist": [
+        "John Smith",
+        "jroe@example.com"
+    ],
+    "organizations": {
+        "Bitergia": [
+            {
+                "domain": "api.bitergia.com",
+                "is_top": false
+            },
+            {
+                "domain": "bitergia.com",
+                "is_top": true
+            },
+            {
+                "domain": "bitergia.net",
+                "is_top": true
+            },
+            {
+                "domain": "test.bitergia.com",
+                "is_top": false
+            }
+        ],
+        "Example": [
+            {
+                "domain": "example.com",
+                "is_top": true
+            },
+            {
+                "domain": "example.net",
+                "is_top": true
+            }
+        ],
+        "Unknown": [
+        ]
+    },
+    "uidentities": {
+        "03e12d00e37fd45593c49a5a5a1652deca4cf302": {
+            "enrollments": [
+                {
+                    "end": "2100-01-01T00:00:00",
+                    "start": "1900-01-01T00:00:00",
+                    "organization": "Example",
+                    "uuid": "03e12d00e37fd45593c49a5a5a1652deca4cf302"
+                }
+            ],
+            "identities": [
+                {
+                    "email": "jsmith@example.com",
+                    "id": "03e12d00e37fd45593c49a5a5a1652deca4cf302",
+                    "name": "John Smith",
+                    "source": "scm",
+                    "username": "jsmith",
+                    "uuid": "03e12d00e37fd45593c49a5a5a1652deca4cf302"
+                },
+                {
+                    "email": "jsmith@example.com",
+                    "id": "75d95d6c8492fd36d24a18bd45d62161e05fbc97",
+                    "name": "John Smith",
+                    "source": "scm",
+                    "username": null,
+                    "uuid": "03e12d00e37fd45593c49a5a5a1652deca4cf302"
+                }
+            ],
+            "profile": {
+                "country": null,
+                "email": "jsmith@example.com",
+                "name": null,
+                "is_bot": true,
+                "uuid": "03e12d00e37fd45593c49a5a5a1652deca4cf302"
+            },
+            "uuid": "03e12d00e37fd45593c49a5a5a1652deca4cf302"
+        }
+    }
+}

--- a/tests/test_parser_sh.py
+++ b/tests/test_parser_sh.py
@@ -212,6 +212,32 @@ class TestSortingHatParser(TestBaseCase):
         self.assertEqual(rol2.start, datetime.datetime(1900, 1, 1, 0, 0))
         self.assertEqual(rol2.end, datetime.datetime(2100, 1, 1, 0, 0))
 
+    def test_no_gender(self):
+        """Check whether if parses identidies without gender information"""
+
+        stream = self.read_file('data/sortinghat_valid_no_gender.json')
+
+        parser = SortingHatParser(stream)
+        uids = parser.identities
+
+        # Check parsed identities
+        self.assertEqual(len(uids), 1)
+
+        # John Smith
+        uid = uids[0]
+        self.assertIsInstance(uid, UniqueIdentity)
+        self.assertEqual(uid.uuid, '03e12d00e37fd45593c49a5a5a1652deca4cf302')
+
+        prf = uid.profile
+        self.assertEqual(prf.uuid, '03e12d00e37fd45593c49a5a5a1652deca4cf302')
+        self.assertEqual(prf.name, None)
+        self.assertEqual(prf.email, 'jsmith@example.com')
+        self.assertEqual(prf.gender, None)
+        self.assertEqual(prf.gender_acc, None)
+        self.assertEqual(prf.is_bot, True)
+        self.assertEqual(prf.country_code, None)
+        self.assertEqual(prf.country, None)
+
     def test_valid_organizations_stream(self):
         """Check whether it parses organizations section from a valid stream"""
 


### PR DESCRIPTION
To support compatibilty between versions, gender data is not required anymore while parsing SH files.