### PR TITLE
[client:mv] Add command to move identities

### DIFF
--- a/sortinghat/cli/cmds/mv.py
+++ b/sortinghat/cli/cmds/mv.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     display,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+@click.command()
+@sh_client_cmd_options
+@click.argument('from_id')
+@click.argument('to_uuid')
+@sh_client
+def mv(ctx, from_id, to_uuid, **extra):
+    """Move an identity to a unique identity.
+
+    This command shifts the identity identified by <from_id> to
+    the unique identity identified by <to_uuid>.
+
+    When <to_uid> is already related to <from_id>, the command does
+    not have any effect.
+
+    In the case of <from_id> and <to_uuid> have equal values and the
+    unique identity does not exist, a new unique identity will be
+    created and the identity will be moved to it.
+
+    FROM_ID: identifier of the identity to move
+
+    TO_UUID: identifier of the unique identity where <from_id> will be moved
+    """
+    with connect(ctx.obj) as conn:
+        _move_identity(conn, from_id=from_id,
+                       to_uuid=to_uuid)
+
+        display('mv.tmpl', from_id=from_id, to_uuid=to_uuid)
+
+
+def _move_identity(conn, **kwargs):
+    """Run a server operation to move an identity."""
+
+    args = {k: v for k, v in kwargs.items() if v is not None}
+
+    op = Operation(SortingHatSchema.SortingHatMutation)
+    op.move_identity(**args)
+    op.move_identity.uuid()
+
+    result = conn.execute(op)
+
+    return result['data']['moveIdentity']['uuid']

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -21,6 +21,7 @@ import click
 
 
 from .cmds.add import add
+from .cmds.mv import mv
 from .cmds.orgs import orgs
 
 
@@ -32,4 +33,5 @@ def sortinghat():
 
 
 sortinghat.add_command(add)
+sortinghat.add_command(mv)
 sortinghat.add_command(orgs)

--- a/sortinghat/cli/templates/mv.tmpl
+++ b/sortinghat/cli/templates/mv.tmpl
@@ -1,0 +1,5 @@
+{% if from_id != to_uuid %}
+Identity {{ from_id }} moved to unique identity {{ to_uuid }}
+{%- else %}
+New unique identity {{ from_id }} created; identity moved
+{%- endif %}

--- a/tests/cli/test_cmd_mv.py
+++ b/tests/cli/test_cmd_mv.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+import unittest.mock
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.mv import mv
+
+
+MV_CMD_OP = """mutation {{
+  moveIdentity(fromId: "{}", toUuid: "{}") {{
+    uuid
+  }}
+}}"""
+
+MV_OUTPUT = (
+    "Identity 322397ed782a798ffd9d0bc7e293df4292fe075d moved to "
+    "unique identity eda9f62ad321b1fbe5f283cc05e2484516203117\n"
+)
+MV_NEW_UID_OUTPUT = (
+    "New unique identity 322397ed782a798ffd9d0bc7e293df4292fe075d created; "
+    "identity moved\n"
+)
+
+
+MV_NOT_FOUND_ERROR = (
+    "FFFFFFFFFFFFFFF not found in the registry"
+)
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestMvCommand(unittest.TestCase):
+    """Mv command unit tests"""
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_mv(self, mock_client):
+        """Check if it moves a new identity"""
+
+        responses = [
+            {'data': {'moveIdentity': {'uuid': 'eda9f62ad321b1fbe5f283cc05e2484516203117'}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Create a new identity
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'eda9f62ad321b1fbe5f283cc05e2484516203117'
+        ]
+        result = runner.invoke(mv, params)
+
+        expected = MV_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d',
+                                    'eda9f62ad321b1fbe5f283cc05e2484516203117')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, MV_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_mv_to_new_uid(self, mock_client):
+        """Check if it creates a new unique identity when moving"""
+
+        responses = [
+            {'data': {'moveIdentity': {'uuid': 'eda9f62ad321b1fbe5f283cc05e2484516203117'}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Create a new identity
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            '322397ed782a798ffd9d0bc7e293df4292fe075d'
+        ]
+        result = runner.invoke(mv, params)
+
+        expected = MV_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d',
+                                    '322397ed782a798ffd9d0bc7e293df4292fe075d')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, MV_NEW_UID_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_error(self, mock_client):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': MV_NOT_FOUND_ERROR,
+            'extensions': {
+                'code': 9
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'FFFFFFFFFFFFFFF'
+        ]
+        result = runner.invoke(mv, params)
+
+        expected = MV_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d',
+                                    'FFFFFFFFFFFFFFF')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        expected_err = "Error: " + MV_NOT_FOUND_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 9)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The command 'mv' allows to move identities to other unique identities.

Fixes #258 
