### PR TITLE
Fix deprecation warning for SafeConfigParser

### DIFF
--- a/bin/sortinghat
+++ b/bin/sortinghat
@@ -141,7 +141,7 @@ def configure_logging(debug=False):
 
 
 def read_config_file(filepath):
-    config = configparser.SafeConfigParser()
+    config = configparser.ConfigParser()
     config.read(filepath)
 
     if 'db' in config.sections():


### PR DESCRIPTION
The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. Use ConfigParser directly instead.