### PR TITLE
[graphql] Allow filtering uidentities by uuid

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -82,6 +82,10 @@ class ProfileInputType(graphene.InputObjectType):
     country_code = graphene.String(required=False)
 
 
+class IdentityFilterType(graphene.InputObjectType):
+    uuid = graphene.String(required=False)
+
+
 class AddOrganization(graphene.Mutation):
     class Arguments:
         name = graphene.String()
@@ -207,13 +211,20 @@ class UpdateProfile(graphene.Mutation):
 
 class SortingHatQuery:
     organizations = graphene.List(OrganizationType)
-    uidentities = graphene.List(UniqueIdentityType)
+    uidentities = graphene.Field(
+        graphene.List(UniqueIdentityType),
+        filters=IdentityFilterType(required=False)
+    )
 
     def resolve_organizations(self, info, **kwargs):
         return Organization.objects.order_by('name')
 
-    def resolve_uidentities(self, info, **kwargs):
-        return UniqueIdentity.objects.order_by('uuid')
+    def resolve_uidentities(self, info, filters=None, **kwargs):
+        query = UniqueIdentity.objects.order_by('uuid')
+
+        if filters and 'uuid' in filters:
+            query = query.filter(uuid=filters['uuid'])
+        return query
 
 
 class SortingHatMutation(graphene.ObjectType):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -93,6 +93,35 @@ SH_UIDS_QUERY = """{
     }
   }
 }"""
+SH_UIDS_UUID_FILTER = """{
+  uidentities(filters: {uuid: "a9b403e150dd4af8953a52a4bb841051e4b705d9"}) {
+    uuid
+    profile {
+      name
+      email
+      gender
+      isBot
+      country {
+        code
+        name
+      }
+    }
+    identities {
+      id
+      name
+      email
+      username
+      source
+    }
+    enrollments {
+      organization {
+        name
+      }
+      start
+      end
+    }
+  }
+}"""
 
 
 class TestQuery(SortingHatQuery, graphene.ObjectType):
@@ -284,6 +313,141 @@ class TestUniqueIdentities(django.test.TestCase):
 
         client = graphene.test.Client(schema)
         executed = client.execute(SH_UIDS_QUERY)
