### PR TITLE
[db] Do not log 'add_profile' operation when adding an identity

### DIFF
--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -337,10 +337,6 @@ def add_unique_identity(trxl, uuid):
     except django.db.utils.IntegrityError as exc:
         _handle_integrity_error(Profile, exc)
 
-    trxl.log_operation(op_type=Operation.OpType.ADD, entity_type='profile',
-                       timestamp=datetime_utcnow(), args=op_args,
-                       target=op_args['uuid'])
-
     uidentity.refresh_from_db()
 
     return uidentity

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -572,7 +572,7 @@ class TestAddIdentity(TestCase):
         trx = transactions[0]
 
         operations = Operation.objects.filter(trx=trx)
-        self.assertEqual(len(operations), 3)
+        self.assertEqual(len(operations), 2)
 
         op1 = operations[0]
         self.assertIsInstance(op1, Operation)
@@ -589,31 +589,19 @@ class TestAddIdentity(TestCase):
         op2 = operations[1]
         self.assertIsInstance(op2, Operation)
         self.assertEqual(op2.op_type, Operation.OpType.ADD.value)
-        self.assertEqual(op2.entity_type, 'profile')
-        self.assertEqual(op2.target, identity.uidentity.uuid)
+        self.assertEqual(op2.entity_type, 'identity')
+        self.assertEqual(op2.target, identity.id)
         self.assertEqual(op2.trx, trx)
         self.assertGreater(op2.timestamp, timestamp)
 
         op2_args = json.loads(op2.args)
-        self.assertEqual(len(op2_args), 1)
-        self.assertEqual(op2_args['uuid'], identity.uidentity.uuid)
-
-        op3 = operations[2]
-        self.assertIsInstance(op3, Operation)
-        self.assertEqual(op3.op_type, Operation.OpType.ADD.value)
-        self.assertEqual(op3.entity_type, 'identity')
-        self.assertEqual(op3.target, identity.id)
-        self.assertEqual(op3.trx, trx)
-        self.assertGreater(op3.timestamp, timestamp)
-
-        op3_args = json.loads(op3.args)
-        self.assertEqual(len(op3_args), 6)
-        self.assertEqual(op3_args['uidentity'], identity.uidentity.uuid)
-        self.assertEqual(op3_args['identity_id'], identity.id)
-        self.assertEqual(op3_args['source'], identity.source)
-        self.assertEqual(op3_args['name'], identity.name)
-        self.assertEqual(op3_args['email'], identity.email)
-        self.assertEqual(op3_args['username'], identity.username)
+        self.assertEqual(len(op2_args), 6)
+        self.assertEqual(op2_args['uidentity'], identity.uidentity.uuid)
+        self.assertEqual(op2_args['identity_id'], identity.id)
+        self.assertEqual(op2_args['source'], identity.source)
+        self.assertEqual(op2_args['name'], identity.name)
+        self.assertEqual(op2_args['email'], identity.email)
+        self.assertEqual(op2_args['username'], identity.username)
 
 
 class TestDeleteIdentity(TestCase):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -837,7 +837,7 @@ class TestAddUniqueIdentity(TestCase):
         trx = transactions[0]
 
         operations = Operation.objects.filter(trx=trx)
-        self.assertEqual(len(operations), 2)
+        self.assertEqual(len(operations), 1)
 
         op1 = operations[0]
         self.assertIsInstance(op1, Operation)
@@ -850,18 +850,6 @@ class TestAddUniqueIdentity(TestCase):
         op1_args = json.loads(op1.args)
         self.assertEqual(len(op1_args), 1)
         self.assertEqual(op1_args['uuid'], uidentity.uuid)
-
-        op2 = operations[1]
-        self.assertIsInstance(op2, Operation)
-        self.assertEqual(op2.op_type, Operation.OpType.ADD.value)
-        self.assertEqual(op2.entity_type, 'profile')
-        self.assertEqual(op2.trx, trx)
-        self.assertEqual(op2.target, '1234567890ABCDFE')
-        self.assertGreater(op2.timestamp, timestamp)
-
-        op2_args = json.loads(op2.args)
-        self.assertEqual(len(op2_args), 1)
-        self.assertEqual(op2_args['uuid'], uidentity.uuid)
 
 
 class TestDeleteUniqueIdentity(TestCase):


### PR DESCRIPTION
This operation should not be logged as there is no dedicated method in `db.py` for adding a profile, but only for updating it.

Both `test_db.py` and `test_api.py` have been updated with this change.