### PR TITLE
[tests] Adapt tests to run with setup.py test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,29 +5,18 @@ python:
 
 sudo: false
 
-before_install:
-  - pip install PyMySQL>=0.7.0
-  - pip install SQLAlchemy>=1.1.15
-  - pip install Jinja2
-  - pip install python-dateutil>=2.6.0
-  - pip install pandas==0.18.1
-  - pip install requests>=2.9
-  - pip install httpretty>=0.9.5
-  - pip install coveralls
-
 install:
-  - ./setup.py install
+  - pip install coveralls
 
 before_script:
   - mysql -e 'create database testhat;'
   - cp tests/tests.conf.sample tests/tests.conf
 
 script:
-  - cd tests
-  - coverage run --source=sortinghat run_tests.py
+  - coverage run --source=sortinghat setup.py test
 
 after_success:
   - coveralls
 
 notifications:
-  irc: "chat.freenode.net#metrics-grimoire"
+  irc: "chat.freenode.net#grimoirelab"

--- a/README.md
+++ b/README.md
@@ -381,6 +381,26 @@ Optionally, you can install Pandas library to speed up the matching process:
 
 * python-pandas >= 0.15
 
+## Running tests
+
+SortingHat comes with a comprehensive list of unit tests.
+To run them, copy the file 'tests/tests.conf.sample' to 'tests/tests.conf'
+and edit it to suit your configuration:
+
+* `name`: Name of the database to use for testing
+* `host`, `port`: How to access the database server (MySQL, MariaDB)
+* `user`, `password`: Credentials for the database server
+* `create`: Whether the database for testing will be created (`True`)
+  or not (`False`, by default). If `True`, tests will fail if database
+  already exists. If `False`, tests will fail if database does not exist.
+
+You can run the tests through `setup.py` (no need to install dependencies
+  or something else, `setup.py` will take care of that):
+
+```
+$ python3 setup.py test
+```
+
 ## Troubleshooting
 
 Once SortingHat has been installed, some errors may pop up when running the test suite due to the underlying MySQL

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2014-2015 Bitergia
@@ -22,13 +22,14 @@
 #
 
 import codecs
-import os
+import os.path
 import re
 import sys
 import unittest
 
 # Always prefer setuptools over distutils
-from setuptools import setup, Command
+from setuptools import setup
+from setuptools.command.test import test as TestClass
 
 here = os.path.abspath(os.path.dirname(__file__))
 readme_md = os.path.join(here, 'README.md')
@@ -52,18 +53,16 @@ with codecs.open(version_py, 'r', encoding='utf-8') as fd:
                         fd.read(), re.MULTILINE).group(1)
 
 
-class TestCommand(Command):
+class TestCommand(TestClass):
 
     user_options = []
     __dir__ = os.path.dirname(os.path.realpath(__file__))
 
     def initialize_options(self):
-        os.chdir(os.path.join(self.__dir__, 'tests'))
+        super().initialize_options()
+        sys.path.insert(0, os.path.join(self.__dir__, 'tests'))
 
-    def finalize_options(self):
-        pass
-
-    def run(self):
+    def run_tests(self):
         test_suite = unittest.TestLoader().discover('.', pattern='test*.py')
         result = unittest.TextTestRunner(buffer=True).run(test_suite)
         sys.exit(not result.wasSuccessful())
@@ -106,6 +105,12 @@ setup(name="sortinghat",
         "misc/mailmap2sh",
         "misc/mozilla2sh",
         "misc/stackalytics2sh"
+      ],
+      setup_requires=[
+        'wheel',
+        'pandoc'],
+      tests_require=[
+        'httpretty>=0.9.5'
       ],
       install_requires=[
         'PyMySQL>=0.7.0',

--- a/tests/test_cmd_config.py
+++ b/tests/test_cmd_config.py
@@ -32,10 +32,10 @@ if '..' not in sys.path:
 from sortinghat.command import CMD_SUCCESS
 from sortinghat.cmd.config import Config
 
-from tests.base import TestCommandCaseBase
+from tests.base import TestCommandCaseBase, datadir
 
 
-MOCK_CONFIG_FILE = './data/mock_config_file.cfg'
+MOCK_CONFIG_FILE = datadir('mock_config_file.cfg')
 
 INVALID_CONFIG_FILE = "Configuration file not given"
 SET_KEY_CONFIG_ERROR = "%(param)s parameter does not exists or cannot be set"
@@ -202,7 +202,7 @@ class TestGetConfig(TestConfigCaseBase):
         # Test non existing file
         self.assertRaisesRegex(RuntimeError, NOT_FOUND_FILE_ERROR,
                                self.cmd.get, 'db.user',
-                               './data/invalid_config_file.cfg')
+                               datadir('invalid_config_file.cfg'))
 
     def test_get_value(self):
         """Test get method"""

--- a/tests/test_cmd_export.py
+++ b/tests/test_cmd_export.py
@@ -36,7 +36,7 @@ from sortinghat.cmd.export import Export,\
     SortingHatIdentitiesExporter, SortingHatOrganizationsExporter
 from sortinghat.db.model import Country
 
-from tests.base import TestCommandCaseBase
+from tests.base import TestCommandCaseBase, datadir
 
 
 class TestExportCaseBase(TestCommandCaseBase):
@@ -132,7 +132,7 @@ class TestExportCommand(TestExportCaseBase):
         # both are the same. To compare, we generate a dict object
         # removing 'time' key.
         a = self.read_json(self.tmpfile)
