### PR TITLE
[db] Support UTF-8 fully in MySQL/MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ $ sortinghat load identities.json
 ## Requirements
 
 * Python >= 3.4
-* MySQL >= 5.5
+* MySQL >= 5.6 or MariaDB 10.0
 * SQLAlchemy >= 1.2
 * Jinja2 >= 2.7
 * python-dateutil >= 2.6

--- a/sortinghat/db/database.py
+++ b/sortinghat/db/database.py
@@ -41,7 +41,7 @@ logger = logging.getLogger(__name__)
 
 class Database(object):
 
-    MYSQL_CREATE_DB = "CREATE DATABASE %(database)s CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+    MYSQL_CREATE_DB = "CREATE DATABASE %(database)s CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci"
     MYSQL_DROP_DB = "DROP DATABASE IF EXISTS %(database)s"
 
     # Regular expressions for handling errors
@@ -172,7 +172,7 @@ def create_database_engine(user, password, database, host, port):
 
     driver = 'mysql+pymysql'
     url = URL(driver, user, password, host, port, database,
-              query={'charset': 'utf8'})
+              query={'charset': 'utf8mb4'})
     return create_engine(url, poolclass=QueuePool,
                          pool_size=25, pool_pre_ping=True,
                          echo=False)

--- a/sortinghat/db/model.py
+++ b/sortinghat/db/model.py
@@ -37,9 +37,14 @@ MAX_PERIOD_DATE = datetime.datetime(2100, 1, 1, 0, 0, 0)
 
 # Default charset and collation
 MYSQL_CHARSET = {
-    'mysql_default_charset': 'utf8',
-    'mysql_collate': 'utf8_unicode_ci'
+    'mysql_default_charset': 'utf8mb4',
+    'mysql_collate': 'utf8mb4_unicode_520_ci'
 }
+
+# Innodb and utf8mb4 can only index 191 characters
+# See https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-conversion.html
+# for more information.
+MAX_SIZE_CHAR_COLUMN = 191
 
 logger = logging.getLogger(__name__)
 ModelBase = declarative_base()
@@ -64,7 +69,7 @@ class Organization(ModelBase):
     __tablename__ = 'organizations'
 
     id = Column(Integer, primary_key=True)
-    name = Column(String(255), nullable=False)
+    name = Column(String(MAX_SIZE_CHAR_COLUMN), nullable=False)
 
     # One-to-Many relationship
     domains = relationship('Domain', backref='organizations',
@@ -118,7 +123,7 @@ class Country(ModelBase):
     __tablename__ = 'countries'
 
     code = Column(String(2), primary_key=True)
-    name = Column(String(255), nullable=False)
+    name = Column(String(MAX_SIZE_CHAR_COLUMN), nullable=False)
     alpha3 = Column(String(3), nullable=False)
 
     __table_args__ = (UniqueConstraint('alpha3', name='_alpha_unique'),


### PR DESCRIPTION
The default charset of UTF-8 (utf8) in MySQL/MariaDB does not support, even when they are part of the standard, 4-bytes long characters. This means characters like emojis or certain chinese characters cannot be inserted. Usually, identities names or usernames have these types of characters.

The charset that fully supports UTF-8 is 'utf8mb4' using the collation 'utf8mb4_unicode_520_ci'. This collation implements the suggested Unicode Collation Algorithm (v5.2).

Using 'utf8mb4' also implies that the maximum size of char (VARCHAR and so on) columns is 191. Indexes cannot be larger than that when using InnoDB engine.

This patch can break the database so it is recommended to regenerate again the database from a dump.

More info:
  * https://dev.mysql.com/worklog/task/?id=2673
  * https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-conversion.html
  * https://mathiasbynens.be/notes/mysql-utf8mb4

This PR fixes #160 