### PR TITLE
[muggle] Add support for merging multiple identities at once

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -354,15 +354,15 @@ class MoveIdentity(graphene.Mutation):
 
 class MergeIdentities(graphene.Mutation):
     class Arguments:
-        from_uuid = graphene.String()
+        from_uuids = graphene.List(graphene.String)
         to_uuid = graphene.String()
 
     uuid = graphene.Field(lambda: graphene.String)
     uidentity = graphene.Field(lambda: UniqueIdentityType)
 
     @check_auth
-    def mutate(self, info, from_uuid, to_uuid):
-        uidentity = merge_identities(from_uuid, to_uuid)
+    def mutate(self, info, from_uuids, to_uuid):
+        uidentity = merge_identities(from_uuids, to_uuid)
 
         return MergeIdentities(
             uuid=uidentity.uuid,


### PR DESCRIPTION
The `merge_identities` mutation has been modified to accept a list of unique identities in the `from_uuid` field (now renamed to `from_uuids`). 

The API method for merging identities has been adapted to support this list as an input. New sub-methods have been included, iterating over the set of unique identities to merge.

Note: This PR is related to issue #236 .