### PR TITLE
First implementation of a basic client

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,11 @@
 Django==2.1
-grimoirelab_toolkit>=0.1.8
-mysqlclient==1.3.13
-python-dateutil>=2.8.0
-graphene-django>=2.0
 django-mysql>=3.2.0
 django-graphql-jwt>=0.3.0
+graphene-django>=2.0
+sgqlc>=10.1
+mysqlclient==1.3.13
+python-dateutil>=2.8.0
+grimoirelab_toolkit>=0.1.8
+requests>=2.7.0
+uri>=2.0.1
+httpretty==0.9.7

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,5 @@ setup(name="sortinghat",
         'pandoc'],
       install_requires=[
       ],
-      cmdclass=cmdclass,
       zip_safe=False
       )

--- a/sortinghat/cli/client/__init__.py
+++ b/sortinghat/cli/client/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+from .client import (SortingHatClient,
+                     SortingHatClientError)
+from .schema import sh_schema as SortingHatSchema
+
+
+__all__ = [
+    SortingHatClient,
+    SortingHatClientError,
+    SortingHatSchema,
+]

--- a/sortinghat/cli/client/client.py
+++ b/sortinghat/cli/client/client.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import requests
+import uri
+
+from sgqlc.endpoint.http import HTTPEndpoint
+from sgqlc.operation import Operation
+
+from .schema import sh_schema
+
+
+class SortingHatClientError(Exception):
+    """SortingHat client error.
+
+    Generic exception raised by the client when an error is found
+    either with connection problems or with GraphQL queries.
+
+    :param msg: message error
+    :param errors: list of GraphQL errors; `None` when the error is
+        not related to GraphQL queries
+    """
+    def __init__(self, msg, errors=None):
+        self.msg = msg
+        self.errors = errors
+
+    def __str__(self):
+        return self.msg
+
+
+class SortingHatClient:
+    """SortingHat client.
+
+    This client allows to run operations in the SortingHat server
+    that listens in `host` and `port`.
+
+    After initializing an instance, call to `connect` to establish
+    a communication with the server. The method `execute` allows to
+    run queries and mutations defined by the server.
+
+    :param host: host of the server
+    :param port: port number used in the connection
+    :param path: path to the API endpoint; by default the endpoint is in '/'
+    :param user: user name to use when authentication is required
+    :param password: password to use when authentication is required
+    :param ssl: use SSL/TSL connection; this is the default behaviour
+
+    :raises ValueError: when any of the given parameters is invalid
+    """
+    def __init__(self, host, port=9314, path=None, user=None, password=None, ssl=True):
+        self.gqlc = None
+        self.host = host
+        self.port = port
+
+        if not path:
+            self.path = '/'
+        elif not path.startswith('/'):
+            self.path = '/' + path
+        else:
+            self.path = path
+
+        self.user = user
+        self.password = password
+
+        try:
+            scheme = 'https' if ssl else 'http'
+            self.url = uri.URI(scheme=scheme,
+                               host=self.host, port=self.port,
+                               path=self.path)
+        except (ValueError, TypeError) as exc:
+            msg = "Invalid URL parameters; cause: {}".format(exc)
+            raise ValueError(msg)
+
+    def connect(self):
+        """Establish a connection to the server."""
+
+        try:
+            result = requests.get(self.url, headers={'Accept': 'text/html'})
+            result.raise_for_status()
+        except requests.exceptions.RequestException as exc:
+            msg = "Connection error; cause: {}".format(exc)
+            raise SortingHatClientError(msg)
+
+        headers = {
+            'X-CSRFToken': result.cookies['csrftoken'],
+            'Cookie': 'csrftoken=' + result.cookies['csrftoken']
+        }
+
+        self.gqlc = HTTPEndpoint(self.url, headers)
+
+        if self.user and self.password:
+            op = Operation(sh_schema.SortingHatMutation)
+            op.token_auth(username=self.user, password=self.password).token()
+
+            result = self.gqlc(op)
+
+            if 'errors' in result:
+                cause = result['errors'][0]['message']
+                msg = "Authentication error; cause: {}".format(cause)
+                raise SortingHatClientError(msg)
+
+            headers['Authorization'] = result['data']['tokenAuth']['token']
+
+    def disconnect(self):
+        """Disconnect the client from the server."""
+
+        self.gqlc = None
+
+    def execute(self, operation):
+        """Execute operations in the server.
+
+        This method allows to run GraphQL operations: queries and mutations.
+        To run an operation, use `sgqlc.operation.Operation` object and a
+        valid SortingHat schema.
+
+        :param operation: GraphQL operation to execute
+
+        :returns: a dict that maps the JSON result returned by the server
+
+        :raises SortingHatClient: raised when either the client is not connected
+            or when an error is returned while running the operation
+        """
+        if not self.gqlc:
+            msg = "Client not connected with {}; call connect() before executing any operation"
+            raise SortingHatClientError(msg.format(self.url))
+
+        result = self.gqlc(operation)
+
+        if 'errors' in result:
+            msg = "GraphQL operation error; {} errors found".format(len(result['errors']))
+            raise SortingHatClientError(msg, errors=result['errors'])
+
+        return result

