### PR TITLE
Use a optimistic approach when inserting data

### DIFF
--- a/sortinghat/cmd/add.py
+++ b/sortinghat/cmd/add.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -151,7 +151,11 @@ class Add(Command):
 
             if matcher:
                 self.__merge_on_matching(uuid, matcher, interactive)
-        except (AlreadyExistsError, NotFoundError, InvalidValueError) as e:
+        except AlreadyExistsError as e:
+            msg = "unique identity '%s' already exists in the registry" % e.eid
+            self.error(msg)
+            return e.code
+        except (NotFoundError, InvalidValueError) as e:
             self.error(str(e))
             return e.code
 

--- a/sortinghat/cmd/blacklist.py
+++ b/sortinghat/cmd/blacklist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -112,7 +112,8 @@ class Blacklist(Command):
             # because entry cannot be None or empty
             raise RuntimeError(str(e))
         except AlreadyExistsError as e:
-            self.error(str(e))
+            msg = "%s already exists in the registry" % entry
+            self.error(msg)
             return e.code
 
         return CMD_SUCCESS

--- a/sortinghat/cmd/organizations.py
+++ b/sortinghat/cmd/organizations.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -163,7 +163,8 @@ class Organizations(Command):
                 # because organization cannot be None or empty
                 raise RuntimeError(str(e))
             except AlreadyExistsError as e:
-                self.error(str(e))
+                msg = "organization '%s' already exists in the registry" % organization
+                self.error(msg)
                 return e.code
         else:
             try:
@@ -173,7 +174,11 @@ class Organizations(Command):
             except InvalidValueError as e:
                 # Same as above, domains cannot be None or empty
                 raise RuntimeError(str(e))
-            except (AlreadyExistsError, NotFoundError) as e:
+            except AlreadyExistsError as e:
+                msg = "domain '%s' already exists in the registry" % domain
+                self.error(msg)
+                return e.code
+            except NotFoundError as e:
                 self.error(str(e))
                 return e.code
 

--- a/sortinghat/exceptions.py
+++ b/sortinghat/exceptions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -55,11 +55,12 @@ class BaseError(Exception):
 class AlreadyExistsError(BaseError):
     """Exception raised when an entity already exists in the registry"""
 
-    message = "%(entity)s already exists in the registry"
+    message = "%(entity)s '%(eid)s' already exists in the registry"
     code = CODE_ALREADY_EXISTS_ERROR
 
     def __init__(self, **kwargs):
-        self.uuid = kwargs.pop('uuid', None)
+        self.entity = kwargs['entity']
+        self.eid = kwargs['eid']
         super(AlreadyExistsError, self).__init__(**kwargs)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -96,7 +96,8 @@ class TestAddUniqueIdentity(TestAPICaseBase):
         with self.assertRaises(AlreadyExistsError) as context:
             api.add_unique_identity(self.db, 'John Smith')
 
-        self.assertEqual(context.exception.uuid, 'John Smith')
+        self.assertEqual(context.exception.eid, 'John Smith')
+        print(context.exception)
 
     def test_none_uuid(self):
         """Check whether None identities cannot be added to the registry"""
@@ -334,7 +335,7 @@ class TestAddIdentity(TestAPICaseBase):
         with self.assertRaises(AlreadyExistsError) as context:
             api.add_identity(self.db, 'scm', 'jsmith@example.com')
 
