### PR TITLE
[schema] Add support for authenticated queries

### DIFF
--- a/config/schema.py
+++ b/config/schema.py
@@ -17,8 +17,10 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
 #
 
+import logging
 import graphene
 
 import sortinghat.core.schema
@@ -29,6 +31,8 @@ class Query(sortinghat.core.schema.SortingHatQuery, graphene.ObjectType):
     # as we begin to add more apps to our project
     pass
 
+
+logging.getLogger("graphql.execution.utils").setLevel(logging.CRITICAL)
 
 schema = graphene.Schema(query=Query,
                          mutation=sortinghat.core.schema.SortingHatMutation)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mysqlclient==1.3.13
 python-dateutil>=2.8.0
 graphene-django>=2.0
 django-mysql>=3.2.0
+django-graphql-jwt>=0.3.0

--- a/sortinghat/core/decorators.py
+++ b/sortinghat/core/decorators.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+from django.conf import settings
+from graphql_jwt.decorators import user_passes_test
+
+
+# This custom decorator takes the `user` object from the request's
+# context and checks the value of the `is_authenticated` variable
+# and the `AUTHENTICATION_REQUIRED` variable from the config settings.
+check_auth = user_passes_test(
+    lambda u: u.is_authenticated or not settings.AUTHENTICATION_REQUIRED
+)


### PR DESCRIPTION
This PR is related with issue #233.

## Summary

These changes add support for performing authenticated queries (both GraphQL queries and mutations), based on JSON Web Tokens (JWT).

To perform an authenticated query, an existing user must generate a token which has to be included in the `Authorization` header with the HTTP request. This token is generated using a mutation which comes defined by the `graphene-jwt` module, together with other extra mutations for verifying an existing token and refreshing it in case the token expired.

By default, all the queries and mutations now require authentication. This is controlled by a decorator named `check_auth` which comes from a pre-defined decorator named `login_required` and extending it to check both if the `user` from the `context.info` Django object is authenticated and the value of a new control variable named `AUTHENTICATION_REQUIRED` defined in Django settings allowing to set whether authentication is required or not.

If the user is not logged or uses an invalid token, the following exception is raised:

```
graphql.error.located_error.GraphQLLocatedError: You do not have permission to perform this action
```

Note that in Graphene-Django, all the exceptions raised which are caused by a GraphQL execution returns a result detailing the errors:

```
{
  "errors": [
    {
      "message": "Organization 'Test' already exists in the registry",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "addOrganization"
      ]
    }
  ],
  "data": {
    "addOrganization": null
  }
}
```

However, even if the exception is properly captured, a Traceback is printed to `STDERR` where the `manage.py` server is executed:

```
Traceback (most recent call last):
  File "/home/mafesan/devel/venvs/sortinghat_muggle/lib/python3.6/site-packages/promise/promise.py", line 487, in _resolve_from_executor
    executor(resolve, reject)
  File "/home/mafesan/devel/venvs/sortinghat_muggle/lib/python3.6/site-packages/promise/promise.py", line 754, in executor
    return resolve(f(*args, **kwargs))
  File "/home/mafesan/devel/venvs/sortinghat_muggle/lib/python3.6/site-packages/graphql/execution/middleware.py", line 75, in make_it_promise
    return next(*args, **kwargs)
  File "/home/mafesan/devel/venvs/sortinghat_muggle/lib/python3.6/site-packages/graphql_jwt/decorators.py", line 30, in wrapper
    return func(info.context, *args, **kwargs)
  File "/home/mafesan/devel/venvs/sortinghat_muggle/lib/python3.6/site-packages/graphql_jwt/decorators.py", line 41, in wrapper
    return f(*args, **kwargs)
  File "/home/mafesan/devel/grimoirelab-sortinghat/sortinghat/core/schema.py", line 220, in mutate
    org = add_organization(name)
  File "/usr/lib/python3.6/contextlib.py", line 52, in inner
    return func(*args, **kwds)
  File "/home/mafesan/devel/grimoirelab-sortinghat/sortinghat/core/api.py", line 378, in add_organization
    raise exc
  File "/home/mafesan/devel/grimoirelab-sortinghat/sortinghat/core/api.py", line 374, in add_organization
    org = add_organization_db(trxl, name=name)
  File "/home/mafesan/devel/grimoirelab-sortinghat/sortinghat/core/db.py", line 191, in add_organization
    _handle_integrity_error(Organization, exc)
  File "/home/mafesan/devel/grimoirelab-sortinghat/sortinghat/core/db.py", line 693, in _handle_integrity_error
    raise AlreadyExistsError(entity=entity, eid=eid)
graphql.error.located_error.GraphQLLocatedError: Organization 'Test' already exists in the registry
```