-        b = self.read_json('data/sortinghat_identities_valid.json')
+        b = self.read_json(datadir('sortinghat_identities_valid.json'))
 
         a.pop('time')
         b.pop('time')
@@ -147,7 +147,7 @@ class TestExportCommand(TestExportCaseBase):
         self.assertEqual(code, CMD_SUCCESS)
 
         a = self.read_json(self.tmpfile)
-        b = self.read_json('data/sortinghat_identities_source.json')
+        b = self.read_json(datadir('sortinghat_identities_source.json'))
 
         a.pop('time')
         b.pop('time')
@@ -164,7 +164,7 @@ class TestExportCommand(TestExportCaseBase):
         # both are the same. To compare, we generate a dict object
         # removing 'time' key.
         a = self.read_json(self.tmpfile)
-        b = self.read_json('data/sortinghat_orgs.json')
+        b = self.read_json(datadir('sortinghat_orgs.json'))
 
         a.pop('time')
         b.pop('time')
@@ -186,7 +186,7 @@ class TestExportIdentities(TestExportCaseBase):
         # both are the same. To compare, we generate a dict object
         # removing 'time' key.
         a = self.read_json(self.tmpfile)
-        b = self.read_json('data/sortinghat_identities_valid.json')
+        b = self.read_json(datadir('sortinghat_identities_valid.json'))
 
         a.pop('time')
         b.pop('time')
@@ -201,7 +201,7 @@ class TestExportIdentities(TestExportCaseBase):
             self.assertEqual(code, CMD_SUCCESS)
 
         a = self.read_json(self.tmpfile)
-        b = self.read_json('data/sortinghat_identities_source.json')
+        b = self.read_json(datadir('sortinghat_identities_source.json'))
 
         a.pop('time')
         b.pop('time')
@@ -433,7 +433,7 @@ class TestExportOrganizations(TestExportCaseBase):
         # both are the same. To compare, we generate a dict object
         # removing 'time' key.
         a = self.read_json(self.tmpfile)
-        b = self.read_json('data/sortinghat_orgs.json')
+        b = self.read_json(datadir('sortinghat_orgs.json'))
 
         a.pop('time')
         b.pop('time')

--- a/tests/test_cmd_init.py
+++ b/tests/test_cmd_init.py
@@ -40,7 +40,7 @@ from sortinghat.exceptions import CODE_DATABASE_ERROR, CODE_DATABASE_EXISTS, \
 DB_ACCESS_ERROR = r".+Access denied for user '%(user)s'@"
 DB_EXISTS_ERROR = r".+Can't create database '%(database)s'; database exists \(err: 1007\)"
 
-CONFIG_FILE = 'tests.conf'
+from tests.base import CONFIG_FILE
 
 
 class TestInitCaseBase(unittest.TestCase):

--- a/tests/test_cmd_load.py
+++ b/tests/test_cmd_load.py
@@ -21,6 +21,7 @@
 #
 
 import datetime
+import os.path
 import sys
 import unittest
 import warnings
@@ -35,8 +36,7 @@ from sortinghat.db.model import Country
 from sortinghat.parsing.sh import SortingHatParser
 from sortinghat.exceptions import CODE_MATCHER_NOT_SUPPORTED_ERROR, CODE_INVALID_FORMAT_ERROR
 
-from tests.base import TestCommandCaseBase
-
+from tests.base import TestCommandCaseBase, datadir
 
 LOAD_BLACKLIST_EMPTY_STRINGS_ERROR = "Error: invalid json format. Blacklist entries cannot be null or empty"
 LOAD_IDENTITIES_INVALID_JSON_FORMAT_ERROR = "Error: invalid json format. Expecting ',' delimiter: line 86 column 17 (char 2821)"
@@ -206,7 +206,7 @@ class TestLoadCommand(TestLoadCaseBase):
     def test_load(self):
         """Test to load identities and organizations from a file"""
 
-        code = self.cmd.run('data/sortinghat_valid.json', '--verbose')
+        code = self.cmd.run(datadir('sortinghat_valid.json'), '--verbose')
         self.assertEqual(code, CMD_SUCCESS)
 
         uids = api.unique_identities(self.db)
@@ -221,7 +221,8 @@ class TestLoadCommand(TestLoadCaseBase):
     def test_load_identities(self):
         """Test to load identities from a file"""
 
-        code = self.cmd.run('--identities', 'data/sortinghat_valid.json', '--verbose')
+        code = self.cmd.run('--identities', datadir('sortinghat_valid.json'),
+                            '--verbose')
         self.assertEqual(code, CMD_SUCCESS)
 
         uids = api.unique_identities(self.db)
@@ -242,7 +243,7 @@ class TestLoadCommand(TestLoadCaseBase):
         """Test to load identities from a file using default matching"""
 
         code = self.cmd.run('--identities', '--matching', 'default',
-                            'data/sortinghat_valid.json',
+                            datadir('sortinghat_valid.json'),
                             '--verbose')
         self.assertEqual(code, CMD_SUCCESS)
 
@@ -261,7 +262,7 @@ class TestLoadCommand(TestLoadCaseBase):
 
         code = self.cmd.run('--identities', '--matching', 'default',
                             '--no-strict-matching',
-                            'data/sortinghat_no_strict_valid.json',
+                            datadir('sortinghat_no_strict_valid.json'),
                             '--verbose')
         self.assertEqual(code, CMD_SUCCESS)
 
