### PR TITLE
[schema] Add queries for exporting transactions and operations

### DIFF
--- a/sortinghat/core/models.py
+++ b/sortinghat/core/models.py
@@ -116,7 +116,8 @@ class Operation(Model):
     op_type = CharField(max_length=MAX_SIZE_CHAR_FIELD, choices=OpType.choices())
     entity_type = CharField(max_length=MAX_SIZE_CHAR_FIELD)
     target = CharField(max_length=MAX_SIZE_CHAR_FIELD)
-    trx = ForeignKey(Transaction, null=True, on_delete=CASCADE, db_column='tuid')
+    trx = ForeignKey(Transaction, related_name='operations',
+                     on_delete=CASCADE, db_column='tuid')
     timestamp = DateTimeField()
     args = JSONField()
 


### PR DESCRIPTION
These new queries allow to export the list of transactions and operations from the database with the following format:

```
query {
    transactions {
        name
        createdAt
        tuid
        isClosed
        closedAt
    }
}
```

```
query {
    operations {
        ouid
        opType
        entityType
        target
        timestamp
        args
        trx {
            name
            createdAt
        }
    }
}
```

Both queries support filtering for most of the fields from their corresponding models, including `from_date` and `to_date` filters for both models (referencing to `created_at` field for transactions and `timestamp` for operations). This date can be passed as filter as a string following ISO 8601 format.

As the `args` field from `Operations` model is encoded in a serialized JSON, it was necessary to define a explicit conversion to return these encoded JSON fields as dictionaries. The class in charge of this process is named `OperationArgsType` and it inherits from `GenericScalar` class, which is a basic type defined in `graphene` module representing a generic GraphQL scalar value that could be String, Boolean, Int, Float, List or Object.

In `models.py`, `Operations` model has been modified:
* The parameter `related_name` in `trx` field allows to reference the related operations logged under a given transaction.
* The `null` value was set to `True` and now it has been removed, as the `trx` field from `Operations` model cannot be unset.

For future reference, here are some example queries including filtering:

* Get all the `DELETE` operations for unique identities from a given date:

```
query {
  operations( 
    filters:{
      opType:"DELETE",
      entityType:"unique_identity",
      fromDate:"2019-11-11T15:01:32.152416+00:00"
    }
  ){
    ouid
    opType
    entityType
    target
    timestamp
    args
    trx{
      name
      createdAt
    }
  }
}
```

* Get the list of transactions up to a given date, including their related operations:

```
query {
  transactions (
    filters: {
      toDate: "2019-11-18T13:01:32.152416+00:00"
    }
  ){
    tuid
    name
    createdAt
    operations {
      opType
      entityType
      ouid
      target
      args
    }
  }
}
```