### PR TITLE
Mutations to add/remove organizations and domains

### DIFF
--- a/config/schema.py
+++ b/config/schema.py
@@ -30,4 +30,5 @@ class Query(sortinghat.core.schema.SortingHatQuery, graphene.ObjectType):
     pass
 
 
-schema = graphene.Schema(query=Query)
+schema = graphene.Schema(query=Query,
+                         mutation=sortinghat.core.schema.SortingHatMutations)

--- a/config/schema.py
+++ b/config/schema.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2018 Bitergia
+# Copyright (C) 2014-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,4 +31,4 @@ class Query(sortinghat.core.schema.SortingHatQuery, graphene.ObjectType):
 
 
 schema = graphene.Schema(query=Query,
-                         mutation=sortinghat.core.schema.SortingHatMutations)
+                         mutation=sortinghat.core.schema.SortingHatMutation)

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -1,3 +1,13 @@
+import sys
+import logging
+
+# Graphene logs SortingHat exceptions and Django pritns them
+# to the standard error output. This code prevents Django
+# kind of errors are not shown.
+if len(sys.argv) > 1 and sys.argv[1] == 'test':
+    logging.disable(logging.CRITICAL)
+
+
 SECRET_KEY = 'fake-key'
 
 INSTALLED_APPS = [

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -117,6 +117,16 @@ def add_domain(organization, domain_name, is_top_domain=False):
     return domain
 
 
+def delete_domain(domain):
+    """Remove a domain from the database.
+
+    Deletes from the database the domain given in `domain`.
+
+    :param domain: domain to remove
+    """
+    domain.delete()
+
+
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")
 
 

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -23,8 +23,10 @@ import re
 
 import django.db.utils
 
+from grimoirelab_toolkit.datetime import datetime_utcnow
+
 from .errors import AlreadyExistsError
-from .models import Organization
+from .models import Organization, UniqueIdentity
 
 
 def add_organization(name):
@@ -57,6 +59,21 @@ def add_organization(name):
 
     return organization
 
+
+def delete_organization(organization):
+    """Remove an organization from the database.
+
+    Function that removes from the database the organization
+    given in `organization`. Data related such as domains
+    or enrollments are also removed.
+
+    :param organization: organization to remove
+    """
+    last_modified = datetime_utcnow()
+    UniqueIdentity.objects.filter(enrollments__organization=organization).\
+        update(last_modified=last_modified)
+
+    organization.delete()
 
 
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import re
+
+import django.db.utils
+
+from .errors import AlreadyExistsError
+from .models import Organization
+
+
+def add_organization(name):
+    """Add an organization to the database.
+
+    This function adds a new organization to the database,
+    using the given `name` as an identifier. Name cannot be
+    empty or `None`.
+
+    It returns a new `Organization` object.
+
+    :param name: name of the organization
+    :returns: a new organization
+
+    :raises ValueError: when `name` is `None` or empty.
+    :raises AlreadyExistsError: when an instance with the same name
+        already exists in the database.
+    """
+    if name is None:
+        raise ValueError("'name' cannot be None")
+    if name == '':
+        raise ValueError("'name' cannot be an empty string")
+
+    organization = Organization(name=name)
+
+    try:
+        organization.save()
+    except django.db.utils.IntegrityError as exc:
+        _handle_integrity_error(Organization, exc)
+
+    return organization
+
+
+
+_MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")
+
+
+def _handle_integrity_error(model, exc):
+    """Handle integrity error exceptions."""
+
+    m = re.match(_MYSQL_DUPLICATE_ENTRY_ERROR_REGEX,
+                 exc.__cause__.args[1])
+    if not m:
+        raise exc
+
+    entity = model.__name__
+    eid = m.group('value')
+
+    raise AlreadyExistsError(entity=entity, eid=eid)

--- a/sortinghat/core/errors.py
+++ b/sortinghat/core/errors.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+CODE_BASE_ERROR = 1
+CODE_ALREADY_EXISTS_ERROR = 2
+
+
+class BaseError(Exception):
+    """Base class error.
+
+    Derived classes can overwrite error message declaring
+    'message' property.
+    """
+    code = CODE_BASE_ERROR
+    message = "SortingHat unknown error"
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.msg = self.message % kwargs
+
+    def __str__(self):
+        return self.msg
+
+    def __int__(self):
+        return self.code
+
+
+class AlreadyExistsError(BaseError):
+    """Exception raised when an entity already exists in the registry"""
+
+    message = "%(entity)s '%(eid)s' already exists in the registry"
+    code = CODE_ALREADY_EXISTS_ERROR
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.entity = kwargs['entity']
+        self.eid = kwargs['eid']

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -22,6 +22,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
+from .db import add_organization
 from .models import (Organization,
                      Domain,
                      Country,
@@ -64,6 +65,24 @@ class ProfileType(DjangoObjectType):
 class EnrollmentType(DjangoObjectType):
     class Meta:
         model = Enrollment
+
+
+class AddOrganization(graphene.Mutation):
+    class Arguments:
+        name = graphene.String()
+
+    organization = graphene.Field(lambda: OrganizationType)
+
+    def mutate(self, info, name):
+        org = add_organization(name)
+
+        return AddOrganization(
+            organization=org
+        )
+
+
+class SortingHatMutations(graphene.ObjectType):
+    add_organization = AddOrganization.Field()
 
 
 class SortingHatQuery:

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -22,7 +22,9 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from .db import add_organization, delete_organization
+from .db import (add_organization,
+                 delete_organization,
+                 add_domain)
 from .models import (Organization,
                      Domain,
                      Country,
@@ -96,9 +98,27 @@ class DeleteOrganization(graphene.Mutation):
         )
 
 
+class AddDomain(graphene.Mutation):
+    class Arguments:
+        organization = graphene.String()
+        domain = graphene.String()
+        is_top_domain = graphene.Boolean()
+
+    domain = graphene.Field(lambda: DomainType)
+
+    def mutate(self, info, organization, domain, is_top_domain=False):
+        org = Organization.objects.get(name=organization)
+        dom = add_domain(org, domain, is_top_domain=is_top_domain)
+
+        return AddDomain(
+            domain=dom
+        )
+
+
 class SortingHatMutations(graphene.ObjectType):
     add_organization = AddOrganization.Field()
     delete_organization = DeleteOrganization.Field()
+    add_domain = AddDomain.Field()
 
 
 class SortingHatQuery:

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2018 Bitergia
+# Copyright (C) 2014-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,7 +24,8 @@ from graphene_django.types import DjangoObjectType
 
 from .db import (add_organization,
                  delete_organization,
-                 add_domain)
+                 add_domain,
+                 delete_domain)
 from .models import (Organization,
                      Domain,
                      Country,
@@ -115,10 +116,19 @@ class AddDomain(graphene.Mutation):
         )
 
 
-class SortingHatMutations(graphene.ObjectType):
-    add_organization = AddOrganization.Field()
-    delete_organization = DeleteOrganization.Field()
-    add_domain = AddDomain.Field()
+class DeleteDomain(graphene.Mutation):
+    class Arguments:
+        domain = graphene.String()
+
+    domain = graphene.Field(lambda: DomainType)
+
+    def mutate(self, info, domain):
+        dom = Domain.objects.get(domain=domain)
+        delete_domain(dom)
+
+        return DeleteDomain(
+            domain=dom
+        )
 
 
 class SortingHatQuery:
@@ -130,3 +140,10 @@ class SortingHatQuery:
 
     def resolve_uidentities(self, info, **kwargs):
         return UniqueIdentity.objects.order_by('uuid')
+
+
+class SortingHatMutation(graphene.ObjectType):
+    add_organization = AddOrganization.Field()
+    delete_organization = DeleteOrganization.Field()
+    add_domain = AddDomain.Field()
+    delete_domain = DeleteDomain.Field()

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -22,7 +22,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from .db import add_organization
+from .db import add_organization, delete_organization
 from .models import (Organization,
                      Domain,
                      Country,
@@ -81,8 +81,24 @@ class AddOrganization(graphene.Mutation):
         )
 
 
+class DeleteOrganization(graphene.Mutation):
+    class Arguments:
+        name = graphene.String()
+
+    organization = graphene.Field(lambda: OrganizationType)
+
+    def mutate(self, info, name):
+        org = Organization.objects.get(name=name)
+        delete_organization(org)
+
+        return DeleteOrganization(
+            organization=org
+        )
+
+
 class SortingHatMutations(graphene.ObjectType):
     add_organization = AddOrganization.Field()
+    delete_organization = DeleteOrganization.Field()
 
 
 class SortingHatQuery:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+from django.test import TestCase
+
+from sortinghat.core import db
+from sortinghat.core.errors import AlreadyExistsError
+from sortinghat.core.models import Organization
+
+
+NAME_NONE_ERROR = "'name' cannot be None"
+NAME_EMPTY_ERROR = "'name' cannot be an empty string"
+DUPLICATED_ORG_ERROR = "Organization 'Example' already exists in the registry"
+
+
+class TestAddOrganization(TestCase):
+    """Unit tests for add_organization"""
+
+    def test_add_organization(self):
+        """Check if a new organization is added"""
+
+        name = 'Example'
+
+        org = db.add_organization(name)
+        self.assertIsInstance(org, Organization)
+        self.assertEqual(org.name, name)
+
+        org = Organization.objects.get(name=name)
+        self.assertIsInstance(org, Organization)
+        self.assertEqual(org.name, name)
+
+    def test_name_none(self):
+        """Check whether organizations with None as name cannot be added"""
+
+        with self.assertRaisesRegex(ValueError, NAME_NONE_ERROR):
+            db.add_organization(None)
+
+    def test_name_empty(self):
+        """Check whether organizations with empty names cannot be added"""
+
+        with self.assertRaisesRegex(ValueError, NAME_EMPTY_ERROR):
+            db.add_organization('')
+
+    def test_integrity_error(self):
+        """Check whether organizations with the same name cannot be inserted"""
+
+        name = 'Example'
+
+        with self.assertRaisesRegex(AlreadyExistsError, DUPLICATED_ORG_ERROR):
+            db.add_organization(name)
+            db.add_organization(name)
+

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -253,3 +253,28 @@ class TestAddDomain(TestCase):
         with self.assertRaisesRegex(AlreadyExistsError, DUPLICATED_DOM_ERROR):
             db.add_domain(org, domain_name)
             db.add_domain(org, domain_name)
+
+
+class TestDeleteDomain(TestCase):
+    """Unit tests for delete_domain"""
+
+    def test_delete_domain(self):
+        """Check whether it deletes a domain"""
+
+        org = Organization.objects.create(name='Example')
+        dom = Domain.objects.create(domain='example.org', organization=org)
+        Domain.objects.create(domain='example.com', organization=org)
+
+        # Check data and remove domain
+        org.refresh_from_db()
+        self.assertEqual(len(org.domains.all()), 2)
+
+        dom.refresh_from_db()
+        db.delete_domain(dom)
+
+        # Tests
+        with self.assertRaises(ObjectDoesNotExist):
+            Domain.objects.get(domain='example.org')
+
+        org.refresh_from_db()
+        self.assertEqual(len(org.domains.all()), 1)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+from django.test import TestCase
+
+from sortinghat.core.errors import BaseError, AlreadyExistsError
+
+
+# Mock classes to test BaseError class
+class MockCode(BaseError):
+    message = "Mock error with code"
+    code = 9314
+
+
+class MockErrorNoArgs(BaseError):
+    message = "Mock error without args"
+
+
+class MockErrorArgs(BaseError):
+    message = "Mock error with args. Error: %(code)s %(msg)s"
+
+
+class TestBaseError(TestCase):
+    """Unit tests for BaseError"""
+
+    def test_int_code_casting(self):
+        """Check if the error can be casted into an error code"""
+
+        e = MockCode()
+        self.assertEqual(int(e), 9314)
+
+    def test_subblass_with_no_args(self):
+        """Check subclasses that do not require arguments.
+
+        Arguments passed to the constructor should be ignored.
+        """
+        e = MockErrorNoArgs(code=1, msg='Fatal error')
+
+        self.assertEqual("Mock error without args", str(e))
+
+    def test_subclass_args(self):
+        """Check subclasses that require arguments"""
+
+        e = MockErrorArgs(code=1, msg='Fatal error')
+
+        self.assertEqual("Mock error with args. Error: 1 Fatal error",
+                         str(e))
+
+    def test_subclass_invalid_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {'code': 1, 'error': 'Fatal error'}
+        self.assertRaises(KeyError, MockErrorArgs, **kwargs)
+
+
+class TestAlreadyExistsError(TestCase):
+    """Unit tests for AlreadyExistsError"""
+
+    def test_message(self):
+        """Make sure it prints the right error"""
+
+        e = AlreadyExistsError(entity='Domain', eid='example.com')
+        self.assertEqual(str(e),
+                         "Domain 'example.com' already exists in the registry")
+
+    def test_args(self):
+        """Test whether attributes are set when they are given as arguments"""
+
+        e = AlreadyExistsError(entity='UniqueIdentity', eid='FFFFFFFFFFF')
+        self.assertEqual(str(e), "UniqueIdentity 'FFFFFFFFFFF' already exists in the registry")
+        self.assertEqual(e.entity, 'UniqueIdentity')
+        self.assertEqual(e.eid, 'FFFFFFFFFFF')
+
+    def test_no_args(self):
+        """Check when required arguments are not given"""
+
+        kwargs = {}
+        self.assertRaises(KeyError, AlreadyExistsError, **kwargs)


### PR DESCRIPTION
This PR addresses the requirements defined in #173. It adds four mutations:

* `addOrganization`
* `addDomain`
* `removeOrganization`
* `removeDomain`

Basic model operations have been defined to add/remove these object models too. It follows the schema defined by the stable version of SortingHat.
