### PR TITLE
[client:rm] Add command to remove identities

### DIFF
--- a/sortinghat/cli/cmds/rm.py
+++ b/sortinghat/cli/cmds/rm.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     display,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+@click.command()
+@sh_client_cmd_options
+@click.argument('uuid')
+@sh_client
+def rm(ctx, uuid, **extra):
+    """Remove an identity from the registry.
+
+    This command removes from the registry the identity whose
+    identifier matches with <uuid>.
+
+    When the <uuid> also belongs to a unique identity, this entry
+    and those identities linked to it will be removed too.
+
+    UUID: identifier of the identity to remove
+    """
+    with connect(ctx.obj) as conn:
+        rm_id = _remove_identity(conn, uuid=uuid)
+        display('rm.tmpl', uuid=uuid, is_id_removed=rm_id)
+
+
+def _remove_identity(conn, **kwargs):
+    """Run a server operation to remove an identity from the registry."""
+
+    args = {k: v for k, v in kwargs.items() if v is not None}
+
+    op = Operation(SortingHatSchema.SortingHatMutation)
+    op.delete_identity(**args)
+    op.delete_identity.uidentity().uuid()
+
+    result = conn.execute(op)
+
+    uidentity = result['data']['deleteIdentity']['uidentity']
+
+    return uidentity is not None

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -22,6 +22,7 @@ import click
 
 from .cmds.add import add
 from .cmds.orgs import orgs
+from .cmds.rm import rm
 
 
 @click.group()
@@ -32,4 +33,5 @@ def sortinghat():
 
 
 sortinghat.add_command(add)
+sortinghat.add_command(rm)
 sortinghat.add_command(orgs)

--- a/sortinghat/cli/templates/rm.tmpl
+++ b/sortinghat/cli/templates/rm.tmpl
@@ -1,0 +1,5 @@
+{% if is_id_removed %}
+Identity {{ uuid }} removed
+{%- else %}
+Unique identity {{ uuid }} removed
+{%- endif %}

--- a/tests/cli/test_cmd_rm.py
+++ b/tests/cli/test_cmd_rm.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+import unittest.mock
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.rm import rm
+
+
+RM_CMD_OP = """mutation {{
+  deleteIdentity(uuid: "{}") {{
+    uidentity {{
+      uuid
+    }}
+  }}
+}}"""
+
+RM_UID_OUTPUT = (
+    "Unique identity eda9f62ad321b1fbe5f283cc05e2484516203117 removed\n"
+)
+RM_ID_OUTPUT = (
+    "Identity eda9f62ad321b1fbe5f283cc05e2484516203117 removed\n"
+)
+
+RM_NOT_FOUND_ERROR = (
+    "FFFFFFFFFFFFFFF not found in the registry"
+)
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestRmCommand(unittest.TestCase):
+    """Rm command unit tests"""
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_rm_unique_identity(self, mock_client):
+        """Check if it removes an identity"""
+
+        responses = [
+            {'data': {'deleteIdentity': {'uidentity': None}}},
+
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Remove a unique identity
+        params = ['eda9f62ad321b1fbe5f283cc05e2484516203117']
+        result = runner.invoke(rm, params)
+
+        expected = RM_CMD_OP.format('eda9f62ad321b1fbe5f283cc05e2484516203117')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, RM_UID_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_rm_identity(self, mock_client):
+        """Check if it removes an identity"""
+
+        responses = [
+            {
+                'data': {
+                    'deleteIdentity': {
+                        'uidentity': {'uuid': 'eda9f62ad321b1fbe5f283cc05e2484516203117'}
+                    }
+                }
+            },
+
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Remove an identity
+        params = ['eda9f62ad321b1fbe5f283cc05e2484516203117']
+        result = runner.invoke(rm, params)
+
+        expected = RM_CMD_OP.format('eda9f62ad321b1fbe5f283cc05e2484516203117')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, RM_ID_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_error(self, mock_client):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': RM_NOT_FOUND_ERROR,
+            'extensions': {
+                'code': 9
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = ['FFFFFFFFFFFFFFF']
+        result = runner.invoke(rm, params, obj=mock_client)
+
+        expected = RM_CMD_OP.format('FFFFFFFFFFFFFFF')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        expected_err = "Error: " + RM_NOT_FOUND_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 9)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The command 'rm' allows to remove unique identities or identities from the registry.

The differences with the original command are that the flag `identity ` has been removed. When the `uuid` references to a unique identity and to an identity it will remove both. The server doesn't allow to remove only the identity.

Fixes #257 