### PR TITLE
[matching-email] Support blacklist when strict matching is False

### DIFF
--- a/sortinghat/matching/email.py
+++ b/sortinghat/matching/email.py
@@ -130,7 +130,7 @@ class EmailMatcher(IdentityMatcher):
         if fa.uuid and fb.uuid and fa.uuid == fb.uuid:
             return True
 
-        if fa.email in self.blacklist:
+        if self._check_blacklist(fa):
             return False
 
         # Compare email addresses first
@@ -160,6 +160,9 @@ class EmailMatcher(IdentityMatcher):
             if self.sources and id_.source.lower() not in self.sources:
                 continue
 
+            if self._check_blacklist(id_):
+                continue
+
             if self.strict:
                 if self._check_email(id_.email):
                     email = id_.email.lower()
@@ -180,13 +183,23 @@ class EmailMatcher(IdentityMatcher):
         """
         return ['email']
 
+    # not used
     def _filter_emails(self, ids):
         return [id_.email.lower() for id_ in ids
                 if self._check_email(id_.email)]
 
+    def _check_blacklist(self, id_):
+        if not id_.email:
+            return False
+
+        blacklisted = id_.email.lower() in self.blacklist
+
+        return blacklisted
+
     def _check_email(self, email):
         if not email:
             return False
-        elif email.lower() in self.blacklist:
-            return False
-        return self.email_pattern.match(email) is not None
+
+        checked = self.email_pattern.match(email) is not None
+
+        return checked

--- a/sortinghat/matching/email.py
+++ b/sortinghat/matching/email.py
@@ -183,11 +183,6 @@ class EmailMatcher(IdentityMatcher):
         """
         return ['email']
 
-    # not used
-    def _filter_emails(self, ids):
-        return [id_.email.lower() for id_ in ids
-                if self._check_email(id_.email)]
-
     def _check_blacklist(self, id_):
         if not id_.email:
             return False


### PR DESCRIPTION
This code addresses https://github.com/chaoss/grimoirelab-sortinghat/issues/228, thus refactors the code to support the blacklisting of emails when the strict mode is set to `False`. The method `_check_blacklist` is created and the method `check_email` is modified accordingly (by removing the logic that blacklists emails).

Tests have been added accordingly.

Furthermore this PR removes the method `_filter_emails` which isn't used either in sortinghat or in other grimoirelab components.