### PR TITLE
Add GraphQL mutation to enroll identities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==2.1
 grimoirelab_toolkit>=0.1.8
 mysqlclient==1.3.13
-python-dateutil>=2.6.0
+python-dateutil>=2.8.0
 graphene-django>=2.0

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -104,6 +104,30 @@ def find_organization(name):
         return organization
 
 
+def search_enrollments_in_period(uuid, org_name,
+                                 from_date=MIN_PERIOD_DATE,
+                                 to_date=MIN_PERIOD_DATE):
+    """Look for enrollments in a given period.
+
+    Returns the enrollments of a unique identity for a given
+    organization during period of time.
+
+    An empty list will be returned when no enrollments could be
+    found, due to the unique identity or the organization do not
+    exist, or there are not enrollments assigned on that period.
+
+    :param uuid: id of the unique identity
+    :param org_name: name of the organization
+    :param from_date: starting date for the period
+    :param to_date: ending date for the period
+
+    :returns: a list of enrollment objects
+    """
+    return Enrollment.objects.filter(uidentity__uuid=uuid,
+                                     organization__name=org_name,
+                                     start__lte=to_date, end__gte=from_date).order_by('start')
+
+
 def add_organization(name):
     """Add an organization to the database.
 

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -82,6 +82,28 @@ def find_identity(uuid):
         return identity
 
 
+def find_organization(name):
+    """Find an organization.
+
+    Find an organization by its name in the database. When the
+    organization does not exist the function will raise
+    a `NotFoundError`.
+
+    :param name: name of the organization to find
+
+    :returns: an organization object
+
+    :raises NotFoundError: when the organization with the
+        given `name` does not exists.
+    """
+    try:
+        organization = Organization.objects.get(name=name)
+    except Organization.DoesNotExist:
+        raise NotFoundError(entity=name)
+    else:
+        return organization
+
+
 def add_organization(name):
     """Add an organization to the database.
 

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -434,6 +434,18 @@ def add_enrollment(uidentity, organization,
     return enrollment
 
 
+def delete_enrollment(enrollment):
+    """Remove an enrollment from the database.
+
+    This function removes from the database the enrollment given
+    in `enrollment`.
+
+    :param enrollment: enrollment object to remove
+    """
+    enrollment.delete()
+    enrollment.uidentity.save()
+
+
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")
 
 

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -24,15 +24,18 @@ import re
 import django.core.exceptions
 import django.db.utils
 
-from grimoirelab_toolkit.datetime import datetime_utcnow
+from grimoirelab_toolkit.datetime import datetime_utcnow, datetime_to_utc
 
 from .errors import AlreadyExistsError, NotFoundError
-from .models import (Organization,
+from .models import (MIN_PERIOD_DATE,
+                     MAX_PERIOD_DATE,
+                     Organization,
                      Domain,
                      Country,
                      UniqueIdentity,
                      Identity,
-                     Profile)
+                     Profile,
+                     Enrollment)
 
 
 def find_unique_identity(uuid):
@@ -376,6 +379,59 @@ def update_profile(uidentity, **kwargs):
     uidentity.save()
 
     return uidentity
+
+
+def add_enrollment(uidentity, organization,
+                   start=MIN_PERIOD_DATE, end=MAX_PERIOD_DATE):
+    """Enroll a unique identity to an organization in the database.
+
+    The function adds a new relationship between the unique
+    identity in `uidentity` and the given `organization` to
+    the database.
+
+    The period of the enrollment can be given with the parameters
+    `from_date` and `to_date`, where `from_date <= to_date`.
+    Default values for these dates are `MIN_PERIOD_DATE` and
+    `MAX_PERIOD_DATE`. These dates cannot be `None`.
+
+    This function returns as result a new `Enrollment` object.
+
+    :param uidentity: unique identity to enroll
+    :param organization: organization where the unique identity is enrolled
+    :param start: date when the enrollment starts
+    :param end: date when the enrollment ends
+
+    :returns: a new enrollment
+
+    :raises ValueError: when either `start` or `end` are `None`;
+        when `start < MIN_PERIOD_DATE`; or `end > MAX_PERIOD_DATE`
+        or `start > end`.
+    """
+    if not start:
+        raise ValueError("'start' date cannot be None")
+    if not end:
+        raise ValueError("'end' date cannot be None")
+
+    start = datetime_to_utc(start)
+    end = datetime_to_utc(end)
+
+    if start < MIN_PERIOD_DATE or start > MAX_PERIOD_DATE:
+        raise ValueError("'start' date {} is out of bounds".format(start))
+    if end < MIN_PERIOD_DATE or end > MAX_PERIOD_DATE:
+        raise ValueError("'end' date {} is out of bounds".format(end))
+    if start > end:
+        raise ValueError("'start' date {} cannot be greater than {}".format(start, end))
+
+    try:
+        enrollment = Enrollment(uidentity=uidentity,
+                                organization=organization,
+                                start=start, end=end)
+        enrollment.save()
+        uidentity.save()
+    except django.db.utils.IntegrityError as exc:
+        _handle_integrity_error(Identity, exc)
+
+    return enrollment
 
 
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")

--- a/sortinghat/core/models.py
+++ b/sortinghat/core/models.py
@@ -172,6 +172,7 @@ class Enrollment(ModelBase):
     class Meta:
         db_table = 'enrollments'
         unique_together = ('uidentity', 'organization', 'start', 'end',)
+        ordering = ('start', 'end', )
 
     def __str__(self):
         return '%s - %s' % (self.uidentity.uuid, self.organization.name)

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -22,9 +22,11 @@
 import graphene
 from graphene_django.types import DjangoObjectType
 
+
 from .api import (add_identity,
                   delete_identity,
-                  update_profile)
+                  update_profile,
+                  enroll)
 from .db import (add_organization,
                  delete_organization,
                  add_domain,
@@ -209,6 +211,25 @@ class UpdateProfile(graphene.Mutation):
         )
 
 
