### PR TITLE
[tests] Fix travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - pip install cryptography
 
 before_script:
+  - mysql -e "SET GLOBAL sql_mode = 'ONLY_FULL_GROUP_BY,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
   - mysql -e 'create database testhat;'
   - cp tests/tests.conf.sample tests/tests.conf
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ python:
 
 sudo: false
 
+services:
+  - mysql
+
 install:
   - pip install coveralls
   - pip install cryptography


### PR DESCRIPTION
This PR fixes the tests on Travis by including mysql as service and removing STRICT_TRANS_TABLES from the mysql sql_mode variable. This last change is needed to make the test [test_duplicate_identities_with_truncated_values](https://github.com/chaoss/grimoirelab-sortinghat/blob/master/tests/test_api.py#L300) pass with success.