### PR TITLE
[api] Optimize how last modified identities are retrieved

### DIFF
--- a/sortinghat/api.py
+++ b/sortinghat/api.py
@@ -942,27 +942,42 @@ def search_unique_identities_slice(db, term, offset, limit):
 def search_last_modified_identities(db, after):
     """Look for the uuids of identities modified on or after a given date.
 
-    This function returns the uuids of those unique identities and
-    identities that where modified on the given date or after it.
-    The result is a tuple containing two list of uuids: one with
-    unique identities and the other with identities.
+    This function returns the uuids of identities modified on
+    the given date or after it. The result is a list of uuids
+    identities.
 
-    :param db: database manater
+    :param db: database manager
     :param after: look for identities modified on or after this date
 
-    :returns: a tuple containing the list of unique identities and the
-        identities modified
+    :returns: a list of uuids of identities modified
     """
     with db.connect() as session:
-        query = session.query(UniqueIdentity).\
-            filter(UniqueIdentity.last_modified >= after)
-        uids = [uid.uuid for uid in query.order_by(UniqueIdentity.uuid).all()]
-
-        query = session.query(Identity).\
+        query = session.query(Identity.id).\
             filter(Identity.last_modified >= after)
         ids = [id_.id for id_ in query.order_by(Identity.id).all()]
 
-    return uids, ids
+    return ids
+
+
+def search_last_modified_unique_identities(db, after):
+    """Look for the uuids of unique identities modified on or
+    after a given date.
+
+    This function returns the uuids of unique identities
+    modified on the given date or after it. The result is a
+    list of uuids unique identities.
+
+    :param db: database manager
+    :param after: look for identities modified on or after this date
+
+    :returns: a list of uuids of unique identities modified
+    """
+    with db.connect() as session:
+        query = session.query(UniqueIdentity.uuid).\
+            filter(UniqueIdentity.last_modified >= after)
+        uids = [uid.uuid for uid in query.order_by(UniqueIdentity.uuid).all()]
+
+    return uids
 
 
 def search_profiles(db, no_gender=False):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2884,7 +2884,7 @@ class TestSearchLastModifiedIdentities(TestAPICaseBase):
     """Unit tests for last_modified_identities"""
 
     def test_search_last_modified_identities(self):
-        """Check if it returns the uuids of the modified entities"""
+        """Check if it returns the uuids of the modified identities"""
 
         # Add identities
         before_dt = datetime.datetime.utcnow()
@@ -2899,9 +2899,7 @@ class TestSearchLastModifiedIdentities(TestAPICaseBase):
                                        uuid='John Doe')
 
         # Check if all uuids are returned
-        uuids, ids = api.search_last_modified_identities(self.db, before_dt)
-
-        self.assertListEqual(uuids, ['John Doe', 'John Smith'])
+        ids = api.search_last_modified_identities(self.db, before_dt)
         self.assertListEqual(ids, [jdoe_id, jsmith_id, jdoe_alt_id])
 
         # Update identities
@@ -2909,11 +2907,37 @@ class TestSearchLastModifiedIdentities(TestAPICaseBase):
         api.move_identity(self.db, jdoe_id, 'John Smith')
 
         # Check if only modified uuids are returned
-        uuids, ids = api.search_last_modified_identities(self.db, before_move_dt)
-        self.assertListEqual(uuids, ['John Doe', 'John Smith'])
+        ids = api.search_last_modified_identities(self.db, before_move_dt)
         self.assertListEqual(ids, [jdoe_id])
 
-    def test_empty_search(self):
+    def test_search_last_modified_unique_identities(self):
+        """Check if it returns the uuids of the modified unique identities"""
+
+        # Add identities
+        before_dt = datetime.datetime.utcnow()
+        api.add_unique_identity(self.db, 'John Smith')
+        jsmith_id = api.add_identity(self.db, 'scm', 'jsmith@example.com',
+                                     uuid='John Smith')
+
+        api.add_unique_identity(self.db, 'John Doe')
+        jdoe_id = api.add_identity(self.db, 'scm', 'jdoe@example.com',
+                                   uuid='John Doe')
+        jdoe_alt_id = api.add_identity(self.db, 'scm', 'jdoe@example.com', 'Jon Doe',
+                                       uuid='John Doe')
+
+        # Check if all uuids are returned
+        uuids = api.search_last_modified_unique_identities(self.db, before_dt)
+        self.assertListEqual(uuids, ['John Doe', 'John Smith'])
+
+        # Update identities
+        before_move_dt = datetime.datetime.utcnow()
+        api.move_identity(self.db, jdoe_id, 'John Smith')
+
+        # Check if only modified uuids are returned
+        uuids = api.search_last_modified_unique_identities(self.db, before_move_dt)
+        self.assertListEqual(uuids, ['John Doe', 'John Smith'])
+
+    def test_empty_search_modified_identities(self):
         """Check if the result is empty when identities are not modified"""
 
         # Add identities
@@ -2930,10 +2954,28 @@ class TestSearchLastModifiedIdentities(TestAPICaseBase):
         after_dt = datetime.datetime.utcnow()
 
         # Check if all uuids are returned
-        uuids, ids = api.search_last_modified_identities(self.db, after_dt)
-
-        self.assertListEqual(uuids, [])
+        ids = api.search_last_modified_identities(self.db, after_dt)
         self.assertListEqual(ids, [])
+
+    def test_empty_search_modified_unique_identities(self):
+        """Check if the result is empty when unique identities are not modified"""
+
+        # Add identities
+        api.add_unique_identity(self.db, 'John Smith')
+        api.add_identity(self.db, 'scm', 'jsmith@example.com',
+                         uuid='John Smith')
+
+        api.add_unique_identity(self.db, 'John Doe')
+        api.add_identity(self.db, 'scm', 'jdoe@example.com',
+                         uuid='John Doe')
+        api.add_identity(self.db, 'scm', 'jdoe@example.com', 'Jon Doe',
+                         uuid='John Doe')
+
+        after_dt = datetime.datetime.utcnow()
+
+        # Check if all uuids are returned
+        uuids = api.search_last_modified_unique_identities(self.db, after_dt)
+        self.assertListEqual(uuids, [])
 
 
 class TestSearchProfiles(TestAPICaseBase):


### PR DESCRIPTION
This code refactors and optimize how the last modified identities are retrieve to reduce the memory usage. First, the method `search_last_modified_identities` is splitted in two methods, one retrieves the last modified unique identities and the other one the last modified identities. Second, instead of retrieving the complete objects representing the identities, only their ids/uudis are returned.