### PR TITLE
[utils] Prevent insertion of white space values

### DIFF
--- a/sortinghat/utils.py
+++ b/sortinghat/utils.py
@@ -149,17 +149,21 @@ def uuid(source, email=None, name=None, username=None):
     :raises ValueError: when source is None or empty; each one of the
         parameters is None; parameters are empty.
     """
+    _email = email.strip() if email else email
+    _name = name.strip() if name else name
+    _username = username.strip() if username else username
+
     if source is None:
         raise ValueError("source cannot be None")
     if source == '':
         raise ValueError("source cannot be an empty string")
-    if not (email or name or username):
+    if not (_email or _name or _username):
         raise ValueError("identity data cannot be None or empty")
 
     s = ':'.join((to_unicode(source),
-                  to_unicode(email),
-                  to_unicode(name, unaccent=True),
-                  to_unicode(username))).lower()
+                  to_unicode(_email),
+                  to_unicode(_name, unaccent=True),
+                  to_unicode(_username))).lower()
 
     sha1 = hashlib.sha1(s.encode('UTF-8', errors="surrogateescape"))
     uuid_ = sha1.hexdigest()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -438,6 +438,8 @@ class TestAddIdentity(TestAPICaseBase):
                                api.add_identity, self.db, 'scm', None, '', None)
         self.assertRaisesRegex(ValueError, IDENTITY_NONE_OR_EMPTY_ERROR,
                                api.add_identity, self.db, 'scm', '', '', '')
+        self.assertRaisesRegex(ValueError, IDENTITY_NONE_OR_EMPTY_ERROR,
+                               api.add_identity, self.db, 'scm', '  ', '  ', '  ')
 
 
 class TestAddOrganization(TestAPICaseBase):


### PR DESCRIPTION
This PR addresses https://github.com/chaoss/grimoirelab-sortinghat/issues/162, thus it processes the values of email, name and username by splitting white spaces.

Tests have been addded accordingly.