+class Enroll(graphene.Mutation):
+    class Arguments:
+        uuid = graphene.String()
+        organization = graphene.String()
+        from_date = graphene.DateTime(required=False)
+        to_date = graphene.DateTime(required=False)
+
+    uuid = graphene.Field(lambda: graphene.String)
+    uidentity = graphene.Field(lambda: UniqueIdentityType)
+
+    def mutate(self, info, uuid, organization, from_date=None, to_date=None):
+        uidentity = enroll(uuid, organization,
+                           from_date=from_date, to_date=to_date)
+        return Enroll(
+            uuid=uidentity.uuid,
+            uidentity=uidentity
+        )
+
+
 class SortingHatQuery:
     organizations = graphene.List(OrganizationType)
     uidentities = graphene.Field(
@@ -235,3 +256,4 @@ class SortingHatMutation(graphene.ObjectType):
     add_identity = AddIdentity.Field()
     delete_identity = DeleteIdentity.Field()
     update_profile = UpdateProfile.Field()
+    enroll = Enroll.Field()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -61,6 +61,7 @@ SOURCE_EMPTY_ERROR = "'source' cannot be an empty string"
 IDENTITY_DATA_NONE_OR_EMPTY_ERROR = "identity data cannot be None or empty"
 UNIQUE_IDENTITY_NOT_FOUND_ERROR = "zyxwuv not found in the registry"
 IDENTITY_NOT_FOUND_ERROR = "zyxwuv not found in the registry"
+ORGANIZATION_NOT_FOUND_ERROR = "Bitergia not found in the registry"
 IS_BOT_VALUE_ERROR = "'is_bot' must have a boolean value"
 COUNTRY_CODE_ERROR = r"'country_code' \({code}\) does not match with a valid code"
 GENDER_ACC_INVALID_ERROR = "'gender_acc' can only be set when 'gender' is given"
@@ -118,6 +119,29 @@ class TestFindIdentity(TestCase):
 
         with self.assertRaisesRegex(NotFoundError, IDENTITY_NOT_FOUND_ERROR):
             db.find_identity('zyxwuv')
+
+
+class TestFindOrganization(TestCase):
+    """Unit tests for find_organization"""
+
+    def test_find_organization(self):
+        """Test if an organization is found by its name"""
+
+        name = 'Example'
+        Organization.objects.create(name=name)
+
+        organization = db.find_organization(name)
+        self.assertIsInstance(organization, Organization)
+        self.assertEqual(organization.name, name)
+
+    def test_organization_not_found(self):
+        """Test whether it raises an exception when the organization is not found"""
+
+        name = 'Example'
+        Organization.objects.create(name=name)
+
+        with self.assertRaisesRegex(NotFoundError, ORGANIZATION_NOT_FOUND_ERROR):
+            db.find_organization('Bitergia')
 
 
 class TestAddOrganization(TestCase):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1049,16 +1049,16 @@ class TestAddEnrollment(TestCase):
         self.assertEqual(len(enrollments), 3)
 
         enrollment = enrollments[0]
-        self.assertEqual(enrollment.start, datetime.datetime(1999, 1, 1, tzinfo=UTC))
-        self.assertEqual(enrollment.end, MAX_PERIOD_DATE)
+        self.assertEqual(enrollment.start, MIN_PERIOD_DATE)
+        self.assertEqual(enrollment.end, datetime.datetime(2005, 1, 1, tzinfo=UTC))
         self.assertIsInstance(enrollment.uidentity, UniqueIdentity)
         self.assertEqual(enrollment.uidentity.uuid, uuid)
         self.assertIsInstance(enrollment.organization, Organization)
         self.assertEqual(enrollment.organization.name, name)
 
         enrollment = enrollments[1]
-        self.assertEqual(enrollment.start, MIN_PERIOD_DATE)
-        self.assertEqual(enrollment.end, datetime.datetime(2005, 1, 1, tzinfo=UTC))
+        self.assertEqual(enrollment.start, datetime.datetime(1999, 1, 1, tzinfo=UTC))
+        self.assertEqual(enrollment.end, MAX_PERIOD_DATE)
         self.assertIsInstance(enrollment.uidentity, UniqueIdentity)
         self.assertEqual(enrollment.uidentity.uuid, uuid)
         self.assertIsInstance(enrollment.organization, Organization)


### PR DESCRIPTION
This mutation allows to enroll identities in organizations. Some functions were added to the API to support this feature.

This commit adds the features requested on #185