### PR TITLE
Add GraphQL mutation to move identities

### DIFF
--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -492,6 +492,37 @@ def delete_enrollment(enrollment):
     enrollment.uidentity.save()
 
 
+def move_identity(identity, uidentity):
+    """Move an identity to a unique identity.
+
+    Shifts `identity` to the unique identity given in `uidentity`.
+    As a result, it will return `uidentity` object with list of
+    identities updated.
+
+    When `identity` is already assigned to `uidentity`, the function
+    will raise an `ValueError` exception.
+
+    :param identity: identity to be moved
+    :param uidentity: unique identity where `identity` will be moved
+
+    :returns: the unique identity with related identities updated
+
+    :raises ValueError: when `identity` is already part of `uidentity`
+    """
+    if identity.uidentity == uidentity:
+        msg = "identity '{}' is already assigned to '{}'".format(identity.id, uidentity.uuid)
+        raise ValueError(msg)
+
+    old_uidentity = identity.uidentity
+    identity.uidentity = uidentity
+
+    identity.save()
+    old_uidentity.save()
+    uidentity.save()
+
+    return uidentity
+
+
 _MYSQL_DUPLICATE_ENTRY_ERROR_REGEX = re.compile(r"Duplicate entry '(?P<value>.+)' for key")
 
 

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -26,6 +26,7 @@ from graphene_django.types import DjangoObjectType
 from .api import (add_identity,
                   delete_identity,
                   update_profile,
+                  move_identity,
                   enroll,
                   withdraw)
 from .db import (add_organization,
@@ -212,6 +213,23 @@ class UpdateProfile(graphene.Mutation):
         )
 
 
+class MoveIdentity(graphene.Mutation):
+    class Arguments:
+        from_id = graphene.String()
+        to_uuid = graphene.String()
+
+    uuid = graphene.Field(lambda: graphene.String)
+    uidentity = graphene.Field(lambda: UniqueIdentityType)
+
+    def mutate(self, info, from_id, to_uuid):
+        uidentity = move_identity(from_id, to_uuid)
+
+        return MoveIdentity(
+            uuid=uidentity.uuid,
+            uidentity=uidentity
+        )
+
+
 class Enroll(graphene.Mutation):
     class Arguments:
         uuid = graphene.String()
@@ -276,5 +294,6 @@ class SortingHatMutation(graphene.ObjectType):
     add_identity = AddIdentity.Field()
     delete_identity = DeleteIdentity.Field()
     update_profile = UpdateProfile.Field()
+    move_identity = MoveIdentity.Field()
     enroll = Enroll.Field()
     withdraw = Withdraw.Field()


### PR DESCRIPTION
This PR add the functionality to move identities from one unique identity to another. This functionality works the same than in the original version of SortingHat. It also adds the features requested on #187.