### PR TITLE
[setup] Set pandas dep version to 0.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(name="sortinghat",
         'sqlalchemy>=1.2',
         'jinja2',
         'python-dateutil>=2.6.0',
-        'pandas==0.24.2',
+        'pandas==0.22.0',
         'pyyaml>=3.12',
         'requests>=2.9',
         'urllib3>=1.22'


### PR DESCRIPTION
This code changes the version of the Pandas dependency to 0.22.0. This change is needed since in Travis the max version distribution for Pandas is currently 0.22.0. No problems appear when executing the Travis CI for sortinghat with a higher version (0.24.2), since the latter version is downloaded and compiled. This doesn't happen when executing Travis tests for components that have a dependency with
SortingHat (i.e., ELK and Mordred). In this case, Travis relies on the version distributions available
(<= 0.22.0).