@@ -271,7 +272,7 @@ class TestLoadCommand(TestLoadCaseBase):
     def test_load_identities_invalid_file(self):
         """Test whether it prints error messages while reading invalid files"""
 
-        code = self.cmd.run('--identities', 'data/sortinghat_invalid.json')
+        code = self.cmd.run('--identities', datadir('sortinghat_invalid.json'))
         self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[0]
         self.assertEqual(output, LOAD_IDENTITIES_INVALID_JSON_FORMAT_ERROR)
@@ -279,7 +280,7 @@ class TestLoadCommand(TestLoadCaseBase):
     def test_load_organizations(self):
         """Test to load organizations from a file"""
 
-        code = self.cmd.run('--orgs', 'data/sortinghat_orgs_valid.json')
+        code = self.cmd.run('--orgs', datadir('sortinghat_orgs_valid.json'))
         self.assertEqual(code, CMD_SUCCESS)
 
         uids = api.unique_identities(self.db)
@@ -298,7 +299,7 @@ class TestLoadCommand(TestLoadCaseBase):
         """Test to load organizations from a file with overwrite parameter set"""
 
         code = self.cmd.run('--orgs', '--overwrite',
-                            'data/sortinghat_orgs_valid.json')
+                            datadir('sortinghat_orgs_valid.json'))
         self.assertEqual(code, CMD_SUCCESS)
         output = sys.stdout.getvalue().strip()
         self.assertEqual(output, LOAD_ORGS_OVERWRITE_OUTPUT)
@@ -306,34 +307,34 @@ class TestLoadCommand(TestLoadCaseBase):
     def test_invalid_format(self):
         """Check whether it prints an error when parsing invalid files"""
 
-        code = self.cmd.run('data/sortinghat_invalid.json')
+        code = self.cmd.run(datadir('sortinghat_invalid.json'))
         self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[0]
         self.assertEqual(output, LOAD_IDENTITIES_INVALID_JSON_FORMAT_ERROR)
 
-        code = self.cmd.run('data/sortinghat_ids_missing_keys.json')
+        code = self.cmd.run(datadir('sortinghat_ids_missing_keys.json'))
         self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[1]
         self.assertEqual(output, LOAD_IDENTITIES_MISSING_KEYS_ERROR)
 
         # Context added to catch deprecation warnings raised on Python 3
         with warnings.catch_warnings(record=True):
-            code = self.cmd.run('data/sortinghat_orgs_invalid_json.json')
+            code = self.cmd.run(datadir('sortinghat_orgs_invalid_json.json'))
             self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
             output = sys.stderr.getvalue().strip().split('\n')[2]
             self.assertRegexpMatches(output, LOAD_ORGS_INVALID_FORMAT_ERROR)
 
-        code = self.cmd.run('data/sortinghat_orgs_missing_keys.json')
+        code = self.cmd.run(datadir('sortinghat_orgs_missing_keys.json'))
         self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[3]
         self.assertEqual(output, LOAD_ORGS_MISSING_KEYS_ERROR)
 
-        code = self.cmd.run('data/sortinghat_orgs_invalid_top.json')
+        code = self.cmd.run(datadir('sortinghat_orgs_invalid_top.json'))
         self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[4]
         self.assertEqual(output, LOAD_ORGS_IS_TOP_ERROR)
 
-        code = self.cmd.run('data/sortinghat_blacklist_empty_strings.json')
+        code = self.cmd.run(datadir('sortinghat_blacklist_empty_strings.json'))
         self.assertEqual(code, CODE_INVALID_FORMAT_ERROR)
         output = sys.stderr.getvalue().strip().split('\n')[5]
         self.assertEqual(output, LOAD_BLACKLIST_EMPTY_STRINGS_ERROR)
@@ -345,7 +346,7 @@ class TestLoadBlacklist(TestLoadCaseBase):
     def test_valid_file(self):
         """Check insertion of valid data from a file"""
 
-        parser = self.get_parser('data/sortinghat_valid.json')
+        parser = self.get_parser(datadir('sortinghat_valid.json'))
 
         self.cmd.import_blacklist(parser)
 
@@ -367,7 +368,7 @@ class TestLoadIdentities(TestLoadCaseBase):
     def test_valid_identities_file(self):
         """Check insertion of valid data from a file"""
 
-        parser = self.get_parser('data/sortinghat_valid.json')
+        parser = self.get_parser(datadir('sortinghat_valid.json'))
 
         code = self.cmd.import_identities(parser)
         self.assertEqual(code, CMD_SUCCESS)
@@ -486,7 +487,7 @@ class TestLoadIdentities(TestLoadCaseBase):
         api.edit_profile(self.db, uuid, name='John Smith', is_bot=False,
                          country_code='US')
 
-        parser = self.get_parser('data/sortinghat_valid.json')
+        parser = self.get_parser(datadir('sortinghat_valid.json'))
 
         code = self.cmd.import_identities(parser, matching='default')
         self.assertEqual(code, CMD_SUCCESS)
@@ -590,7 +591,7 @@ class TestLoadIdentities(TestLoadCaseBase):
     def test_match_new_identities(self):
         """Check whether it matches only new identities"""
 
-        parser = self.get_parser('data/sortinghat_valid.json')
+        parser = self.get_parser(datadir('sortinghat_valid.json'))
 
         code = self.cmd.import_identities(parser, matching='default')
         self.assertEqual(code, CMD_SUCCESS)