-        self.assertEqual(context.exception.uuid,
+        self.assertEqual(context.exception.eid,
                          '334da68fcd3da4e799791f73dfada2afb22648c6')
 
         # Insert the same identity with upper case letters.
@@ -342,7 +343,7 @@ class TestAddIdentity(TestAPICaseBase):
         with self.assertRaises(AlreadyExistsError) as context:
             api.add_identity(self.db, 'scm', 'JSMITH@example.com')
 
-        self.assertEqual(context.exception.uuid,
+        self.assertEqual(context.exception.eid,
                          '334da68fcd3da4e799791f73dfada2afb22648c6')
 
         # "None" tuples also raise an exception
@@ -351,7 +352,7 @@ class TestAddIdentity(TestAPICaseBase):
         with self.assertRaises(AlreadyExistsError) as context:
             api.add_identity(self.db, 'scm', None, "None", None)
 
-        self.assertEqual(context.exception.uuid,
+        self.assertEqual(context.exception.eid,
                          'f0999c4eed908d33365fa3435d9686d3add2412d')
 
     def test_unaccent_identities(self):
@@ -365,7 +366,7 @@ class TestAddIdentity(TestAPICaseBase):
         with self.assertRaises(AlreadyExistsError) as context:
             api.add_identity(self.db, 'scm', name='Jöhn Smith')
 
-        self.assertEqual(context.exception.uuid,
+        self.assertEqual(context.exception.eid,
                          'c7acd177d107a0aefa6718e2ff0dec6ceba71660')
 
         # Insert an accent identity again. It should raise AlreadyExistsError
@@ -376,7 +377,7 @@ class TestAddIdentity(TestAPICaseBase):
         with self.assertRaises(AlreadyExistsError) as context:
             api.add_identity(self.db, 'scm', name='John Doe')
 
-        self.assertEqual(context.exception.uuid,
+        self.assertEqual(context.exception.eid,
                          'a16659ea83d28c839ffae76ceebb3ca9fb8e8894')
 
     def test_charset(self):

--- a/tests/test_cmd_add.py
+++ b/tests/test_cmd_add.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -37,9 +37,9 @@ from sortinghat.exceptions import (CODE_ALREADY_EXISTS_ERROR,
 from tests.base import TestCommandCaseBase
 
 
-ADD_EXISTING_ERROR = "Error: scm-jsmith@example.com-John Smith-jsmith already exists in the registry"
-ADD_EXISTING_LOWERCASE_ERROR = "Error: scm-jsmith@example.com-john smith-jsmith already exists in the registry"
-ADD_EXISTING_ACCENTS_ERROR = "Error: scm-jsmith@example.com-john smith-jsmith already exists in the registry"
+ADD_EXISTING_ERROR = "Error: unique identity 'a9b403e150dd4af8953a52a4bb841051e4b705d9' already exists in the registry"
+ADD_EXISTING_LOWERCASE_ERROR = "Error: unique identity 'a9b403e150dd4af8953a52a4bb841051e4b705d9' already exists in the registry"
+ADD_EXISTING_ACCENTS_ERROR = "Error: unique identity 'a9b403e150dd4af8953a52a4bb841051e4b705d9' already exists in the registry"
 ADD_IDENTITY_NONE_OR_EMPTY_ERROR = "Error: identity data cannot be None or empty"
 ADD_MATCHING_ERROR = "Error: mock identity matcher is not supported"
 ADD_SOURCE_NONE_ERROR = "Error: source cannot be None"

--- a/tests/test_cmd_enroll.py
+++ b/tests/test_cmd_enroll.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,7 +38,7 @@ from tests.base import TestCommandCaseBase
 ENROLL_UUID_NOT_FOUND_ERROR = "Error: Jane Roe not found in the registry"
 ENROLL_ORG_NOT_FOUND_ERROR = "Error: LibreSoft not found in the registry"
 ENROLL_INVALID_PERIOD_ERROR = "Error: 'from_date' 2001-01-01 00:00:00 cannot be greater than 1999-01-01 00:00:00"
-ENROLL_EXISTING_ERROR = "Error: John Smith-Example-1900-01-01 00:00:00-2100-01-01 00:00:00 already exists in the registry"
+ENROLL_EXISTING_ERROR = "Error: enrollment for 'John Smith' at 'Example' (from: 1900-01-01 00:00:00, to: 2100-01-01 00:00:00) already exists in the registry"
 ENROLL_INVALID_DATE_ERROR = "Error: 1999-13-01 is not a valid date"
 ENROLL_INVALID_FORMAT_DATE_ERROR = "Error: YYZYY is not a valid date"
 ENROLL_EMPTY_OUTPUT = ""

--- a/tests/test_cmd_load.py
+++ b/tests/test_cmd_load.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -129,8 +129,8 @@ Loading unique identities...
 2/3 unique identities loaded"""
 
 LOAD_IDENTITIES_OUTPUT_ERROR = """Error: not enough info to load 0000000000000000000000000000000000000000 unique identity. Skipping.
-Warning: Bitergia already exists in the registry. Organization not updated.
-Warning: Example already exists in the registry. Organization not updated."""
+Warning: Organization 'Bitergia' already exists in the registry. Organization not updated.
+Warning: Organization 'Example' already exists in the registry. Organization not updated."""
 
 LOAD_IDENTITIES_NO_STRICT_OUTPUT = """Loading blacklist...
 0/0 blacklist entries loaded
@@ -175,7 +175,7 @@ Domain example.net added to organization Bitergia
 Domain example.com added to organization Example
 Domain example.net added to organization Example"""
 
-LOAD_ORGS_OUTPUT_WARNING = """Warning: example.net (Bitergia) already exists in the registry. Not updated."""
+LOAD_ORGS_OUTPUT_WARNING = """Warning: Domain 'example.net' already exists in the registry. Not updated."""
 
 
 class TestLoadCaseBase(TestCommandCaseBase):

--- a/tests/test_cmd_organizations.py
+++ b/tests/test_cmd_organizations.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,8 +34,8 @@ from sortinghat.exceptions import NotFoundError, CODE_ALREADY_EXISTS_ERROR, CODE
 from tests.base import TestCommandCaseBase
 
 
-REGISTRY_ORG_ALREADY_EXISTS_ERROR = "Error: Bitergium already exists in the registry"
-REGISTRY_DOM_ALREADY_EXISTS_ERROR = "Error: bitergia.com (Bitergia) already exists in the registry"
+REGISTRY_ORG_ALREADY_EXISTS_ERROR = "Error: organization 'Bitergium' already exists in the registry"
+REGISTRY_DOM_ALREADY_EXISTS_ERROR = "Error: domain 'bitergia.com' already exists in the registry"
 REGISTRY_ORG_NOT_FOUND_ERROR = "Error: Bitergium not found in the registry"
 REGISTRY_ORG_NOT_FOUND_ERROR_ALT = "Error: LibreSoft not found in the registry"
 REGISTRY_DOM_NOT_FOUND_ERROR = "Error: example.com not found in the registry"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2017 Bitergia
+# Copyright (C) 2014-2018 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -73,16 +73,17 @@ class TestAlreadyExistsError(unittest.TestCase):
     def test_message(self):
         """Make sure that prints the correct error"""
 
-        e = AlreadyExistsError(entity='example.com')
+        e = AlreadyExistsError(entity='Domain', eid='example.com')
         self.assertEqual(str(e),
-                         "example.com already exists in the registry")
+                         "Domain 'example.com' already exists in the registry")
 
-    def test_uuid_arg(self):
-        """Test that uuid attribute is set when given as argument"""
+    def test_args(self):
+        """Test whether attributes are set when given as arguments"""
 
-        e = AlreadyExistsError(uuid='FFFFFFFFFFF', entity='FFFFFFFFFFF')
-        self.assertEqual(str(e), "FFFFFFFFFFF already exists in the registry")
-        self.assertEqual(e.uuid, 'FFFFFFFFFFF')
+        e = AlreadyExistsError(entity='UniqueIdentity', eid='FFFFFFFFFFF')
+        self.assertEqual(str(e), "UniqueIdentity 'FFFFFFFFFFF' already exists in the registry")
+        self.assertEqual(e.entity, 'UniqueIdentity')
+        self.assertEqual(e.eid, 'FFFFFFFFFFF')
 
     def test_no_args(self):
         """Check whether it raises a KeyError exception when


### PR DESCRIPTION
This PR tries to fix the enhancement proposed in #151.

With this optimistic approach, no more queries to check whether an entity exists on the database are run prior to its insertion. The new procedure works as follows:

  * Try to insert an entity without checking whether it exists in the database or not.
  * If the entity exists, an `IntegrityError` or a `FlushError` will be raised.
  * Rollback the transaction
  * Catch this error and check if it is an error raised by a duplicate entry.
  * If that was the cause, handle the error and raise an `AlreadyExistsError`.

Some changes were needed in `AlreadyExistsError` exception to store the ID and the type of the duplicated entry.
