### PR TITLE
[setup] Let pandas be >= 0.22.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(name="sortinghat",
         'sqlalchemy>=1.2',
         'jinja2',
         'python-dateutil>=2.6.0',
-        'pandas==0.22.0',
+        'pandas>=0.22.0,<=0.25.3',
         'pyyaml>=3.12',
         'requests>=2.9',
         'urllib3>=1.22'


### PR DESCRIPTION
If we pin pandas at 0.22.0, it doesn't build with Python 3.7.x, apparently because of problems when building numpy for pandas.

Letting pandas be greater or equal than 0.22.0 doesn't seem to break anything, since platforms having only 0.22.0, as Travis had in July'19 (see #206), would still fulfill the dependency.


Signed-off-by: Jesus M. Gonzalez-Barahona <jgb@gsyc.es>