@@ -607,7 +608,7 @@ class TestLoadIdentities(TestLoadCaseBase):
         self.assertEqual(len(uids), 3)
 
         # This file has a new identity, only Jane Roe will match.
-        parser = self.get_parser('data/sortinghat_valid_updated.json')
+        parser = self.get_parser(datadir('sortinghat_valid_updated.json'))
 
         code = self.cmd.import_identities(parser, matching='default',
                                           match_new=True)
@@ -630,7 +631,7 @@ class TestLoadIdentities(TestLoadCaseBase):
 
         # Now, if we reload again the file but setting 'match_new' to false,
         # the identity that we inserted before will match "John Smith"
-        parser = self.get_parser('data/sortinghat_valid_updated.json')
+        parser = self.get_parser(datadir('sortinghat_valid_updated.json'))
 
         code = self.cmd.import_identities(parser, matching='default')
         self.assertEqual(code, CMD_SUCCESS)
@@ -657,7 +658,7 @@ class TestLoadIdentities(TestLoadCaseBase):
         # from the file
         api.add_identity(self.db, 'unknown', email='jsmith@example')
 
-        parser = self.get_parser('data/sortinghat_no_strict_valid.json')
+        parser = self.get_parser(datadir('sortinghat_no_strict_valid.json'))
 
         code = self.cmd.import_identities(parser, matching='default',
                                           no_strict_matching=True)
@@ -678,7 +679,7 @@ class TestLoadIdentities(TestLoadCaseBase):
         api.edit_profile(self.db, uuid, name='John Smith', is_bot=False,
                          country_code='US')
 
-        parser = self.get_parser('data/sortinghat_valid.json')
+        parser = self.get_parser(datadir('sortinghat_valid.json'))
 
         code = self.cmd.import_identities(parser)
         self.assertEqual(code, CMD_SUCCESS)
@@ -728,7 +729,7 @@ class TestLoadIdentities(TestLoadCaseBase):
     def test_create_profile_from_identities(self):
         """Check whether a profile is created using the data identities"""
 
-        parser = self.get_parser('data/sortinghat_identities_profiles.json')
+        parser = self.get_parser(datadir('sortinghat_identities_profiles.json'))
 
         code = self.cmd.import_identities(parser)
         self.assertEqual(code, CMD_SUCCESS)
@@ -792,7 +793,7 @@ class TestLoadIdentities(TestLoadCaseBase):
                            datetime.datetime(2000, 1, 1, 0, 0),
                            datetime.datetime(2100, 1, 1, 0, 0))
 
-        parser = self.get_parser('data/sortinghat_valid.json')
+        parser = self.get_parser(datadir('sortinghat_valid.json'))
 
         code = self.cmd.import_identities(parser, reset=True)
         self.assertEqual(code, CMD_SUCCESS)
@@ -862,7 +863,7 @@ class TestLoadIdentities(TestLoadCaseBase):
     def test_dates_out_of_bounds(self):
         """Check dates when they are out of bounds"""
 
-        parser = self.get_parser('data/sortinghat_ids_dates_out_of_bounds.json')
+        parser = self.get_parser(datadir('sortinghat_ids_dates_out_of_bounds.json'))
 
         # This command returns a success value even when some data is wrong
         code = self.cmd.import_identities(parser)
@@ -894,7 +895,7 @@ class TestLoadIdentities(TestLoadCaseBase):
     def test_invalid_matching_method(self):
         """Check if it fails when an invalid matching method is given"""
 
-        parser = self.get_parser('data/sortinghat_valid.json')
+        parser = self.get_parser(datadir('sortinghat_valid.json'))
 
         code = self.cmd.import_identities(parser, matching='mock')
         self.assertEqual(code, CODE_MATCHER_NOT_SUPPORTED_ERROR)
@@ -909,7 +910,7 @@ class TestLoadSortingHatImportOrganizations(TestLoadCaseBase):
     def test_valid_organizations_file(self):
         """Check insertion of valid data from a file"""
 
-        parser = self.get_parser('data/sortinghat_orgs_valid.json')
+        parser = self.get_parser(datadir('sortinghat_orgs_valid.json'))
 
         self.cmd.import_organizations(parser)
 
@@ -974,7 +975,7 @@ class TestLoadSortingHatImportOrganizations(TestLoadCaseBase):
         api.add_domain(self.db, 'Bitergia', 'bitergia.com')
 
         # Import new data, overwriting existing relationships
-        parser = self.get_parser('data/sortinghat_orgs_valid_alt.json')
+        parser = self.get_parser(datadir('sortinghat_orgs_valid_alt.json'))
 
         self.cmd.import_organizations(parser, True)
 

--- a/tests/test_parser_eclipse.py
+++ b/tests/test_parser_eclipse.py
@@ -31,6 +31,8 @@ from sortinghat.db.model import UniqueIdentity, Identity, Organization
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.eclipse import EclipseParser
 
+from tests.base import TestCommandCaseBase, datadir
+
 
 ECLIPSE_INVALID_JSON_FORMAT_ERROR = r"invalid json format\. Expecting ':' delimiter"
 ECLIPSE_IDS_MISSING_KEYS_ERROR = "Attribute active not found"
@@ -55,7 +57,7 @@ class TestEclipseParser(TestBaseCase):
     def test_valid_identities_stream(self):
         """Check insertion of valid data from a file"""
 
