### PR TITLE
Add support to parse a blacklist

### DIFF
--- a/misc/grimoirelab2sh
+++ b/misc/grimoirelab2sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2017 Bitergia
+# Copyright (C) 2017-2019 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@
 # Authors:
 #     Luis Cañas-Díaz <lcanas@bitergia.com>
 #     Miguel Ángel Fernández Sánchez <mafesan@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
 #
 
 import argparse
@@ -46,7 +47,10 @@ def main():
     except (IOError, UnicodeDecodeError, InvalidFormatError) as e:
         raise RuntimeError(str(e))
 
-    j = to_json(parser.identities, parser.organizations, args.source)
+    j = to_json(parser.blacklist,
+                parser.identities,
+                parser.organizations,
+                args.source)
 
     try:
         args.outfile.write(j)
@@ -100,7 +104,7 @@ def parse_grimoirelab_file(identities, organizations, source, email_validation):
     return parser
 
 
-def to_json(uidentities, organizations, source):
+def to_json(blacklist, uidentities, organizations, source):
     """Convert unique identities and organizations to Sorting Hat JSON format"""
 
     uids = {}
@@ -126,10 +130,12 @@ def to_json(uidentities, organizations, source):
 
         orgs[organization.name] = domains
 
+    blacklist = [mb.excluded for mb in blacklist]
+
     # Generate JSON file
     obj = {'time': str(datetime.datetime.now()),
            'source': source,
-           'blacklist': [],
+           'blacklist': blacklist,
            'organizations': orgs,
            'uidentities': uids}
 

--- a/tests/data/grimoirelab_invalid_blacklist_empty_entry.yml
+++ b/tests/data/grimoirelab_invalid_blacklist_empty_entry.yml
@@ -1,4 +1,3 @@
-# valid entry
 - profile:
     name: J. Manrique Lopez de la Fuente
   enrollments:
@@ -11,7 +10,6 @@
   email:
     - jsmanrique@bitergia.com
 
-# valid entry
 - profile:
     name: Luis Cañas-Díaz
   enrollments:
@@ -28,7 +26,6 @@
   email:
     - lcanas@bitergia.com
 
-# valid entry
 - profile:
     name: Owl Bot
     is_bot: true
@@ -40,5 +37,5 @@
 
 - blacklist:
     - no-reply@example.com
-    - root
+    -
     - Generic Account

--- a/tests/data/grimoirelab_invalid_blacklist_no_list.yml
+++ b/tests/data/grimoirelab_invalid_blacklist_no_list.yml
@@ -1,4 +1,3 @@
-# valid entry
 - profile:
     name: J. Manrique Lopez de la Fuente
   enrollments:
@@ -11,7 +10,6 @@
   email:
     - jsmanrique@bitergia.com
 
-# valid entry
 - profile:
     name: Luis Cañas-Díaz
   enrollments:
@@ -28,7 +26,6 @@
   email:
     - lcanas@bitergia.com
 
-# valid entry
 - profile:
     name: Owl Bot
     is_bot: true
@@ -39,6 +36,4 @@
       start: 2017-01-01T00:00:00
 
 - blacklist:
-    - no-reply@example.com
-    - root
-    - Generic Account
+


### PR DESCRIPTION
While SortingHat standard file includes a list of blacklisted entries, GrimoireLab format does not.
This patch allows to include a blacklist on the YAML file, that will be parsed and converted into the
SortingHat format. Take into account the inclusion of a blacklist is totally optional.

This patch also updates `grimoirelab2sh` script to support this new feature.