### PR TITLE
[tests] Remove hard-coded DB params

### DIFF
--- a/tests/test_cmd_init.py
+++ b/tests/test_cmd_init.py
@@ -89,11 +89,13 @@ class TestInitCommand(TestInitCaseBase):
     def test_connection_error(self):
         """Check connection errors"""
 
-        kwargs = {'user': 'nouser',
-                  'password': 'nopassword',
-                  'database': None,
-                  'host': 'localhost',
-                  'port': '3306'}
+        kwargs = {
+            'user': 'nouser',
+            'password': 'nopassword',
+            'database': None,
+            'host': self.kwargs['host'],
+            'port': self.kwargs['port']
+        }
 
         cmd = Init(**kwargs)
         code = cmd.run(self.name)
@@ -149,12 +151,14 @@ class TestInitialize(TestInitCaseBase):
     def test_connection_error(self):
         """Check connection errors"""
 
-        kwargs = {'user': 'nouser',
-                  'password': 'nopassword',
-                  'database': None,
-                  'host': 'localhost',
-                  'port': '3306',
-                  'reuse': False}
+        kwargs = {
+            'user': 'nouser',
+            'password': 'nopassword',
+            'database': None,
+            'host': self.kwargs['host'],
+            'port': self.kwargs['port'],
+            'reuse': False
+        }
 
         cmd = Init(**kwargs)
         code = cmd.initialize(self.name)


### PR DESCRIPTION
This code addresses #226, thus it fixes the tests `test_connection_error` in the classes `TestInitialize` and `TestInitCommand` by replacing the hard-coded params `host` and `port` with the ones defined in the tests.conf file.