-        stream = self.read_file('data/eclipse_valid.json')
+        stream = self.read_file(datadir('eclipse_valid.json'))
 
         parser = EclipseParser(stream, source='unknown')
         uids = parser.identities
@@ -155,7 +157,7 @@ class TestEclipseParser(TestBaseCase):
     def test_valid_organizations_stream(self):
         """Check whether it parses organizations section from a valid stream"""
 
-        stream = self.read_file('data/eclipse_valid.json')
+        stream = self.read_file(datadir('eclipse_valid.json'))
 
         parser = EclipseParser(stream)
         orgs = parser.organizations
@@ -186,22 +188,22 @@ class TestEclipseParser(TestBaseCase):
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     ECLIPSE_INVALID_JSON_FORMAT_ERROR):
-            s = self.read_file('data/eclipse_invalid.json')
+            s = self.read_file(datadir('eclipse_invalid.json'))
             EclipseParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     ECLIPSE_IDS_MISSING_KEYS_ERROR):
-            s = self.read_file('data/eclipse_ids_missing_keys.json')
+            s = self.read_file(datadir('eclipse_ids_missing_keys.json'))
             EclipseParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     ECLIPSE_ORGS_MISSING_KEYS_ERROR):
-            s = self.read_file('data/eclipse_orgs_missing_keys.json')
+            s = self.read_file(datadir('eclipse_orgs_missing_keys.json'))
             EclipseParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     ECLIPSE_DATETIME_ERROR):
-            s = self.read_file('data/eclipse_invalid_datetime.json')
+            s = self.read_file(datadir('eclipse_invalid_datetime.json'))
             EclipseParser(s)
 
     def test_empty_stream(self):

--- a/tests/test_parser_gitdm.py
+++ b/tests/test_parser_gitdm.py
@@ -32,6 +32,8 @@ from sortinghat.db.model import UniqueIdentity, Identity, Enrollment, Organizati
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.gitdm import GitdmParser
 
+from tests.base import TestCommandCaseBase, datadir
+
 
 DOMAINS_INVALID_FORMAT_ERROR = "line %(line)s: invalid format"
 
@@ -50,7 +52,7 @@ class TestGidmParser(TestBaseCase):
     """Test Gitdm parser"""
 
     def test_aliases_parser(self):
-        aliases = self.read_file('data/gitdm_email_aliases_valid.txt')
+        aliases = self.read_file(datadir('gitdm_email_aliases_valid.txt'))
 
         parser = GitdmParser(aliases=aliases)
 
@@ -139,8 +141,8 @@ class TestGidmParser(TestBaseCase):
         self.assertEqual(len(uid.enrollments), 0)
 
     def test_email_validation(self):
-        aliases = self.read_file('data/gitdm_email_aliases_valid.txt')
-        email_to_employer = self.read_file('data/gitdm_email_to_employer_invalid.txt')
+        aliases = self.read_file(datadir('gitdm_email_aliases_valid.txt'))
+        email_to_employer = self.read_file(datadir('gitdm_email_to_employer_invalid.txt'))
 
         with self.assertRaises(InvalidFormatError):
             GitdmParser(aliases=aliases,
@@ -148,7 +150,7 @@ class TestGidmParser(TestBaseCase):
                         source='unknown', email_validation=True)
 
     def test_supress_email_validation(self):
-        email_to_employer = self.read_file('data/gitdm_email_to_employer_invalid.txt')
+        email_to_employer = self.read_file(datadir('gitdm_email_to_employer_invalid.txt'))
 
         parser = GitdmParser(email_to_employer=email_to_employer,
                              source='unknown', email_validation=False)
@@ -171,8 +173,8 @@ class TestGidmParser(TestBaseCase):
             self.assertEqual(id.uuid, None)
 
     def test_enrollments_parser(self):
-        aliases = self.read_file('data/gitdm_email_aliases_valid.txt')
-        email_to_employer = self.read_file('data/gitdm_email_to_employer_valid.txt')
+        aliases = self.read_file(datadir('gitdm_email_aliases_valid.txt'))
+        email_to_employer = self.read_file(datadir('gitdm_email_to_employer_valid.txt'))
 
         parser = GitdmParser(aliases=aliases,
                              email_to_employer=email_to_employer,
@@ -331,7 +333,7 @@ class TestGidmParser(TestBaseCase):
     def test_organizations_parser(self):
         """Check whether it parses a valid organizations file"""
 
-        stream = self.read_file('data/gitdm_orgs_valid.txt')
+        stream = self.read_file(datadir('gitdm_orgs_valid.txt'))
 
         parser = GitdmParser(domain_to_employer=stream)
 
@@ -413,12 +415,12 @@ class TestGidmParser(TestBaseCase):
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     DOMAINS_INVALID_FORMAT_ERROR % {'line': '10'}):
-            stream = self.read_file('data/gitdm_orgs_invalid_comments.txt')
+            stream = self.read_file(datadir('gitdm_orgs_invalid_comments.txt'))
             GitdmParser(domain_to_employer=stream)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     DOMAINS_INVALID_FORMAT_ERROR % {'line': '8'}):
-            stream = self.read_file('data/gitdm_orgs_invalid_entries.txt')
+            stream = self.read_file(datadir('gitdm_orgs_invalid_entries.txt'))
             GitdmParser(domain_to_employer=stream)
 
 

--- a/tests/test_parser_grimoirelab.py
+++ b/tests/test_parser_grimoirelab.py
@@ -32,6 +32,8 @@ from sortinghat.db.model import UniqueIdentity, Identity, Enrollment, Organizati
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.grimoirelab import GrimoireLabParser
 
