### PR TITLE
Add API methods for adding and removing organizations

### DIFF
--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
 #
 
 import re
@@ -97,6 +98,8 @@ def find_organization(name):
     :raises NotFoundError: when the organization with the
         given `name` does not exists.
     """
+    validate_field('name', name)
+
     try:
         organization = Organization.objects.get(name=name)
     except Organization.DoesNotExist:

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -29,11 +29,11 @@ from .api import (add_identity,
                   update_profile,
                   move_identity,
                   merge_identities,
+                  add_organization,
+                  delete_organization,
                   enroll,
                   withdraw)
-from .db import (add_organization,
-                 delete_organization,
-                 add_domain,
+from .db import (add_domain,
                  delete_domain)
 from .models import (Organization,
                      Domain,
@@ -113,8 +113,7 @@ class DeleteOrganization(graphene.Mutation):
     organization = graphene.Field(lambda: OrganizationType)
 
     def mutate(self, info, name):
-        org = Organization.objects.get(name=name)
-        delete_organization(org)
+        org = delete_organization(name)
 
         return DeleteOrganization(
             organization=org

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1028,6 +1028,26 @@ class TestAddOrganization(TestCase):
 
         with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
             api.add_organization(name='')
+
+    def test_organization_name_whitespaces(self):
+        """Check if it fails when organization name is composed by whitespaces only"""
+
+        with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
+            api.add_organization(name='   ')
+
+        with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
+            api.add_organization(name='\t')
+
+        with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
+            api.add_organization(name=' \t  ')
+
+    def test_organization_name_int(self):
+        """Check if it fails when organization name is an integer"""
+
+        with self.assertRaisesRegex(TypeError, ORGANIZATION_VALUE_ERROR):
+            api.add_organization(name=12345)
+
+
 class TestDeleteOrganization(TestCase):
     """Unit tests for delete_organization"""
 
@@ -1081,6 +1101,24 @@ class TestDeleteOrganization(TestCase):
 
         with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
             api.delete_organization(name='')
+
+    def test_organization_name_whitespaces(self):
+        """Check if it fails when organization name is composed by whitespaces"""
+
+        with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
+            api.delete_organization(name='   ')
+
+        with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
+            api.delete_organization(name='\t')
+
+        with self.assertRaisesRegex(InvalidValueError, ORGANIZATION_NAME_NONE_OR_EMPTY_ERROR):
+            api.delete_organization(name=' \t  ')
+
+    def test_organization_name_int(self):
+        """Check if it fails when organization name is an integer"""
+
+        with self.assertRaisesRegex(TypeError, ORGANIZATION_VALUE_ERROR):
+            api.delete_organization(name=12345)
 
 
 class TestEnroll(TestCase):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -60,7 +60,8 @@ UUID_EMPTY_ERROR = "'uuid' cannot be an empty string"
 ORG_DOES_NOT_EXIST_ERROR = "Organization matching query does not exist."
 DOMAIN_DOES_NOT_EXIST_ERROR = "Domain matching query does not exist."
 UID_DOES_NOT_EXIST_ERROR = "FFFFFFFFFFFFFFF not found in the registry"
-ORGANIZATION_DOES_NOT_EXIST_ERROR = "Bitergia not found in the registry"
+ORGANIZATION_BITERGIA_DOES_NOT_EXIST_ERROR = "Bitergia not found in the registry"
+ORGANIZATION_EXAMPLE_DOES_NOT_EXIST_ERROR = "Example not found in the registry"
 ENROLLMENT_DOES_NOT_EXIST_ERROR = "'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3-Example-2050-01-01 00:00:00+00:00-2060-01-01 00:00:00+00:00' not found in the registry"
 
 
@@ -604,13 +605,13 @@ class TestDeleteOrganizationMutation(django.test.TestCase):
 
         # Check error
         msg = executed['errors'][0]['message']
-        self.assertEqual(msg, ORG_DOES_NOT_EXIST_ERROR)
+        self.assertEqual(msg, ORGANIZATION_EXAMPLE_DOES_NOT_EXIST_ERROR)
 
         # It should not remove anything
         Organization.objects.create(name='Bitergia')
 
         msg = executed['errors'][0]['message']
-        self.assertEqual(msg, ORG_DOES_NOT_EXIST_ERROR)
+        self.assertEqual(msg, ORGANIZATION_EXAMPLE_DOES_NOT_EXIST_ERROR)
 
         orgs = Organization.objects.all()
         self.assertEqual(len(orgs), 1)
@@ -1610,7 +1611,7 @@ class TestEnrollMutation(django.test.TestCase):
         executed = client.execute(self.SH_ENROLL, variables=params)
 
         msg = executed['errors'][0]['message']
-        self.assertEqual(msg, ORGANIZATION_DOES_NOT_EXIST_ERROR)
+        self.assertEqual(msg, ORGANIZATION_BITERGIA_DOES_NOT_EXIST_ERROR)
 
     def test_integrity_error(self):
         """Check whether enrollments in an existing period cannot be inserted"""
@@ -1786,7 +1787,7 @@ class TestWithdrawMutation(django.test.TestCase):
         executed = client.execute(self.SH_WITHDRAW, variables=params)
 
         msg = executed['errors'][0]['message']
-        self.assertEqual(msg, ORGANIZATION_DOES_NOT_EXIST_ERROR)
+        self.assertEqual(msg, ORGANIZATION_BITERGIA_DOES_NOT_EXIST_ERROR)
 
     def test_non_existing_enrollments(self):
         """Check if it fails when the enrollments for a period do not exist"""


### PR DESCRIPTION
* New API methods: `add_organization` and `delete_organization`.
* `AddOrganization` and `DeleteOrganization` mutations now use these new API methods instead of the DB methods used directly.
* This PR contains also one minor change to `db.py` script to add an additional validation of the organization name field when performing a search within its `find_organization` method.