--- a/sortinghat/cli/client/schema.py
+++ b/sortinghat/cli/client/schema.py
@@ -1,0 +1,539 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+"""
+SortingHat client schema.
+
+Automatically generated using sgqlc tools.
+"""
+
+import sgqlc.types
+import sgqlc.types.datetime
+
+
+sh_schema = sgqlc.types.Schema()
+
+
+########################################################################
+# Scalars and Enumerations
+########################################################################
+Boolean = sgqlc.types.Boolean
+
+DateTime = sgqlc.types.datetime.DateTime
+
+
+class GenericScalar(sgqlc.types.Scalar):
+    __schema__ = sh_schema
+
+
+ID = sgqlc.types.ID
+
+Int = sgqlc.types.Int
+
+
+class OperationArgsType(sgqlc.types.Scalar):
+    __schema__ = sh_schema
+
+
+class OperationOpType(sgqlc.types.Enum):
+    __schema__ = sh_schema
+    __choices__ = ('ADD', 'DELETE', 'UPDATE')
+
+
+String = sgqlc.types.String
+
+
+########################################################################
+# Input Objects
+########################################################################
+
+class IdentityFilterType(sgqlc.types.Input):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'is_locked')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    is_locked = sgqlc.types.Field(Boolean, graphql_name='isLocked')
+
+
+class OperationFilterType(sgqlc.types.Input):
+    __schema__ = sh_schema
+    __field_names__ = ('ouid', 'op_type', 'entity_type', 'target', 'from_date', 'to_date')
+    ouid = sgqlc.types.Field(String, graphql_name='ouid')
+    op_type = sgqlc.types.Field(String, graphql_name='opType')
+    entity_type = sgqlc.types.Field(String, graphql_name='entityType')
+    target = sgqlc.types.Field(String, graphql_name='target')
+    from_date = sgqlc.types.Field(DateTime, graphql_name='fromDate')
+    to_date = sgqlc.types.Field(DateTime, graphql_name='toDate')
+
+
+class OrganizationFilterType(sgqlc.types.Input):
+    __schema__ = sh_schema
+    __field_names__ = ('name',)
+    name = sgqlc.types.Field(String, graphql_name='name')
+
+
+class ProfileInputType(sgqlc.types.Input):
+    __schema__ = sh_schema
+    __field_names__ = ('name', 'email', 'gender', 'gender_acc', 'is_bot', 'country_code')
+    name = sgqlc.types.Field(String, graphql_name='name')
+    email = sgqlc.types.Field(String, graphql_name='email')
+    gender = sgqlc.types.Field(String, graphql_name='gender')
+    gender_acc = sgqlc.types.Field(Int, graphql_name='genderAcc')
+    is_bot = sgqlc.types.Field(Boolean, graphql_name='isBot')
+    country_code = sgqlc.types.Field(String, graphql_name='countryCode')
+
+
+class TransactionFilterType(sgqlc.types.Input):
+    __schema__ = sh_schema
+    __field_names__ = ('tuid', 'name', 'is_closed', 'from_date', 'to_date', 'authored_by')
+    tuid = sgqlc.types.Field(String, graphql_name='tuid')
+    name = sgqlc.types.Field(String, graphql_name='name')
+    is_closed = sgqlc.types.Field(Boolean, graphql_name='isClosed')
+    from_date = sgqlc.types.Field(DateTime, graphql_name='fromDate')
+    to_date = sgqlc.types.Field(DateTime, graphql_name='toDate')
+    authored_by = sgqlc.types.Field(String, graphql_name='authoredBy')
+
+
+########################################################################
+# Output Objects and Interfaces
+########################################################################
+
+class AddDomain(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('domain',)
+    domain = sgqlc.types.Field('DomainType', graphql_name='domain')
+
+
+class AddIdentity(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field('UniqueIdentityType', graphql_name='uidentity')
+
+
+class AddOrganization(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('organization',)
+    organization = sgqlc.types.Field('OrganizationType', graphql_name='organization')
+
+
+class CountryType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('created_at', 'last_modified', 'code', 'name', 'alpha3', 'profile_set')
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    last_modified = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='lastModified')
+    code = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='code')
+    name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
+    alpha3 = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='alpha3')
+    profile_set = sgqlc.types.Field(sgqlc.types.list_of('ProfileType'), graphql_name='profileSet')
+
+
+class DeleteDomain(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('domain',)
+    domain = sgqlc.types.Field('DomainType', graphql_name='domain')
+
+
+class DeleteIdentity(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field('UniqueIdentityType', graphql_name='uidentity')
+
+
+class DeleteOrganization(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('organization',)
+    organization = sgqlc.types.Field('OrganizationType', graphql_name='organization')
+
+
+class DomainType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('created_at', 'last_modified', 'id', 'domain', 'is_top_domain', 'organization')
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    last_modified = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='lastModified')
+    id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name='id')
+    domain = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='domain')
+    is_top_domain = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isTopDomain')
+    organization = sgqlc.types.Field(sgqlc.types.non_null('OrganizationType'), graphql_name='organization')
+
+
+class Enroll(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field('UniqueIdentityType', graphql_name='uidentity')
+
+
+class EnrollmentType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('created_at', 'last_modified', 'id', 'uidentity', 'organization', 'start', 'end')
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    last_modified = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='lastModified')
+    id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name='id')
+    uidentity = sgqlc.types.Field(sgqlc.types.non_null('UniqueIdentityType'), graphql_name='uidentity')
+    organization = sgqlc.types.Field(sgqlc.types.non_null('OrganizationType'), graphql_name='organization')
+    start = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='start')
+    end = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='end')
+
+
+class IdentityPaginatedType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('entities', 'page_info')
+    entities = sgqlc.types.Field(sgqlc.types.list_of('UniqueIdentityType'), graphql_name='entities')
+    page_info = sgqlc.types.Field('PaginationType', graphql_name='pageInfo')
+
+
+class IdentityType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('created_at', 'last_modified', 'id', 'name', 'email', 'username', 'source', 'uidentity')
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    last_modified = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='lastModified')
+    id = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='id')
+    name = sgqlc.types.Field(String, graphql_name='name')
+    email = sgqlc.types.Field(String, graphql_name='email')
+    username = sgqlc.types.Field(String, graphql_name='username')
+    source = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='source')
+    uidentity = sgqlc.types.Field(sgqlc.types.non_null('UniqueIdentityType'), graphql_name='uidentity')
+
+
+class LockIdentity(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field('UniqueIdentityType', graphql_name='uidentity')
+
+
+class MergeIdentities(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field('UniqueIdentityType', graphql_name='uidentity')
+
+
+class MoveIdentity(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field('UniqueIdentityType', graphql_name='uidentity')
+
+
+class ObtainJSONWebToken(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('token',)
+    token = sgqlc.types.Field(String, graphql_name='token')
+
+
+class OperationPaginatedType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('entities', 'page_info')
+    entities = sgqlc.types.Field(sgqlc.types.list_of('OperationType'), graphql_name='entities')
+    page_info = sgqlc.types.Field('PaginationType', graphql_name='pageInfo')
+
+
+class OperationType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('ouid', 'op_type', 'entity_type', 'target', 'trx', 'timestamp', 'args')
+    ouid = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='ouid')
+    op_type = sgqlc.types.Field(sgqlc.types.non_null(OperationOpType), graphql_name='opType')
+    entity_type = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='entityType')
+    target = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='target')
+    trx = sgqlc.types.Field(sgqlc.types.non_null('TransactionType'), graphql_name='trx')
+    timestamp = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='timestamp')
+    args = sgqlc.types.Field(sgqlc.types.non_null(OperationArgsType), graphql_name='args')
+
+
+class OrganizationPaginatedType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('entities', 'page_info')
+    entities = sgqlc.types.Field(sgqlc.types.list_of('OrganizationType'), graphql_name='entities')
+    page_info = sgqlc.types.Field('PaginationType', graphql_name='pageInfo')
+
+
+class OrganizationType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('id', 'created_at', 'last_modified', 'name', 'domains', 'enrollments')
+    id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name='id')
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    last_modified = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='lastModified')
+    name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
+    domains = sgqlc.types.Field(sgqlc.types.list_of(DomainType), graphql_name='domains')
+    enrollments = sgqlc.types.Field(sgqlc.types.list_of(EnrollmentType), graphql_name='enrollments')
+
+
+class PaginationType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = (
+        'page', 'page_size', 'num_pages', 'has_next', 'has_prev', 'start_index', 'end_index', 'total_results'
+    )
+    page = sgqlc.types.Field(Int, graphql_name='page')
+    page_size = sgqlc.types.Field(Int, graphql_name='pageSize')
+    num_pages = sgqlc.types.Field(Int, graphql_name='numPages')
+    has_next = sgqlc.types.Field(Boolean, graphql_name='hasNext')
+    has_prev = sgqlc.types.Field(Boolean, graphql_name='hasPrev')
+    start_index = sgqlc.types.Field(Int, graphql_name='startIndex')
+    end_index = sgqlc.types.Field(Int, graphql_name='endIndex')
+    total_results = sgqlc.types.Field(Int, graphql_name='totalResults')
+
+
+class ProfileType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = (
+        'created_at', 'last_modified', 'id', 'uidentity', 'name', 'email', 'gender', 'gender_acc', 'is_bot', 'country'
+    )
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    last_modified = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='lastModified')
+    id = sgqlc.types.Field(sgqlc.types.non_null(ID), graphql_name='id')
+    uidentity = sgqlc.types.Field(sgqlc.types.non_null('UniqueIdentityType'), graphql_name='uidentity')
+    name = sgqlc.types.Field(String, graphql_name='name')
+    email = sgqlc.types.Field(String, graphql_name='email')
+    gender = sgqlc.types.Field(String, graphql_name='gender')
+    gender_acc = sgqlc.types.Field(Int, graphql_name='genderAcc')
+    is_bot = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isBot')
+    country = sgqlc.types.Field(CountryType, graphql_name='country')
+
+
+class Query(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('organizations', 'uidentities', 'transactions', 'operations')
+    organizations = sgqlc.types.Field(
+        OrganizationPaginatedType, graphql_name='organizations', args=sgqlc.types.ArgDict((
+            ('page_size', sgqlc.types.Arg(Int, graphql_name='pageSize', default=None)),
+            ('page', sgqlc.types.Arg(Int, graphql_name='page', default=None)),
+            ('filters', sgqlc.types.Arg(OrganizationFilterType, graphql_name='filters', default=None)),
+        ))
+    )
+    uidentities = sgqlc.types.Field(
+        IdentityPaginatedType, graphql_name='uidentities', args=sgqlc.types.ArgDict((
+            ('page_size', sgqlc.types.Arg(Int, graphql_name='pageSize', default=None)),
+            ('page', sgqlc.types.Arg(Int, graphql_name='page', default=None)),
+            ('filters', sgqlc.types.Arg(IdentityFilterType, graphql_name='filters', default=None)),
+        ))
+    )
+    transactions = sgqlc.types.Field(
+        'TransactionPaginatedType', graphql_name='transactions', args=sgqlc.types.ArgDict((
+            ('page_size', sgqlc.types.Arg(Int, graphql_name='pageSize', default=None)),
+            ('page', sgqlc.types.Arg(Int, graphql_name='page', default=None)),
+            ('filters', sgqlc.types.Arg(TransactionFilterType, graphql_name='filters', default=None)),
+        ))
+    )
+    operations = sgqlc.types.Field(
+        OperationPaginatedType, graphql_name='operations', args=sgqlc.types.ArgDict((
+            ('page_size', sgqlc.types.Arg(Int, graphql_name='pageSize', default=None)),
+            ('page', sgqlc.types.Arg(Int, graphql_name='page', default=None)),
+            ('filters', sgqlc.types.Arg(OperationFilterType, graphql_name='filters', default=None)),
+        ))
+    )
+
+
+class Refresh(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('token', 'payload')
+    token = sgqlc.types.Field(String, graphql_name='token')
+    payload = sgqlc.types.Field(GenericScalar, graphql_name='payload')
+
+
+class SortingHatMutation(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = (
+        'add_organization', 'delete_organization', 'add_domain', 'delete_domain', 'add_identity',
+        'delete_identity', 'update_profile', 'move_identity', 'lock_identity', 'unlock_identity',
+        'merge_identities', 'unmerge_identities', 'enroll', 'withdraw',
+        'token_auth', 'verify_token', 'refresh_token'
+    )
+    add_organization = sgqlc.types.Field(
+        AddOrganization, graphql_name='addOrganization', args=sgqlc.types.ArgDict((
+            ('name', sgqlc.types.Arg(String, graphql_name='name', default=None)),
+        ))
+    )
+    delete_organization = sgqlc.types.Field(
+        DeleteOrganization, graphql_name='deleteOrganization', args=sgqlc.types.ArgDict((
+            ('name', sgqlc.types.Arg(String, graphql_name='name', default=None)),
+        ))
+    )
+    add_domain = sgqlc.types.Field(
+        AddDomain, graphql_name='addDomain', args=sgqlc.types.ArgDict((
+            ('domain', sgqlc.types.Arg(String, graphql_name='domain', default=None)),
+            ('is_top_domain', sgqlc.types.Arg(Boolean, graphql_name='isTopDomain', default=None)),
+            ('organization', sgqlc.types.Arg(String, graphql_name='organization', default=None)),
+        ))
+    )
+    delete_domain = sgqlc.types.Field(
+        DeleteDomain, graphql_name='deleteDomain', args=sgqlc.types.ArgDict((
+            ('domain', sgqlc.types.Arg(String, graphql_name='domain', default=None)),
+        ))
+    )
+    add_identity = sgqlc.types.Field(
+        AddIdentity, graphql_name='addIdentity', args=sgqlc.types.ArgDict((
+            ('email', sgqlc.types.Arg(String, graphql_name='email', default=None)),
+            ('name', sgqlc.types.Arg(String, graphql_name='name', default=None)),
+            ('source', sgqlc.types.Arg(String, graphql_name='source', default=None)),
+            ('username', sgqlc.types.Arg(String, graphql_name='username', default=None)),
+            ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
+        ))
+    )
+    delete_identity = sgqlc.types.Field(
+        DeleteIdentity, graphql_name='deleteIdentity', args=sgqlc.types.ArgDict((
+            ('unique_identity', sgqlc.types.Arg(Boolean, graphql_name='uniqueIdentity', default=None)),
+            ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
+        ))
+    )
+    update_profile = sgqlc.types.Field(
+        'UpdateProfile', graphql_name='updateProfile', args=sgqlc.types.ArgDict((
+            ('data', sgqlc.types.Arg(ProfileInputType, graphql_name='data', default=None)),
+            ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
+        ))
+    )
+    move_identity = sgqlc.types.Field(
+        MoveIdentity, graphql_name='moveIdentity', args=sgqlc.types.ArgDict((
+            ('from_id', sgqlc.types.Arg(String, graphql_name='fromId', default=None)),
+            ('to_uuid', sgqlc.types.Arg(String, graphql_name='toUuid', default=None)),
+        ))
+    )
+    lock_identity = sgqlc.types.Field(
+        LockIdentity, graphql_name='lockIdentity', args=sgqlc.types.ArgDict((
+            ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
+        ))
+    )
+    unlock_identity = sgqlc.types.Field(
+        'UnlockIdentity', graphql_name='unlockIdentity', args=sgqlc.types.ArgDict((
+            ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
+        ))
+    )
+    merge_identities = sgqlc.types.Field(
+        MergeIdentities, graphql_name='mergeIdentities', args=sgqlc.types.ArgDict((
+            ('from_uuids', sgqlc.types.Arg(sgqlc.types.list_of(String), graphql_name='fromUuids', default=None)),
+            ('to_uuid', sgqlc.types.Arg(String, graphql_name='toUuid', default=None)),
+        ))
+    )
+    unmerge_identities = sgqlc.types.Field(
+        'UnmergeIdentities', graphql_name='unmergeIdentities', args=sgqlc.types.ArgDict((
+            ('uuids', sgqlc.types.Arg(sgqlc.types.list_of(String), graphql_name='uuids', default=None)),
+        ))
+    )
+    enroll = sgqlc.types.Field(
+        Enroll, graphql_name='enroll', args=sgqlc.types.ArgDict((
+            ('from_date', sgqlc.types.Arg(DateTime, graphql_name='fromDate', default=None)),
+            ('organization', sgqlc.types.Arg(String, graphql_name='organization', default=None)),
+            ('to_date', sgqlc.types.Arg(DateTime, graphql_name='toDate', default=None)),
+            ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
+        ))
+    )
+    withdraw = sgqlc.types.Field(
+        'Withdraw', graphql_name='withdraw', args=sgqlc.types.ArgDict((
+            ('from_date', sgqlc.types.Arg(DateTime, graphql_name='fromDate', default=None)),
+            ('organization', sgqlc.types.Arg(String, graphql_name='organization', default=None)),
+            ('to_date', sgqlc.types.Arg(DateTime, graphql_name='toDate', default=None)),
+            ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
+        ))
+    )
+    token_auth = sgqlc.types.Field(
+        ObtainJSONWebToken, graphql_name='tokenAuth', args=sgqlc.types.ArgDict((
+            ('username', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='username', default=None)),
+            ('password', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='password', default=None)),
+        ))
+    )
+    verify_token = sgqlc.types.Field(
+        'Verify', graphql_name='verifyToken', args=sgqlc.types.ArgDict((
+            ('token', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='token', default=None)),
+        ))
+    )
+    refresh_token = sgqlc.types.Field(
+        Refresh, graphql_name='refreshToken', args=sgqlc.types.ArgDict((
+            ('token', sgqlc.types.Arg(sgqlc.types.non_null(String), graphql_name='token', default=None)),
+        ))
+    )
+
+
+class TransactionPaginatedType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('entities', 'page_info')
+    entities = sgqlc.types.Field(sgqlc.types.list_of('TransactionType'), graphql_name='entities')
+    page_info = sgqlc.types.Field(PaginationType, graphql_name='pageInfo')
+
+
+class TransactionType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('tuid', 'name', 'created_at', 'closed_at', 'is_closed', 'authored_by', 'operations')
+    tuid = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='tuid')
+    name = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='name')
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    closed_at = sgqlc.types.Field(DateTime, graphql_name='closedAt')
+    is_closed = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isClosed')
+    authored_by = sgqlc.types.Field(String, graphql_name='authoredBy')
+    operations = sgqlc.types.Field(sgqlc.types.list_of(OperationType), graphql_name='operations')
+
+
+class UniqueIdentityType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('created_at', 'last_modified', 'uuid', 'is_locked', 'identities', 'profile', 'enrollments')
+    created_at = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='createdAt')
+    last_modified = sgqlc.types.Field(sgqlc.types.non_null(DateTime), graphql_name='lastModified')
+    uuid = sgqlc.types.Field(sgqlc.types.non_null(String), graphql_name='uuid')
+    is_locked = sgqlc.types.Field(sgqlc.types.non_null(Boolean), graphql_name='isLocked')
+    identities = sgqlc.types.Field(sgqlc.types.list_of(IdentityType), graphql_name='identities')
+    profile = sgqlc.types.Field(ProfileType, graphql_name='profile')
+    enrollments = sgqlc.types.Field(sgqlc.types.list_of(EnrollmentType), graphql_name='enrollments')
+
+
+class UnlockIdentity(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field(UniqueIdentityType, graphql_name='uidentity')
+
+
+class UnmergeIdentities(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuids', 'uidentities')
+    uuids = sgqlc.types.Field(sgqlc.types.list_of(String), graphql_name='uuids')
+    uidentities = sgqlc.types.Field(sgqlc.types.list_of(UniqueIdentityType), graphql_name='uidentities')
+
+
+class UpdateProfile(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field(UniqueIdentityType, graphql_name='uidentity')
+
+
+class Verify(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('payload',)
+    payload = sgqlc.types.Field(GenericScalar, graphql_name='payload')
+
+
+class Withdraw(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('uuid', 'uidentity')
+    uuid = sgqlc.types.Field(String, graphql_name='uuid')
+    uidentity = sgqlc.types.Field(UniqueIdentityType, graphql_name='uidentity')
+
+
+########################################################################
+# Unions
+########################################################################
+
+########################################################################
+# Schema Entry Points
+########################################################################
+sh_schema.query_type = Query
+sh_schema.mutation_type = SortingHatMutation
+sh_schema.subscription_type = None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,294 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import logging
+import json
+import unittest
+
+import httpretty
+import sgqlc.endpoint.http
+
+from sgqlc.operation import Operation
+
+from sortinghat.cli.client import (SortingHatClient,
+                                   SortingHatClientError,
+                                   SortingHatSchema)
+
+
+# Some 'sgqlc' errors are shown because a bad configuration in
+# logging. This allows to ignore these errors while running
+# the tests.
+logging.disable(logging.CRITICAL)
+
+
+SORTINGHAT_SERVER_URL = "http://localhost:9314/"
+
+# Errors
+AUTHENTICATION_ERROR = r"Authentication error"
+CONNECTION_ERROR = r"Connection error"
+NOT_CONNECTED_CLIENT_ERROR = r"Client not connected with " + SORTINGHAT_SERVER_URL
+
+
+class MockSortingHatServer:
+    """Class to mock calls to a SortingHat server"""
+
+    # GraphQL queries
+    MUTATION_AUTH_TOKEN = """mutation {\ntokenAuth(username: "admin", password: "admin") {\ntoken\n}\n}"""
+    MUTATION_AUTH_TOKEN_INVALID = """mutation {\ntokenAuth(username: "admin", password: "1234") {\ntoken\n}\n}"""
+
+    def __init__(self, base_url, raise_error_on_get=False):
+        self.base_url = base_url
+        self.raise_error_on_get = raise_error_on_get
+
+        httpretty.enable()
+
+        httpretty.register_uri(httpretty.GET,
+                               self.base_url,
+                               responses=[
+                                   httpretty.Response(body=self.get_callback)
+                               ])
+        httpretty.register_uri(httpretty.POST,
+                               self.base_url,
+                               body=self.graphql_callback)
+
+    def get_callback(self, method, uri, headers):
+        if self.raise_error_on_get:
+            return [500, {}, "HTTP 500 Internal server error"]
+
+        response_headers = {
+            'Set-Cookie': 'csrftoken=ABCDEFGHIJK'
+        }
+        return [200, response_headers, "SortingHat server"]
+
+    def graphql_callback(self, request, uri, response_headers):
+        query = json.loads(request.body)['query']
+
+        if query == self.MUTATION_AUTH_TOKEN:
+            response = {'data': {'tokenAuth': {'token': '12345678'}}}
+            body = json.dumps(response)
+        elif query == self.MUTATION_AUTH_TOKEN_INVALID:
+            response = {
+                'errors': [
+                    {
+                        'message': "Invalid credentials.",
+                        'locations': [{'line': 1, 'column': 1}],
+                        'path': ['tokenAuth', 'token']
+                    }
+                ]
+            }
+            body = json.dumps(response)
+
+        return [200, response_headers, body]
+
+
+class TestSortingHatClient(unittest.TestCase):
+    """Unit tests for SortingHatClient class"""
+
+    def setUp(self):
+        self.server = MockSortingHatServer(SORTINGHAT_SERVER_URL)
+
+    def test_client_initialization(self):
+        """Test if a client instance is correctly initialized"""
+
+        # Check with default values
+        client = SortingHatClient('localhost')
+
+        self.assertEqual(client.url, "https://localhost:9314/")
+        self.assertEqual(client.user, None)
+        self.assertEqual(client.password, None)
+        self.assertEqual(client.gqlc, None)
+
+        # Check with defined parameters
+        client = SortingHatClient('localhost', port=1111, path='graphql',
+                                  user='admin', password='admin', ssl=False)
+        self.assertEqual(client.url, "http://localhost:1111/graphql/")
+        self.assertEqual(client.user, 'admin')
+        self.assertEqual(client.password, 'admin')
+
+        client = SortingHatClient('localhost', path='/graphql')
+        self.assertEqual(client.url, "https://localhost:9314/graphql/")
+
+    @httpretty.activate
+    def test_connect(self):
+        """Test whether the client establishes a connection with a SortingHat server"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL)
+
+        client = SortingHatClient('localhost', ssl=False)
+        client.connect()
+
+        self.assertIsInstance(client.gqlc, sgqlc.endpoint.http.HTTPEndpoint)
+
+        latest_requests = httpretty.latest_requests()
+        self.assertEqual(len(latest_requests), 1)
+
+        request = latest_requests[0]
+        self.assertEqual(request.method, 'GET')
+
+        headers = dict(request.headers)
+        self.assertEqual(headers['Host'], 'localhost:9314')
+        self.assertEqual(headers['Accept'], 'text/html')
+
+        # Connection was established and tokens set
+        expected = {
+            'X-CSRFToken': 'ABCDEFGHIJK',
+            'Cookie': 'csrftoken=ABCDEFGHIJK'
+        }
+        self.assertDictEqual(client.gqlc.base_headers, expected)
+
+    @httpretty.activate
+    def test_connection_error(self):
+        """Test whether it raises an exception on server connection errors"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL,
+                             raise_error_on_get=True)
+        client = SortingHatClient('localhost', ssl=False)
+
+        with self.assertRaisesRegex(SortingHatClientError, CONNECTION_ERROR):
+            client.connect()
+
+    @httpretty.activate
+    def test_disconnect(self):
+        """Test whether the client disconnects from the server"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL)
+
+        client = SortingHatClient('localhost', ssl=False)
+        client.connect()
+        client.disconnect()
+
+    @httpretty.activate
+    def test_authentication(self):
+        """Test whether the client authenticates on a SortingHat server"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL)
+
+        client = SortingHatClient('localhost', user='admin', password='admin', ssl=False)
+        client.connect()
+
+        self.assertIsInstance(client.gqlc, sgqlc.endpoint.http.HTTPEndpoint)
+
+        latest_requests = httpretty.latest_requests()
+        self.assertEqual(len(latest_requests), 2)
+
+        request = latest_requests[0]
+        self.assertEqual(request.method, 'GET')
+        self.assertEqual(dict(request.headers)['Host'], 'localhost:9314')
+
+        request = latest_requests[1]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(dict(request.headers)['Host'], 'localhost:9314')
+
+        # Connection was established and authorization was completed
+        expected = {
+            'Authorization': '12345678',
+            'X-CSRFToken': 'ABCDEFGHIJK',
+            'Cookie': 'csrftoken=ABCDEFGHIJK'
+        }
+        self.assertDictEqual(client.gqlc.base_headers, expected)
+
+    @httpretty.activate
+    def test_authentication_error(self):
+        """Test whether it raises an error when the credentials are wrong"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL)
+        client = SortingHatClient('localhost', user='admin', password='1234',
+                                  ssl=False)
+
+        with self.assertRaisesRegex(SortingHatClientError, AUTHENTICATION_ERROR):
+            client.connect()
+
+    @httpretty.activate
+    def test_execute(self):
+        """Test if GraphQL operations are executed by the client"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL)
+
+        client = SortingHatClient('localhost', ssl=False)
+        client.connect()
+
+        op = Operation(SortingHatSchema.SortingHatMutation)
+        op.token_auth(username='admin', password='admin').token()
+        result = client.execute(op)
+
+        # Check output
+        expected = {
+            'data': {
+                'tokenAuth': {
+                    'token': '12345678'
+                }
+            }
+        }
+        self.assertDictEqual(result, expected)
+
+        # Check query
+        expected_body = (
+            b'{"query": "mutation {\\ntokenAuth(username: \\"admin\\", password: \\"admin\\") {\\ntoken\\n}\\n}", '
+            b'"variables": null, '
+            b'"operationName": null}'
+        )
+
+        request = httpretty.latest_requests()[-1]
+        self.assertEqual(request.method, 'POST')
+        self.assertEqual(dict(request.headers)['Host'], 'localhost:9314')
+        self.assertEqual(request.body, expected_body)
+
+    @httpretty.activate
+    def test_execute_error(self):
+        """Test if it raises an exception when an error is found"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL)
+        client = SortingHatClient('localhost', user='admin', password='admin',
+                                  ssl=False)
+        client.connect()
+
+        with self.assertRaises(SortingHatClientError) as exc:
+            op = Operation(SortingHatSchema.SortingHatMutation)
+            op.token_auth(username='admin', password='1234').token()
+            client.execute(op)
+
+        expected = [
+            {
+                'message': "Invalid credentials.",
+                'locations': [{'line': 1, 'column': 1}],
+                'path': ['tokenAuth', 'token']
+            }
+        ]
+
+        error = exc.exception
+        self.assertEqual(error.msg, "GraphQL operation error; 1 errors found")
+        self.assertListEqual(error.errors, expected)
+
+    @httpretty.activate
+    def test_execute_not_connected(self):
+        """Test if execute fails when the client is not connected"""
+
+        MockSortingHatServer(SORTINGHAT_SERVER_URL)
+        client = SortingHatClient('localhost', ssl=False)
+
+        with self.assertRaisesRegex(SortingHatClientError, NOT_CONNECTED_CLIENT_ERROR):
+            op = Operation(SortingHatSchema.SortingHatMutation)
+            op.token_auth(username='admin', password='1234').token()
+            client.execute(op)
+
+
+if __name__ == "__main__":
+    unittest.main(warnings='ignore')


### PR DESCRIPTION
This commit adds a naive implementation of a SortingHat client. It allows to run any query or mutation supported by the server calling the method `execute()`.

This client uses `sgqlc` library that allows to define GraphQL operations faster.

Related to #239.