### PR TITLE
[tests] Fix flake8 test_api

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,6 @@ from sortinghat.core.errors import (AlreadyExistsError,
 from sortinghat.core.models import (Country,
                                     UniqueIdentity,
                                     Identity,
-                                    Profile,
                                     Enrollment)
 
 


### PR DESCRIPTION
This code removes the import of Profile from the package core.models, which is not used, thus fixing the related flake8 error.