### PR TITLE
Add GraphQL mutation to edit/update profiles

### DIFF
--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -21,6 +21,7 @@
 
 import re
 
+import django.core.exceptions
 import django.db.utils
 
 from grimoirelab_toolkit.datetime import datetime_utcnow
@@ -28,6 +29,7 @@ from grimoirelab_toolkit.datetime import datetime_utcnow
 from .errors import AlreadyExistsError, NotFoundError
 from .models import (Organization,
                      Domain,
+                     Country,
                      UniqueIdentity,
                      Identity,
                      Profile)
@@ -290,6 +292,90 @@ def delete_identity(identity):
     """
     identity.delete()
     identity.uidentity.save()
+
+
+def update_profile(uidentity, **kwargs):
+    """Update unique identity profile.
+
+    This function allows to edit or update the profile information
+    of the given unique identity. The values to update are given
+    as keyword arguments. The allowed keys are listed below
+    (other keywords will be ignored):
+
+       - `name`: name of the unique identity
+       - `email`: email address of the unique identity
+       - `gender`: gender of the unique identity
+       - `gender_acc`: gender accuracy (range of 1 to 100; by default, set to 100)
+       - `is_bot`: boolean value to determine whether a unique identity is
+             a bot or not. By default, this value is initialized to
+             `False`.
+       - `country_code`: ISO-3166 country code
+
+    As a result, it will return the `UniqueIdentity` object with
+    the updated data.
+
+    :param uidentity: unique identity whose profile will be updated
+    :param kwargs: parameters to edit the profile
+
+    :returns: uidentity object with the updated profile
+
+    :raises ValueError: raised either when `is_bot` does not have a boolean value;
+        `gender_acc` is not an `int` or is not in range.
+    """
+    def to_none_if_empty(x):
+        return None if not x else x
+
+    profile = uidentity.profile
+
+    if 'name' in kwargs:
+        profile.name = to_none_if_empty(kwargs['name'])
+    if 'email' in kwargs:
+        profile.email = to_none_if_empty(kwargs['email'])
+
+    if 'is_bot' in kwargs:
+        is_bot = kwargs['is_bot']
+
+        if not isinstance(is_bot, bool):
+            raise ValueError("'is_bot' must have a boolean value")
+
+        profile.is_bot = is_bot
+
+    if 'country_code' in kwargs:
+        code = to_none_if_empty(kwargs['country_code'])
+
+        if code:
+            try:
+                country = Country.objects.get(code=code)
+            except django.core.exceptions.ObjectDoesNotExist:
+                msg = "'country_code' ({}) does not match with a valid code"
+                raise ValueError(msg.format(str(code)))
+
+            profile.country = country
+        else:
+            profile.country = None
+
+    if 'gender' in kwargs:
+        gender = to_none_if_empty(kwargs['gender'])
+        gender_acc = None
+
+        if gender:
+            gender_acc = kwargs.get('gender_acc', 100)
+
+            if not isinstance(gender_acc, int):
+                raise ValueError("'gender_acc' must have an integer value")
+            elif not 1 <= gender_acc <= 100:
+                raise ValueError("'gender_acc' (%d) is not in range (1,100)"
+                                 % gender_acc)
+
+        profile.gender = gender
+        profile.gender_acc = gender_acc
+    elif 'gender_acc' in kwargs:
+        raise ValueError("'gender_acc' can only be set when 'gender' is given")
+
+    profile.save()
+    uidentity.save()
+
+    return uidentity
 
 
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -22,7 +22,9 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
-from .api import add_identity, delete_identity
+from .api import (add_identity,
+                  delete_identity,
+                  update_profile)
 from .db import (add_organization,
                  delete_organization,
                  add_domain,
@@ -69,6 +71,15 @@ class ProfileType(DjangoObjectType):
 class EnrollmentType(DjangoObjectType):
     class Meta:
         model = Enrollment
+
+
+class ProfileInputType(graphene.InputObjectType):
+    name = graphene.String(required=False)
+    email = graphene.String(required=False)
+    gender = graphene.String(required=False)
+    gender_acc = graphene.Int(required=False)
+    is_bot = graphene.Boolean(required=False)
+    country_code = graphene.String(required=False)
 
 
 class AddOrganization(graphene.Mutation):
@@ -175,6 +186,23 @@ class DeleteIdentity(graphene.Mutation):
         )
 
 
+class UpdateProfile(graphene.Mutation):
+    class Arguments:
+        uuid = graphene.String()
+        data = ProfileInputType()
+
+    uuid = graphene.Field(lambda: graphene.String)
+    uidentity = graphene.Field(lambda: UniqueIdentityType)
+
+    def mutate(self, info, uuid, data):
+        uidentity = update_profile(uuid, **data)
+
+        return UpdateProfile(
+            uuid=uidentity.uuid,
+            uidentity=uidentity
+        )
+
+
 class SortingHatQuery:
     organizations = graphene.List(OrganizationType)
     uidentities = graphene.List(UniqueIdentityType)
@@ -193,3 +221,4 @@ class SortingHatMutation(graphene.ObjectType):
     delete_domain = DeleteDomain.Field()
     add_identity = AddIdentity.Field()
     delete_identity = DeleteIdentity.Field()
+    update_profile = UpdateProfile.Field()


### PR DESCRIPTION
This mutation allows to update profile identities. Some functions were added to the API to update profiles in the database layer.

This commit adds the features requested on #184 