### PR TITLE
[cmd:autoprofile] Fix expected string or bytes-like object error

### DIFF
--- a/sortinghat/cmd/autoprofile.py
+++ b/sortinghat/cmd/autoprofile.py
@@ -102,8 +102,9 @@ class AutoProfile(Command):
                     name = identity.name or identity.username
                 elif identity.name and len(identity.name) > len(name):
                     name = identity.name
+
                 # Do not set email addresses on the name field
-                if email_pattern.match(name):
+                if name and email_pattern.match(name):
                     name = oldname
 
                 if not email and identity.email:

--- a/tests/test_cmd_autoprofile.py
+++ b/tests/test_cmd_autoprofile.py
@@ -146,6 +146,28 @@ class TestAutoProfileCommand(TestAutoProfileCaseBase):
         self.assertEqual(uid.profile.name, 'jrae')
         self.assertEqual(uid.profile.email, None)
 
+    def test_no_error_email_pattern_for_name_profile(self):
+        """Check if does not fail when email pattern is checked with empty values"""
+
+        # None values for name and username
+        jrae_uuid = api.add_identity(self.db, 'mls', 'jrae@example.com',
+                                     None, None)
+        api.add_identity(self.db, 'mls', 'jrae@example.net',
+                         None, '', uuid=jrae_uuid)
+        api.add_identity(self.db, 'mls', 'jrae@example.org',
+                         None, None, uuid=jrae_uuid)
+
+        # Empty values on name and username fields do not crash
+        # when email pattern is check
+        self.cmd.autocomplete(['mls', 'its'])
+
+        uids = api.unique_identities(self.db, uuid=jrae_uuid)
+        uid = uids[0]
+
+        self.assertEqual(uid.uuid, jrae_uuid)
+        self.assertEqual(uid.profile.name, None)
+        self.assertEqual(uid.profile.email, 'jrae@example.net')
+
 
 if __name__ == "__main__":
     unittest.main(buffer=True, exit=False)


### PR DESCRIPTION
This error was caused when name or username fields were set to `None`. In these cases, the regular expression to match whether any of these values is an email address failed. A string value is required and not a None value.

Fixes #170