After researching about this behavior, it seems it is a known issue. There are several workarounds proposed, but there is not an official solution for this problem yet:

* This user is describing the same behavior: https://github.com/graphql-python/graphene-django/issues/780.
* This other user opened an older issue (https://github.com/graphql-python/graphene-django/issues/735) where the
proposed work around is to avoid this Traceback to be displayed by disabling the logging object which is printing it.
* [This user from Stack Overflow](https://stackoverflow.com/a/52881442) proposes a similar workaround for this behavior, limiting the depth of the Traceback.

We decided to go for this workaround, as the Traceback is not displayed anymore but the query result
is still including the information from `results.errors`, including what caused the error or exception when executing the query (for instance, adding an existing organization, not having permissions for performing some action, etc.).

## Configuration

There is a new package dependency: `graphql_jwt` module:

```
pip install django-graphql-jwt
```

In the Django settings script, it is necessary to include the following lines: 

```

AUTHENTICATION_BACKENDS = [
    'graphql_jwt.backends.JSONWebTokenBackend',
    'django.contrib.auth.backends.ModelBackend',
]

GRAPHENE = {
    'SCHEMA': 'sortinghat.core.schema',
    'MIDDLEWARE': [
        'graphql_jwt.middleware.JSONWebTokenMiddleware',
    ],
}

AUTHENTICATION_REQUIRED = True

```

### Unit tests

Note: After these changes, the `AUTHENTICATION_REQUIRED` variable in the testing configuration script must be set to `True`.

## About how to test these changes

To test Authentication, it is recommended to use _Insomnia_ or other application capable of modifying HTTP headers and cookie settings. As the GraphQL requests are sent via POST, there is an additional procedure to follow to configure the CSRF token for Django. These are the steps to follow:

* Go to `Headers` tab and set a new header named `X-CSRFToken` and for the value select the option "`Request -> Cookie`".

![csrf1](https://user-images.githubusercontent.com/9032790/72609365-f75e9c00-3924-11ea-9f4e-c2f619db726c.png)


* Once the "`Request -> Cookie`" option becomes a tag, click on it to edit it and fill the "Cookie name" field with `csrftoken`.

![csrf2](https://user-images.githubusercontent.com/9032790/72610178-06464e00-3927-11ea-86c0-a96f4339ab93.png)

Now we are ready for testing Authentication. First, we need to create a new user using the Django Admin interface in case we don't have it already. Then, we will use these mutations coming by default with `graphql_jwt` module: `tokenAuth`, `verifyToken` and `refreshToken`.

* `tokenAuth`: With this mutation we generate the token we must include in the HTTP headers to perform the authenticated requests.

```
mutation {
  tokenAuth(username: "user_test", password: "123456A!") {
    token
  }
}
```

* Once we have obtained the token after executing the last mutation, we will have to set the `Authentication` header and paste the token as value, preceded by `JWT ` (see next image).

```
{
  "data": {
    "tokenAuth": {
      "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6Im1hZeHAiOjE1Ngz5MTAmVzYW4iLCJlzMzYsIm9yaWdJYXQiOjE1Nzg5MTAwMzZ9.wUf1P02aUfWqC-my7YwBOhM7awlk5KaoqAfTKNIx0mk"
    }
  }
}
```

![jwt](https://user-images.githubusercontent.com/9032790/72609393-0d6c5c80-3925-11ea-9bd7-e28c55cf75ca.png)


* We can use the `verifyToken` mutation to check if the token is valid:

```
mutation {
  verifyToken(token: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6Im1hZeHAiOjE1Ngz5MTAmVzYW4iLCJlzMzYsIm9yaWdJYXQiOjE1Nzg5MTAwMzZ9.wUf1P02aUfWqC-my7YwBOhM7awlk5KaoqAfTKNIx0mk") {
    payload
  }
}
```

* And the `refreshToken` mutation to obtain a new token:

```
mutation RefreshToken($token: String!) {
  refreshToken(token: $token) {
    token
    payload
  }
}
```

