### PR TITLE
[db-model] Remove CoerceToBool type

### DIFF
--- a/sortinghat/db/model.py
+++ b/sortinghat/db/model.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import backref, relationship
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.orderinglist import ordering_list
-from sqlalchemy.types import TypeDecorator, Boolean
+from sqlalchemy.types import Boolean
 
 # Default dates for periods
 MIN_PERIOD_DATE = datetime.datetime(1900, 1, 1, 0, 0, 0)
@@ -48,21 +48,6 @@ MAX_SIZE_CHAR_COLUMN = 191
 
 logger = logging.getLogger(__name__)
 ModelBase = declarative_base()
-
-
-class CoerceToBool(TypeDecorator):
-    impl = Boolean
-
-    def process_bind_param(self, value, dialect):
-        if type(value) == bool:
-            value = [False, True].index(value)
-        elif type(value) == int:
-            if value not in [0, 1]:
-                raise ValueError
-        else:
-            raise ValueError
-
-        return value
 
 
 class Organization(ModelBase):
@@ -95,7 +80,7 @@ class Domain(ModelBase):
 
     id = Column(Integer, primary_key=True)
     domain = Column(String(128), nullable=False)
-    is_top_domain = Column(CoerceToBool(name='top_domain_check'), default=False)
+    is_top_domain = Column(Boolean(name='top_domain_check'), default=False)
     organization_id = Column(Integer,
                              ForeignKey('organizations.id', ondelete='CASCADE',
                                         onupdate='CASCADE'),
@@ -219,7 +204,7 @@ class Profile(ModelBase):
     email = Column(String(128))
     gender = Column(String(32))
     gender_acc = Column(Integer())
-    is_bot = Column(CoerceToBool(name='is_bot_check'), default=False)
+    is_bot = Column(Boolean(name='is_bot_check'), default=False)
     country_code = Column(String(2),
                           ForeignKey('countries.code', ondelete='CASCADE'))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -397,7 +397,7 @@ class TestIdentity(TestCaseBase):
         """Check whether every identity has a source"""
 
         with self.assertRaisesRegex(IntegrityError, NULL_CHECK_ERROR):
-            id1 = Identity()
+            id1 = Identity(id='A')
             self.session.add(id1)
             self.session.commit()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -40,7 +40,7 @@ from tests.base import Database, CONFIG_FILE
 
 DUP_CHECK_ERROR = 'Duplicate entry'
 NULL_CHECK_ERROR = 'cannot be null'
-INVALID_DATATYPE_ERROR = 'ValueError'
+INVALID_DATATYPE_ERROR = 'TypeError'
 
 
 class MockDatabase(object):
@@ -219,7 +219,7 @@ class TestDomain(TestCaseBase):
             self.session.commit()
 
     def test_is_top_domain_invalid_type(self):
-        """Check invalid values on top_domain bool collumn"""
+        """Check invalid values on top_domain bool column"""
 
         with self.assertRaisesRegex(StatementError, INVALID_DATATYPE_ERROR):
             org1 = Organization(name='Example')


### PR DESCRIPTION
This code fixes the bug #121, thus it removes the type CoerceToBool (introduced at 5f69ed8), which was used to handle string representations of boolean values (i.e., True and False) for SqlAlchemy versions prior to 1.1.14. This was due to the fact that SqlAlchemy versions 1.1.x defined the Boolean type as follows:
```
Boolean typically uses BOOLEAN or SMALLINT on the DDL side,
and on the Python side deals in True or False.
```

Thus, equivalent string representations weren't handled and required the definition of the CoerceToBool (which created an additional CHECK constraint).

From versions greater than >=1.2.0 (already set in the current setup.py),
the CoerceToBool isn't needed anymore and can be removed. In particular, the
Boolean type is now defined as:
```
The Boolean datatype currently has two levels of assertion that the values
persisted are simple true/false values. For all backends, only the Python
values None, True, False, 1 or 0 are accepted as parameter values. For those
backends that don’t support a “native boolean” datatype, a CHECK constraint
is also created on the target column. Production of the CHECK constraint
can be disabled by passing the Boolean.create_constraint flag set to False
```

Tests have been updated accordingly.