### PR TITLE
Define mutation to remove identities

### DIFF
--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -257,6 +257,19 @@ def add_identity(uidentity, identity_id, source,
     return identity
 
 
+def delete_identity(identity):
+    """Remove an identity from the database.
+
+    This function removes from the database the identity given
+    in `identity`. Take into account this function does not
+    remove unique identities in the case they get empty.
+
+    :param identity: identity to remove
+    """
+    identity.delete()
+    identity.uidentity.save()
+
+
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")
 
 

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -38,7 +38,7 @@ def find_unique_identity(uuid):
 
     Find a unique identity by its UUID in the database.
     When the unique identity does not exist the function will
-    raise a `NotFoundException`.
+    raise a `NotFoundError`.
 
     :param uuid: id of the unique identity to find
 
@@ -53,6 +53,28 @@ def find_unique_identity(uuid):
         raise NotFoundError(entity=uuid)
     else:
         return uidentity
+
+
+def find_identity(uuid):
+    """Find an identity.
+
+    Find an identity by its UUID in the database. When the
+    identity does not exist the function will raise
+    a `NotFoundError`.
+
+    :param uuid: id of the identity to find
+
+    :returns: an identity object
+
+    :raises NotFoundError: when the identity with the
+        given `uuid` does not exists.
+    """
+    try:
+        identity = Identity.objects.get(id=uuid)
+    except Identity.DoesNotExist:
+        raise NotFoundError(entity=uuid)
+    else:
+        return identity
 
 
 def add_organization(name):

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -196,6 +196,18 @@ def add_unique_identity(uuid):
     return uidentity
 
 
+def delete_unique_identity(uidentity):
+    """Remove a unique identity from the database.
+
+    Function that removes from the database the unique identity
+    given in `uidentity`. Data related to this identity will be
+    also removed.
+
+    :param uidentity: unique identity to remove
+    """
+    uidentity.delete()
+
+
 def add_identity(uidentity, identity_id, source,
                  name=None, email=None, username=None):
     """Add an identity to the database.

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -22,7 +22,7 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from .api import add_identity
+from .api import add_identity, delete_identity
 from .db import (add_organization,
                  delete_organization,
                  add_domain,
@@ -158,6 +158,23 @@ class AddIdentity(graphene.Mutation):
         )
 
 
+class DeleteIdentity(graphene.Mutation):
+    class Arguments:
+        uuid = graphene.String()
+        unique_identity = graphene.Boolean()
+
+    uuid = graphene.Field(lambda: graphene.String)
+    uidentity = graphene.Field(lambda: UniqueIdentityType)
+
+    def mutate(self, info, uuid):
+        uidentity = delete_identity(uuid)
+
+        return DeleteIdentity(
+            uuid=uuid,
+            uidentity=uidentity
+        )
+
+
 class SortingHatQuery:
     organizations = graphene.List(OrganizationType)
     uidentities = graphene.List(UniqueIdentityType)
@@ -175,3 +192,4 @@ class SortingHatMutation(graphene.ObjectType):
     add_domain = AddDomain.Field()
     delete_domain = DeleteDomain.Field()
     add_identity = AddIdentity.Field()
+    delete_identity = DeleteIdentity.Field()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -53,6 +53,7 @@ SOURCE_NONE_ERROR = "'source' cannot be None"
 SOURCE_EMPTY_ERROR = "'source' cannot be an empty string"
 IDENTITY_DATA_NONE_OR_EMPTY_ERROR = "identity data cannot be None or empty"
 UNIQUE_IDENTITY_NOT_FOUND_ERROR = "zyxwuv not found in the registry"
+IDENTITY_NOT_FOUND_ERROR = "zyxwuv not found in the registry"
 
 
 class TestFindUniqueIdentity(TestCase):
@@ -76,6 +77,31 @@ class TestFindUniqueIdentity(TestCase):
 
         with self.assertRaisesRegex(NotFoundError, UNIQUE_IDENTITY_NOT_FOUND_ERROR):
             db.find_unique_identity('zyxwuv')
+
+
+class TestFindIdentity(TestCase):
+    """Unit tests for find_identity"""
+
+    def test_find_identity(self):
+        """Test if an identity is found by its UUID"""
+
+        uuid = 'abcdefghijklmnopqrstuvwxyz'
+        uidentity = UniqueIdentity.objects.create(uuid=uuid)
+        Identity.objects.create(id=uuid, source='scm', uidentity=uidentity)
+
+        identity = db.find_identity(uuid)
+        self.assertIsInstance(identity, Identity)
+        self.assertEqual(identity.id, uuid)
+
+    def test_identity_not_found(self):
+        """Test whether it raises an exception when the identity is not found"""
+
+        uuid = 'abcdefghijklmnopqrstuvwxyz'
+        uidentity = UniqueIdentity.objects.create(uuid=uuid)
+        Identity.objects.create(id=uuid, source='scm', uidentity=uidentity)
+
+        with self.assertRaisesRegex(NotFoundError, IDENTITY_NOT_FOUND_ERROR):
+            db.find_identity('zyxwuv')
 
 
 class TestAddOrganization(TestCase):


### PR DESCRIPTION
The mutation `deletedentity` allows to remove identities and unique identities from the registry.

This PR addresses the requirements of #179 .