+from tests.base import TestCommandCaseBase, datadir
+
 
 class TestBaseCase(unittest.TestCase):
     """Defines common methods for unit tests"""
@@ -55,7 +57,7 @@ class TestGrimoreLabParser(TestBaseCase):
     def test_identities_parser(self):
         """Check whether it parses a valid identities file"""
 
-        stream_ids = self.read_file('data/grimoirelab_valid.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_valid.yml'))
 
         parser = GrimoireLabParser(stream_ids)
 
@@ -168,7 +170,7 @@ class TestGrimoreLabParser(TestBaseCase):
     def test_organizations_parser(self):
         """Check whether it parses a valid organizations file"""
 
-        stream_orgs = self.read_file('data/grimoirelab_orgs_valid.yml')
+        stream_orgs = self.read_file(datadir('grimoirelab_orgs_valid.yml'))
 
         parser = GrimoireLabParser(organizations=stream_orgs)
 
@@ -239,7 +241,7 @@ class TestGrimoreLabParser(TestBaseCase):
     def test_enrollments_parser(self):
         """Check whether enrollments are correctly parsed"""
 
-        stream_ids = self.read_file('data/grimoirelab_valid.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_valid.yml'))
 
         parser = GrimoireLabParser(stream_ids)
 
@@ -281,7 +283,7 @@ class TestGrimoreLabParser(TestBaseCase):
     def test_email_validation(self):
         """Check wheter it raises an error on invalid email addresses"""
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_email.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_email.yml'))
 
         with self.assertRaisesRegex(InvalidFormatError, '^.+Invalid email address: lcanas__at__bitergia.com$'):
             GrimoireLabParser(stream_ids, email_validation=True)
@@ -289,7 +291,7 @@ class TestGrimoreLabParser(TestBaseCase):
     def test_supress_email_validation(self):
         """Check wheter it ignores invalid email addresses"""
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_email.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_email.yml'))
         parser = GrimoireLabParser(stream_ids, email_validation=False)
 
         uids = parser.identities
@@ -313,62 +315,62 @@ class TestGrimoreLabParser(TestBaseCase):
         """Check whether it parses invalid organizations files"""
 
         # empty domains
