### PR TITLE
Allow to search uidentities by an uuid

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
 Django==2.1
+django-filter>=2
 grimoirelab_toolkit>=0.1.8
 mysqlclient==1.3.13
 python-dateutil>=2.6.0
 graphene-django>=2.0
+graphene-django-extras==0.4.3
+

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -20,7 +20,7 @@
 #
 
 import graphene
-from graphene_django.types import DjangoObjectType
+from graphene_django_extras import DjangoObjectType, DjangoFilterListField
 
 from .api import add_identity, delete_identity
 from .db import (add_organization,
@@ -54,6 +54,7 @@ class CountryType(DjangoObjectType):
 class UniqueIdentityType(DjangoObjectType):
     class Meta:
         model = UniqueIdentity
+        filter_fields = ['uuid']
 
 
 class IdentityType(DjangoObjectType):
@@ -177,7 +178,7 @@ class DeleteIdentity(graphene.Mutation):
 
 class SortingHatQuery:
     organizations = graphene.List(OrganizationType)
-    uidentities = graphene.List(UniqueIdentityType)
+    uidentities = DjangoFilterListField(UniqueIdentityType)
 
     def resolve_organizations(self, info, **kwargs):
         return Organization.objects.order_by('name')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -93,6 +93,35 @@ SH_UIDS_QUERY = """{
     }
   }
 }"""
+SH_UIDS_UUID_FILTER = """{
+  uidentities(uuid: "a9b403e150dd4af8953a52a4bb841051e4b705d9") {
+    uuid
+    profile {
+      name
+      email
+      gender
+      isBot
+      country {
+        code
+        name
+      }
+    }
+    identities {
+      id
+      name
+      email
+      username
+      source
+    }
+    enrollments {
+      organization {
+        name
+      }
+      start
+      end
+    }
+  }
+}"""
 
 
 class TestQuery(SortingHatQuery, graphene.ObjectType):
@@ -284,6 +313,141 @@ class TestUniqueIdentities(django.test.TestCase):
 
         client = graphene.test.Client(schema)
         executed = client.execute(SH_UIDS_QUERY)
+
+        uids = executed['data']['uidentities']
+        self.assertListEqual(uids, [])
+
+    def test_filter_registry(self):
+        """Check whether it returns the uuid searched when using uuid filter"""
+
+        cn = Country.objects.create(code='US',
+                                    name='United States of America',
+                                    alpha3='USA')
+
+        org_ex = Organization.objects.create(name='Example')
+        org_bit = Organization.objects.create(name='Bitergia')
+
+        uid = UniqueIdentity.objects.create(uuid='a9b403e150dd4af8953a52a4bb841051e4b705d9')
+        Profile.objects.create(name=None,
+                               email='jsmith@example.com',
+                               is_bot=True,
+                               gender='M',
+                               country=cn,
+                               uidentity=uid)
+        Identity.objects.create(id='A001',
+                                name='John Smith',
+                                email='jsmith@example.com',
+                                username='jsmith',
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='A002',
+                                name=None,
+                                email='jsmith@bitergia.com',
+                                username=None,
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='A003',
+                                name=None,
+                                email='jsmith@bitergia.com',
+                                username=None,
+                                source='mls',
+                                uidentity=uid)
+        Enrollment.objects.create(uidentity=uid, organization=org_ex)
+        Enrollment.objects.create(uidentity=uid, organization=org_bit,
+                                  start=datetime.datetime(1999, 1, 1, 0, 0, 0,
+                                                          tzinfo=dateutil.tz.tzutc()),
+                                  end=datetime.datetime(2000, 1, 1, 0, 0, 0,
+                                                        tzinfo=dateutil.tz.tzutc()))
+
+        uid = UniqueIdentity.objects.create(uuid='c6d2504fde0e34b78a185c4b709e5442d045451c')
+        Profile.objects.create(email=None,
+                               is_bot=False,
+                               gender='M',
+                               country=None,
+                               uidentity=uid)
+        Identity.objects.create(id='B001',
+                                name='John Doe',
+                                email='jdoe@example.com',
+                                username='jdoe',
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='B002',
+                                name=None,
+                                email='jdoe@libresoft.es',
+                                username=None,
+                                source='scm',
+                                uidentity=uid)
+
+        # Tests
+        client = graphene.test.Client(schema)
+        executed = client.execute(SH_UIDS_UUID_FILTER)
+
+        uidentities = executed['data']['uidentities']
+        self.assertEqual(len(uidentities), 1)
+
+        # Test John Smith unique identity
+        uid = uidentities[0]
+        self.assertEqual(uid['uuid'], 'a9b403e150dd4af8953a52a4bb841051e4b705d9')
+
+        self.assertEqual(uid['profile']['name'], None)
+        self.assertEqual(uid['profile']['email'], 'jsmith@example.com')
+        self.assertEqual(uid['profile']['isBot'], True)
+        self.assertEqual(uid['profile']['country']['code'], 'US')
+        self.assertEqual(uid['profile']['country']['name'], 'United States of America')
+
+        identities = uid['identities']
+        identities.sort(key=lambda x: x['id'])
+        self.assertEqual(len(identities), 3)
+
+        id1 = identities[0]
+        self.assertEqual(id1['email'], 'jsmith@example.com')
+
+        id2 = identities[1]
+        self.assertEqual(id2['email'], 'jsmith@bitergia.com')
+        self.assertEqual(id2['source'], 'scm')
+
+        id3 = identities[2]
+        self.assertEqual(id3['email'], 'jsmith@bitergia.com')
+        self.assertEqual(id3['source'], 'mls')
+
+        enrollments = uid['enrollments']
+        enrollments.sort(key=lambda x: x['organization']['name'])
+        self.assertEqual(len(enrollments), 2)
+
+        rol1 = enrollments[0]
+        self.assertEqual(rol1['organization']['name'], 'Bitergia')
+        self.assertEqual(rol1['start'], '1999-01-01T00:00:00+00:00')
+        self.assertEqual(rol1['end'], '2000-01-01T00:00:00+00:00')
+
+        rol2 = enrollments[1]
+        self.assertEqual(rol2['organization']['name'], 'Example')
+        self.assertEqual(rol2['start'], '1900-01-01T00:00:00+00:00')
+        self.assertEqual(rol2['end'], '2100-01-01T00:00:00+00:00')
+
+    def test_filter_non_exist_registry(self):
+        """Check whether it returns an empty list when searched with a non existing uuid"""
+
+        uid = UniqueIdentity.objects.create(uuid='c6d2504fde0e34b78a185c4b709e5442d045451c')
+        Profile.objects.create(email=None,
+                               is_bot=False,
+                               gender='M',
+                               country=None,
+                               uidentity=uid)
+        Identity.objects.create(id='B001',
+                                name='John Doe',
+                                email='jdoe@example.com',
+                                username='jdoe',
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='B002',
+                                name=None,
+                                email='jdoe@libresoft.es',
+                                username=None,
+                                source='scm',
+                                uidentity=uid)
+
+        client = graphene.test.Client(schema)
+        executed = client.execute(SH_UIDS_UUID_FILTER)
 
         uids = executed['data']['uidentities']
         self.assertListEqual(uids, [])


### PR DESCRIPTION
In order to get one uidentity by its uuid we added a filter to the query. We had to install a graphene-django-extras[1] library to do that in the simplest way. There are three behaviors:

1. If you specify the uuid in the filter you will receive the uidentites that match that uuid.
2. If you don't put the uuid filter, you will receive all the uidentites.
3. If you put an uuid in the filter that does not exist, you will receive an empty list.

There are also tests in order to check that it works as expected.

[1]: https://github.com/eamigo86/graphene-django-extras