### PR TITLE
[api] Fix lost enrollments error merging identities

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -596,8 +596,10 @@ def merge_unique_identities(db, from_uuid, to_uuid):
         for identity in fuid.identities:
             move_identity_db(session, identity, tuid)
 
-        # Move those enrollments that to_uid does not have
-        for rol in fuid.enrollments:
+        # Move those enrollments that to_uid does not have.
+        # It is needed to copy the list in-place to avoid
+        # sync problems when enrollments are moved.
+        for rol in fuid.enrollments[:]:
             enrollment = session.query(Enrollment).\
                 filter(Enrollment.uidentity == tuid,
                        Enrollment.organization == rol.organization,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1985,6 +1985,32 @@ class TestMergeUniqueIdentities(TestAPICaseBase):
             self.assertEqual(rol2.start, datetime.datetime(1999, 1, 1))
             self.assertEqual(rol2.end, datetime.datetime(2000, 1, 1))
 
+    def test_moved_enrollments(self):
+        """Test if enrollments are moved from one identity to another"""
+
+        api.add_unique_identity(self.db, 'John Smith')
+        api.add_identity(self.db, 'scm', 'jsmith@example.com',
+                         uuid='John Smith')
+
+        api.add_unique_identity(self.db, 'John Doe')
+        api.add_identity(self.db, 'scm', 'jdoe@example.com',
+                         uuid='John Doe')
+
+        api.add_organization(self.db, 'Example')
+        api.add_enrollment(self.db, 'John Smith', 'Example')
+
+        api.add_organization(self.db, 'Bitergia')
+        api.add_enrollment(self.db, 'John Smith', 'Bitergia')
+
+        api.merge_unique_identities(self.db, 'John Smith', 'John Doe')
+
+        with self.db.connect() as session:
+            uidentities = session.query(UniqueIdentity).\
+                order_by(UniqueIdentity.uuid).all()
+            self.assertEqual(len(uidentities), 1)
+            self.assertEqual(len(uidentities[0].enrollments), 2)
+
+
     def test_last_modified(self):
         """Check if last modification date is updated"""
 


### PR DESCRIPTION
When two identities were merged some enrollments were lost because the list of enrollments changes when these are moved from one identity to another. Making a in-place copy of the list using slices fixes the problem.