-        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_empty_domains.yml')
+        stream_orgs = self.read_file(datadir('grimoirelab_orgs_invalid_empty_domains.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+List of elements expected for organization Bitergia$'):
             GrimoireLabParser(organizations=stream_orgs)
 
         # one of the domains is empty
-        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_domains_list_with_empty_value.yml')
+        stream_orgs = self.read_file(datadir('grimoirelab_orgs_invalid_domains_list_with_empty_value.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Empty domain name for organization Bitergia$'):
             GrimoireLabParser(organizations=stream_orgs)
 
         # domains got a string instead of a list
-        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_wrong_domains_type.yml')
+        stream_orgs = self.read_file(datadir('grimoirelab_orgs_invalid_wrong_domains_type.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+List of elements expected for organization Bitergia$'):
             GrimoireLabParser(organizations=stream_orgs)
 
         # organization key missing
-        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_missing_key.yml')
+        stream_orgs = self.read_file(datadir('grimoirelab_orgs_invalid_missing_key.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Attribute organization not found$'):
             GrimoireLabParser(organizations=stream_orgs)
 
         # organization key with empty value
-        stream_orgs = self.read_file('data/grimoirelab_orgs_invalid_key_with_no_value.yml')
+        stream_orgs = self.read_file(datadir('grimoirelab_orgs_invalid_key_with_no_value.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Empty organization name$'):
             GrimoireLabParser(organizations=stream_orgs)
 
     def test_not_valid_identities_stream(self):
         """Check whether it parses invalid identities files"""
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_email.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_email.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Invalid email address: lcanas__at__bitergia.com$'):
             GrimoireLabParser(stream_ids)
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_structure.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_structure.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Attribute profile not found$'):
             GrimoireLabParser(stream_ids)
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_missing_accounts.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_missing_accounts.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Attribute name not found$'):
             GrimoireLabParser(stream_ids)
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_missing_profile_name_isbot.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_missing_profile_name_isbot.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Attribute name not found$'):
             GrimoireLabParser(stream_ids)
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_missing_profile.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_missing_profile.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Attribute profile not found$'):
             GrimoireLabParser(stream_ids)
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_missing_organization_name.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_missing_organization_name.yml'))
         with self.assertRaisesRegex(InvalidFormatError, '^.+Empty organization name$'):
             GrimoireLabParser(stream_ids)
 
     def test_not_valid_enrollments_parser(self):
         """Check whether data from both identites and organizations files is coherent"""
 
-        stream_ids = self.read_file('data/grimoirelab_invalid_datetime.yml')
-        stream_orgs = self.read_file('data/grimoirelab_orgs_valid.yml')
+        stream_ids = self.read_file(datadir('grimoirelab_invalid_datetime.yml'))
+        stream_orgs = self.read_file(datadir('grimoirelab_orgs_valid.yml'))
 
         with self.assertRaises(InvalidFormatError):
             GrimoireLabParser(stream_ids, stream_orgs)

--- a/tests/test_parser_mailmap.py
+++ b/tests/test_parser_mailmap.py
@@ -31,6 +31,8 @@ from sortinghat.db.model import UniqueIdentity, Identity, Organization
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.mailmap import MailmapParser
 
+from tests.base import TestCommandCaseBase, datadir
+
 
 class TestBaseCase(unittest.TestCase):
     """Defines common methods for unit tests"""
@@ -48,7 +50,7 @@ class TestMailmapParser(TestBaseCase):
     def test_valid_identities_stream(self):
         """Check parsed identities from a valid file"""
 
-        stream = self.read_file('data/mailmap_identities.txt')
+        stream = self.read_file(datadir('mailmap_identities.txt'))
         parser = MailmapParser(stream, source='unknown')
 
         # Check parsed identities
@@ -157,7 +159,7 @@ class TestMailmapParser(TestBaseCase):
     def test_valid_organizations_stream(self):
         """Check parsed orgs and identities from a valid file"""
 
-        stream = self.read_file('data/mailmap_orgs.txt')
+        stream = self.read_file(datadir('mailmap_orgs.txt'))
         parser = MailmapParser(stream, has_orgs=True, source='unknown')
 
         # Check parsed organizations
@@ -258,7 +260,7 @@ class TestMailmapParser(TestBaseCase):
         """Check whether it prints an error when parsing invalid streams"""
 
         with self.assertRaises(InvalidFormatError):
-            s = self.read_file('data/mailmap_invalid.txt')
+            s = self.read_file(datadir('mailmap_invalid.txt'))
             MailmapParser(s)
 
 

--- a/tests/test_parser_mozilla.py
+++ b/tests/test_parser_mozilla.py
@@ -31,6 +31,8 @@ from sortinghat.db.model import UniqueIdentity, Identity, Organization
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.mozilla import MOZILLIANS_ORG, MozilliansParser
 
+from tests.base import TestCommandCaseBase, datadir
+
 
 MOZILLIANS_INVALID_JSON_FORMAT_ERROR = r"invalid json format\. Expecting ':' delimiter"
 MOZILLIANS_IDS_MISSING_KEYS_ERROR = "Attribute full_name not found"
@@ -53,7 +55,7 @@ class TestMozilliansParser(TestBaseCase):
     def test_valid_identities_stream(self):
         """Check insertion of valid data from a file"""
 
-        stream = self.read_file('data/mozillians_valid.json')
+        stream = self.read_file(datadir('mozillians_valid.json'))
 
         parser = MozilliansParser(stream, source='unknown')
         uids = parser.identities
@@ -163,7 +165,7 @@ class TestMozilliansParser(TestBaseCase):
     def test_valid_organizations_stream(self):
         """Check whether it parses organizations section from a valid stream"""
 
-        stream = self.read_file('data/mozillians_valid.json')
+        stream = self.read_file(datadir('mozillians_valid.json'))
 
         parser = MozilliansParser(stream)
         orgs = parser.organizations
@@ -180,12 +182,12 @@ class TestMozilliansParser(TestBaseCase):
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     MOZILLIANS_INVALID_JSON_FORMAT_ERROR):
-            s = self.read_file('data/mozillians_invalid.json')
+            s = self.read_file(datadir('mozillians_invalid.json'))
             MozilliansParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     MOZILLIANS_IDS_MISSING_KEYS_ERROR):
-            s = self.read_file('data/mozillians_ids_missing_keys.json')
+            s = self.read_file(datadir('mozillians_ids_missing_keys.json'))
             MozilliansParser(s)
 
     def test_empty_stream(self):

--- a/tests/test_parser_sh.py
+++ b/tests/test_parser_sh.py
@@ -31,6 +31,8 @@ from sortinghat.db.model import UniqueIdentity, Organization, Domain, MatchingBl
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.sh import SortingHatParser
 
+from tests.base import TestCommandCaseBase, datadir
+
 
 SH_INVALID_JSON_FORMAT_ERROR = "invalid json format\. Expecting ',' delimiter"
 SH_BL_EMPTY_STRING_ERROR = "invalid json format. Blacklist entries cannot be null or empty"
@@ -64,7 +66,7 @@ class TestSortingHatParser(TestBaseCase):
     def test_valid_blacklist_stream(self):
         """Check whether it parsers blacklist section from a valid stream"""
 
-        stream = self.read_file('data/sortinghat_valid.json')
+        stream = self.read_file(datadir('sortinghat_valid.json'))
 
         parser = SortingHatParser(stream)
         bl = parser.blacklist
@@ -83,7 +85,7 @@ class TestSortingHatParser(TestBaseCase):
     def test_valid_identities_stream(self):
         """Check whether it parsers identities section from a valid stream"""
 
-        stream = self.read_file('data/sortinghat_valid.json')
+        stream = self.read_file(datadir('sortinghat_valid.json'))
 
         parser = SortingHatParser(stream)
         uids = parser.identities
@@ -220,7 +222,7 @@ class TestSortingHatParser(TestBaseCase):
     def test_no_gender(self):
         """Check whether if parses identidies without gender information"""
 
-        stream = self.read_file('data/sortinghat_valid_no_gender.json')
+        stream = self.read_file(datadir('sortinghat_valid_no_gender.json'))
 
         parser = SortingHatParser(stream)
         uids = parser.identities
@@ -246,7 +248,7 @@ class TestSortingHatParser(TestBaseCase):
     def test_valid_organizations_stream(self):
         """Check whether it parses organizations section from a valid stream"""
 
-        stream = self.read_file('data/sortinghat_valid.json')
+        stream = self.read_file(datadir('sortinghat_valid.json'))
 
         parser = SortingHatParser(stream)
         orgs = parser.organizations
@@ -313,47 +315,47 @@ class TestSortingHatParser(TestBaseCase):
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_INVALID_JSON_FORMAT_ERROR):
-            s = self.read_file('data/sortinghat_invalid.json')
+            s = self.read_file(datadir('sortinghat_invalid.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_BL_EMPTY_STRING_ERROR):
-            s = self.read_file('data/sortinghat_blacklist_empty_strings.json')
+            s = self.read_file(datadir('sortinghat_blacklist_empty_strings.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_IDS_MISSING_KEYS_ERROR):
-            s = self.read_file('data/sortinghat_ids_missing_keys.json')
+            s = self.read_file(datadir('sortinghat_ids_missing_keys.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_ORGS_MISSING_KEYS_ERROR):
-            s = self.read_file('data/sortinghat_orgs_missing_keys.json')
+            s = self.read_file(datadir('sortinghat_orgs_missing_keys.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_IDS_DATETIME_ERROR):
-            s = self.read_file('data/sortinghat_ids_invalid_date.json')
+            s = self.read_file(datadir('sortinghat_ids_invalid_date.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_IDS_IS_BOT_ERROR):
-            s = self.read_file('data/sortinghat_ids_invalid_is_bot.json')
+            s = self.read_file(datadir('sortinghat_ids_invalid_is_bot.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_IDS_GENDER_ACC_TYPE_ERROR):
-            s = self.read_file('data/sortinghat_ids_invalid_type_gender_acc.json')
+            s = self.read_file(datadir('sortinghat_ids_invalid_type_gender_acc.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_IDS_GENDER_ACC_RANGE_ERROR):
-            s = self.read_file('data/sortinghat_ids_invalid_range_gender_acc.json')
+            s = self.read_file(datadir('sortinghat_ids_invalid_range_gender_acc.json'))
             SortingHatParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     SH_ORGS_IS_TOP_ERROR):
-            s = self.read_file('data/sortinghat_orgs_invalid_top.json')
+            s = self.read_file(datadir('sortinghat_orgs_invalid_top.json'))
             SortingHatParser(s)
 
     def test_empty_stream(self):

--- a/tests/test_parser_stackalytics.py
+++ b/tests/test_parser_stackalytics.py
@@ -32,6 +32,8 @@ from sortinghat.db.model import MIN_PERIOD_DATE, MAX_PERIOD_DATE, \
 from sortinghat.exceptions import InvalidFormatError
 from sortinghat.parsing.stackalytics import StackalyticsParser
 
+from tests.base import TestCommandCaseBase, datadir
+
 
 STACKALYTICS_INVALID_JSON_FORMAT_ERROR = r"invalid json format\. Expecting ':' delimiter"
 STACKALYTICS_IDS_MISSING_KEYS_ERROR = "Attribute companies not found"
@@ -55,7 +57,7 @@ class TestStackalyticsParser(TestBaseCase):
     def test_valid_identities_stream(self):
         """Check insertion of valid data from a file"""
 
-        stream = self.read_file('data/stackalytics_valid.json')
+        stream = self.read_file(datadir('stackalytics_valid.json'))
 
         parser = StackalyticsParser(stream, source='unknown')
         uids = parser.identities
@@ -150,7 +152,7 @@ class TestStackalyticsParser(TestBaseCase):
     def test_valid_organizations_stream(self):
         """Check whether it parses organizations section from a valid stream"""
 
-        stream = self.read_file('data/stackalytics_valid.json')
+        stream = self.read_file(datadir('stackalytics_valid.json'))
 
         parser = StackalyticsParser(stream)
         orgs = parser.organizations
@@ -186,17 +188,17 @@ class TestStackalyticsParser(TestBaseCase):
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     STACKALYTICS_INVALID_JSON_FORMAT_ERROR):
-            s = self.read_file('data/stackalytics_invalid.json')
+            s = self.read_file(datadir('stackalytics_invalid.json'))
             StackalyticsParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     STACKALYTICS_IDS_MISSING_KEYS_ERROR):
-            s = self.read_file('data/stackalytics_ids_missing_keys.json')
+            s = self.read_file(datadir('stackalytics_ids_missing_keys.json'))
             StackalyticsParser(s)
 
         with self.assertRaisesRegex(InvalidFormatError,
                                     STACKALYTICS_ORGS_MISSING_KEYS_ERROR):
-            s = self.read_file('data/stackalytics_orgs_missing_keys.json')
+            s = self.read_file(datadir('stackalytics_orgs_missing_keys.json'))
             StackalyticsParser(s)
 
     def test_empty_stream(self):

--- a/tests/tests.conf.sample
+++ b/tests/tests.conf.sample
@@ -6,3 +6,5 @@ port=3306
 
 user=
 password=
+
+create=False


### PR DESCRIPTION
In the migration to get all of GrimoireLab modules to run the tests via setup.py, some stuff waas needed, which is in this patch:

* Adaption of setup.py itself, including testing dependencies, adapting some other details in the script.
* Adaption of tests to be run from the parent directory.
* Create the database to use for testing, and remove it after the tests.
* New option in tests.conf, for running that code to create the database or not.
* Adapt the README.md to show how tests are run.
* Adapt .travis.yml to run with setup.py (and update it a bit).

In the process for adapting the tests to be run from the parent directory, their portability was increased: now they should run also in systems where "/" is not the path separator.