### PR TITLE
[db] Handle disconnection using pessimistic mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ $ sortinghat load identities.json
 
 * Python >= 3.4
 * MySQL >= 5.5
-* SQLAlchemy >= 1.0.0
+* SQLAlchemy >= 1.2
 * Jinja2 >= 2.7
 * python-dateutil >= 2.6
 * python-yaml >= 3.12

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(name="sortinghat",
       ],
       install_requires=[
         'PyMySQL>=0.7.0',
-        'sqlalchemy>=1.1.15',
+        'sqlalchemy>=1.2',
         'jinja2',
         'python-dateutil>=2.6.0',
         'pandas>=0.18.1',

--- a/sortinghat/db/database.py
+++ b/sortinghat/db/database.py
@@ -174,7 +174,8 @@ def create_database_engine(user, password, database, host, port):
     url = URL(driver, user, password, host, port, database,
               query={'charset': 'utf8'})
     return create_engine(url, poolclass=QueuePool,
-                         pool_size=25, echo=False)
+                         pool_size=25, pool_pre_ping=True,
+                         echo=False)
 
 
 def create_database_session(engine):


### PR DESCRIPTION
SQLAlchemy offers a pessimistic mode to handle database disconnection. Setting 'pool_pre_ping' parameter on the database engine will check if the database connection is still active when a session of the connection pool is reused. To check that it runs a simple SQL statement. This causes a small hit in the performance but it's worth it.

This feature was included in 1.2 version, so the list of dependencies has been updated as well.