### PR TITLE
[parsing] Fix YAMLLoadWarning for grimoirelab parser

### DIFF
--- a/sortinghat/parsing/grimoirelab.py
+++ b/sortinghat/parsing/grimoirelab.py
@@ -303,7 +303,7 @@ class GrimoireLabParser(object):
         """Load yml stream into a dict object """
 
         try:
-            return yaml.load(stream)
+            return yaml.load(stream, Loader=yaml.SafeLoader)
         except ValueError as e:
             cause = "invalid yml format. %s" % str(e)
             raise InvalidFormatError(cause=cause)


### PR DESCRIPTION
This code fixes the warning YAMLLoadWarning thrown when calling yaml.load() without Loader. It fixes https://github.com/chaoss/grimoirelab-sortinghat/issues/199