+
+        uids = executed['data']['uidentities']
+        self.assertListEqual(uids, [])
+
+    def test_filter_registry(self):
+        """Check whether it returns the uuid searched when using uuid filter"""
+
+        cn = Country.objects.create(code='US',
+                                    name='United States of America',
+                                    alpha3='USA')
+
+        org_ex = Organization.objects.create(name='Example')
+        org_bit = Organization.objects.create(name='Bitergia')
+
+        uid = UniqueIdentity.objects.create(uuid='a9b403e150dd4af8953a52a4bb841051e4b705d9')
+        Profile.objects.create(name=None,
+                               email='jsmith@example.com',
+                               is_bot=True,
+                               gender='M',
+                               country=cn,
+                               uidentity=uid)
+        Identity.objects.create(id='A001',
+                                name='John Smith',
+                                email='jsmith@example.com',
+                                username='jsmith',
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='A002',
+                                name=None,
+                                email='jsmith@bitergia.com',
+                                username=None,
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='A003',
+                                name=None,
+                                email='jsmith@bitergia.com',
+                                username=None,
+                                source='mls',
+                                uidentity=uid)
+        Enrollment.objects.create(uidentity=uid, organization=org_ex)
+        Enrollment.objects.create(uidentity=uid, organization=org_bit,
+                                  start=datetime.datetime(1999, 1, 1, 0, 0, 0,
+                                                          tzinfo=dateutil.tz.tzutc()),
+                                  end=datetime.datetime(2000, 1, 1, 0, 0, 0,
+                                                        tzinfo=dateutil.tz.tzutc()))
+
+        uid = UniqueIdentity.objects.create(uuid='c6d2504fde0e34b78a185c4b709e5442d045451c')
+        Profile.objects.create(email=None,
+                               is_bot=False,
+                               gender='M',
+                               country=None,
+                               uidentity=uid)
+        Identity.objects.create(id='B001',
+                                name='John Doe',
+                                email='jdoe@example.com',
+                                username='jdoe',
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='B002',
+                                name=None,
+                                email='jdoe@libresoft.es',
+                                username=None,
+                                source='scm',
+                                uidentity=uid)
+
+        # Tests
+        client = graphene.test.Client(schema)
+        executed = client.execute(SH_UIDS_UUID_FILTER)
+
+        uidentities = executed['data']['uidentities']
+        self.assertEqual(len(uidentities), 1)
+
+        # Test John Smith unique identity
+        uid = uidentities[0]
+        self.assertEqual(uid['uuid'], 'a9b403e150dd4af8953a52a4bb841051e4b705d9')
+
+        self.assertEqual(uid['profile']['name'], None)
+        self.assertEqual(uid['profile']['email'], 'jsmith@example.com')
+        self.assertEqual(uid['profile']['isBot'], True)
+        self.assertEqual(uid['profile']['country']['code'], 'US')
+        self.assertEqual(uid['profile']['country']['name'], 'United States of America')
+
+        identities = uid['identities']
+        identities.sort(key=lambda x: x['id'])
+        self.assertEqual(len(identities), 3)
+
+        id1 = identities[0]
+        self.assertEqual(id1['email'], 'jsmith@example.com')
+
+        id2 = identities[1]
+        self.assertEqual(id2['email'], 'jsmith@bitergia.com')
+        self.assertEqual(id2['source'], 'scm')
+
+        id3 = identities[2]
+        self.assertEqual(id3['email'], 'jsmith@bitergia.com')
+        self.assertEqual(id3['source'], 'mls')
+
+        enrollments = uid['enrollments']
+        enrollments.sort(key=lambda x: x['organization']['name'])
+        self.assertEqual(len(enrollments), 2)
+
+        rol1 = enrollments[0]
+        self.assertEqual(rol1['organization']['name'], 'Bitergia')
+        self.assertEqual(rol1['start'], '1999-01-01T00:00:00+00:00')
+        self.assertEqual(rol1['end'], '2000-01-01T00:00:00+00:00')
+
+        rol2 = enrollments[1]
+        self.assertEqual(rol2['organization']['name'], 'Example')
+        self.assertEqual(rol2['start'], '1900-01-01T00:00:00+00:00')
+        self.assertEqual(rol2['end'], '2100-01-01T00:00:00+00:00')
+
+    def test_filter_non_exist_registry(self):
+        """Check whether it returns an empty list when searched with a non existing uuid"""
+
+        uid = UniqueIdentity.objects.create(uuid='c6d2504fde0e34b78a185c4b709e5442d045451c')
+        Profile.objects.create(email=None,
+                               is_bot=False,
+                               gender='M',
+                               country=None,
+                               uidentity=uid)
+        Identity.objects.create(id='B001',
+                                name='John Doe',
+                                email='jdoe@example.com',
+                                username='jdoe',
+                                source='scm',
+                                uidentity=uid)
+        Identity.objects.create(id='B002',
+                                name=None,
+                                email='jdoe@libresoft.es',
+                                username=None,
+                                source='scm',
+                                uidentity=uid)
+
+        client = graphene.test.Client(schema)
+        executed = client.execute(SH_UIDS_UUID_FILTER)
 
         uids = executed['data']['uidentities']
         self.assertListEqual(uids, [])


### PR DESCRIPTION
In order to get one uidentity by its uuid we added a filter to the
query. Moreover, a new type for filtering has been created in
order to add filters easily without changing the query, so we can
filter in more than one field using this new type.

This query expects these three behaviors:

- If you specify the uuid in the filter you will receive the
  uidentites that match that uuid.
- If you don't put the uuid filter, you will receive all the
  uidentites.
- If you put an uuid in the filter that does not exist,
  you will receive an empty list.

There are also tests in order to check that it works as expected.