### PR TITLE
[api] Fix move when from identity matches its unique identity

### DIFF
--- a/sortinghat/cli/cmds/mv.py
+++ b/sortinghat/cli/cmds/mv.py
@@ -48,6 +48,9 @@ def mv(ctx, from_id, to_uuid, **extra):
     unique identity does not exist, a new unique identity will be
     created and the identity will be moved to it.
 
+    When <from_id> exists also as a unique identity, this command will
+    fail as this identity cannot be moved.
+
     FROM_ID: identifier of the identity to move
 
     TO_UUID: identifier of the unique identity where <from_id> will be moved

--- a/sortinghat/core/api.py
+++ b/sortinghat/core/api.py
@@ -304,6 +304,9 @@ def move_identity(ctx, from_id, to_uuid):
     unique identity does not exist, a new unique identity will be
     created and the identity will be moved to it.
 
+    When `from_id` exists as a unique identity too, the function raises
+    an `InvalidValueError`, as this identity cannot be moved.
+
     The function raises a `NotFoundError` exception when either `from_id`
     or `to_uuid` do not exist in the registry and both identifiers are
     not the same.
@@ -335,6 +338,10 @@ def move_identity(ctx, from_id, to_uuid):
     trxl = TransactionsLog.open('move_identity', ctx)
 
     identity = find_identity(from_id)
+
+    if identity.id == identity.uidentity.uuid:
+        msg = "'from_id' is a unique identity and it cannot be moved; use 'merge' instead"
+        raise InvalidValueError(msg=msg)
 
     try:
         to_uid = find_unique_identity(to_uuid)


### PR DESCRIPTION
This PR aims so solve issue #265. 

Before this change, two problematic cases were found:
* When `from_id` was the only identity of a UniqueIdentity, move operation made the unique identity got orphan.
* When `from_id` matched the `uuid` of its parent UniqueIndentity, the sub-identity was moved to a different UniqueIdentity (the one in `to_uuid`).

This fix prevents these cases to happen checking if `from_id` matches the `uuid` of its parent UniqueIdentity.

There was some existing tests which have been corrected after this change and a new test for this fix both for API and Schema.