### PR TITLE
Add API methods for adding and removing domains

### DIFF
--- a/sortinghat/core/api.py
+++ b/sortinghat/core/api.py
@@ -29,13 +29,16 @@ from grimoirelab_toolkit.datetime import datetime_to_utc
 from .db import (find_unique_identity,
                  find_identity,
                  find_organization,
+                 find_domain,
                  search_enrollments_in_period,
                  add_unique_identity as add_unique_identity_db,
                  add_identity as add_identity_db,
                  add_organization as add_organization_db,
+                 add_domain as add_domain_db,
                  delete_unique_identity as delete_unique_identity_db,
                  delete_identity as delete_identity_db,
                  delete_organization as delete_organization_db,
+                 delete_domain as delete_domain_db,
                  update_profile as update_profile_db,
                  move_identity as move_identity_db,
                  add_enrollment,
@@ -352,6 +355,65 @@ def add_organization(name):
 
 
 @django.db.transaction.atomic
+def add_domain(organization, domain_name, is_top_domain=True):
+    """Add a domain to the registry.
+
+    This function adds a new domain to a given organization.
+    The organization must exist on the registry prior to insert the new
+    domain. Otherwise, it will raise a `NotFoundError` exception. Moreover,
+    if the given domain is already in the registry an `AlreadyExistsError`
+    exception will be raised.
+
+    The new domain is set as a top domain by default. That is useful to avoid
+    the insertion of sub-domains that belong to the same organization (i.e
+    eu.example.com, us.example.com).
+
+    Remember that a domain can only be assigned to one (and only one)
+    organization.
+
+    :param organization: name of the organization
+    :param domain_name: domain to add to the registry
+    :param is_top_domain: set this domain as a top domain
+
+    :returns the new domain object
+
+    :raises InvalidValueError: raised when domain is None or an empty string or
+        is_top_domain does not have a boolean value
+    :raises NotFoundError: raised when the given organization is not found
+        in the registry
+    :raises AlreadyExistsError: raised when the domain already exists
+        in the registry
+    """
+
+    if organization is None:
+        raise InvalidValueError(msg="'org_name' cannot be None")
+    if organization == '':
+        raise InvalidValueError(msg="'org_name' cannot be an empty string")
+    if domain_name is None:
+        raise InvalidValueError(msg="'domain_name' cannot be None")
+    if domain_name == '':
+        raise InvalidValueError(msg="'domain_name' cannot be an empty string")
+
+    try:
+        organization = find_organization(organization)
+    except ValueError as e:
+        raise InvalidValueError(msg=str(e))
+    except NotFoundError as exc:
+        raise exc
+
+    try:
+        domain = add_domain_db(organization=organization,
+                               domain_name=domain_name,
+                               is_top_domain=is_top_domain)
+    except ValueError as e:
+        raise InvalidValueError(msg=str(e))
+    except AlreadyExistsError as exc:
+        raise exc
+
+    return domain
+
+
+@django.db.transaction.atomic
 def delete_organization(name):
     """Remove an organization from the registry.
 
@@ -382,6 +444,38 @@ def delete_organization(name):
     delete_organization_db(organization=org)
 
     return org
+
+
+@django.db.transaction.atomic
+def delete_domain(domain_name):
+    """Remove a domain from the registry.
+
+    This function removes the given domain from the registry.
+    Domain must exist in the registry. Otherwise, it will raise
+    a `NotFoundError` exception.
+
+    :param domain_name: name of the domain to remove
+
+    :returns the removed domain object
+
+    :raises NotFoundError: raised when the domain
+        does not exist in the registry.
+    """
+    if domain_name is None:
+        raise InvalidValueError(msg="'domain_name' cannot be None")
+    if domain_name == '':
+        raise InvalidValueError(msg="'domain_name' cannot be an empty string")
+
+    try:
+        domain = find_domain(domain_name)
+    except ValueError as e:
+        raise InvalidValueError(msg=str(e))
+    except NotFoundError as exc:
+        raise exc
+
+    delete_domain_db(domain)
+
+    return domain
 
 
 @django.db.transaction.atomic

--- a/sortinghat/core/api.py
+++ b/sortinghat/core/api.py
@@ -384,7 +384,6 @@ def add_domain(organization, domain_name, is_top_domain=True):
     :raises AlreadyExistsError: raised when the domain already exists
         in the registry
     """
-
     if organization is None:
         raise InvalidValueError(msg="'org_name' cannot be None")
     if organization == '':

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -108,6 +108,30 @@ def find_organization(name):
         return organization
 
 
+def find_domain(domain_name):
+    """Find a domain.
+
+    Find a domain by its name in the database. When the
+    domain does not exist the function will raise
+    a `NotFoundError`.
+
+    :param domain_name: name of the domain to find
+
+    :returns: a domain object
+
+    :raises NotFoundError: when the domain with the
+        given `name` does not exists.
+    """
+    validate_field('domain_name', domain_name)
+
+    try:
+        domain = Domain.objects.get(domain=domain_name)
+    except Domain.DoesNotExist:
+        raise NotFoundError(entity=domain_name)
+    else:
+        return domain
+
+
 def search_enrollments_in_period(uuid, org_name,
                                  from_date=MIN_PERIOD_DATE,
                                  to_date=MIN_PERIOD_DATE):

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -30,11 +30,11 @@ from .api import (add_identity,
                   move_identity,
                   merge_identities,
                   add_organization,
+                  add_domain,
                   delete_organization,
+                  delete_domain,
                   enroll,
                   withdraw)
-from .db import (add_domain,
-                 delete_domain)
 from .models import (Organization,
                      Domain,
                      Country,
@@ -129,8 +129,7 @@ class AddDomain(graphene.Mutation):
     domain = graphene.Field(lambda: DomainType)
 
     def mutate(self, info, organization, domain, is_top_domain=False):
-        org = Organization.objects.get(name=organization)
-        dom = add_domain(org, domain, is_top_domain=is_top_domain)
+        dom = add_domain(organization, domain, is_top_domain=is_top_domain)
 
         return AddDomain(
             domain=dom
@@ -144,8 +143,7 @@ class DeleteDomain(graphene.Mutation):
     domain = graphene.Field(lambda: DomainType)
 
     def mutate(self, info, domain):
-        dom = Domain.objects.get(domain=domain)
-        delete_domain(dom)
+        dom = delete_domain(domain)
 
         return DeleteDomain(
             domain=dom

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -59,6 +59,7 @@ FROM_UUID_TO_UUID_EQUAL_ERROR = "'from_uuid' and 'to_uuid' cannot be equal"
 UUID_EMPTY_ERROR = "'uuid' cannot be an empty string"
 ORG_DOES_NOT_EXIST_ERROR = "Organization matching query does not exist."
 DOMAIN_DOES_NOT_EXIST_ERROR = "Domain matching query does not exist."
+DOMAIN_NOT_FOUND_ERROR = "example.net not found in the registry"
 UID_DOES_NOT_EXIST_ERROR = "FFFFFFFFFFFFFFF not found in the registry"
 ORGANIZATION_BITERGIA_DOES_NOT_EXIST_ERROR = "Bitergia not found in the registry"
 ORGANIZATION_EXAMPLE_DOES_NOT_EXIST_ERROR = "Example not found in the registry"
@@ -720,7 +721,7 @@ class TestAddDomainMutation(django.test.TestCase):
 
         # Check error
         msg = executed['errors'][0]['message']
-        self.assertEqual(msg, ORG_DOES_NOT_EXIST_ERROR)
+        self.assertEqual(msg, ORGANIZATION_EXAMPLE_DOES_NOT_EXIST_ERROR)
 
 
 class TestDeleteDomainMutation(django.test.TestCase):
@@ -767,14 +768,14 @@ class TestDeleteDomainMutation(django.test.TestCase):
 
         # Check error
         msg = executed['errors'][0]['message']
-        self.assertEqual(msg, DOMAIN_DOES_NOT_EXIST_ERROR)
+        self.assertEqual(msg, DOMAIN_NOT_FOUND_ERROR)
 
         # It should not remove anything
         org = Organization.objects.create(name='Bitergia')
         Domain.objects.create(domain='example.com', organization=org)
 
         msg = executed['errors'][0]['message']
-        self.assertEqual(msg, DOMAIN_DOES_NOT_EXIST_ERROR)
+        self.assertEqual(msg, DOMAIN_NOT_FOUND_ERROR)
 
         domains = Domain.objects.all()
         self.assertEqual(len(domains), 1)


### PR DESCRIPTION
* Following the logic from other similar methods, there is a new method in `db.py` named `find_domain`, to obtain a domain object from the database using the domain name as a search term.
* New API methods: `add_domain` and `delete_domain`.
* `addDomain` and `deleteDomain` mutations now use these new API methods instead of the DB methods used directly.


