### PR TITLE
[client:profile] Add command to update profiles

### DIFF
--- a/sortinghat/cli/cmds/profile.py
+++ b/sortinghat/cli/cmds/profile.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     display,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+@click.command()
+@sh_client_cmd_options
+@click.option('--name',
+              help="Name of the unique identity.")
+@click.option('--email',
+              help="Email address of the unique identity.")
+@click.option('--gender',
+              help="Gender of the unique identity.")
+@click.option('--country',
+              help="ISO_3166-1 country code.")
+@click.option('--bot/--no-bot', default=None,
+              help="Set/unset the unique identity as a bot.")
+@click.argument('uuid')
+@sh_client
+def profile(ctx, uuid, name, email, gender, country, bot, **extra):
+    """Edit profile information.
+
+    This command updates the profile information of the unique
+    identity <uuid>. It is possible to edit, among other information,
+    the name, the email, the country, or to define whether a unique
+    identity is a bot or not.
+
+    When only <uuid> is provided, the command will display the
+    profile of that unique identity.
+
+    UUID: identifier of the unique identity
+    """
+    with connect(ctx.obj) as conn:
+        uid = _update_profile(conn, uuid, email=email,
+                              name=name, gender=gender,
+                              country_code=country,
+                              is_bot=bot)
+        display('profile.tmpl', uid=uid)
+
+
+def _update_profile(conn, uuid, **kwargs):
+    """Run a server operation to update the profile of a unique identity."""
+
+    args = {k: v for k, v in kwargs.items() if v is not None}
+    pd = SortingHatSchema.ProfileInputType(**args)
+
+    op = Operation(SortingHatSchema.SortingHatMutation)
+    op.update_profile(uuid=uuid, data=pd)
+    op.update_profile().uidentity().uuid()
+    op.update_profile().uidentity().profile().__fields__('name', 'email',
+                                                         'gender', 'is_bot')
+    op.update_profile().uidentity().profile().country().__fields__('code', 'name')
+
+    result = conn.execute(op)
+
+    data = op + result
+
+    return data.update_profile.uidentity

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -23,6 +23,7 @@ import click
 from .cmds.add import add
 from .cmds.mv import mv
 from .cmds.orgs import orgs
+from .cmds.profile import profile
 from .cmds.rm import rm
 
 
@@ -35,5 +36,6 @@ def sortinghat():
 
 sortinghat.add_command(add)
 sortinghat.add_command(rm)
+sortinghat.add_command(profile)
 sortinghat.add_command(mv)
 sortinghat.add_command(orgs)

--- a/sortinghat/cli/templates/profile.tmpl
+++ b/sortinghat/cli/templates/profile.tmpl
@@ -1,0 +1,8 @@
+unique identity {{ uid.uuid }}
+
+Profile:
+    * Name: {{ uid.profile.name|d('-', true) }}
+    * E-Mail: {{ uid.profile.email|d('-', true) }}
+    * Gender: {{ uid.profile.gender|d('-', true) }}
+    * Bot: {{ '%s' % 'Yes' if uid.profile.is_bot else 'No' }}
+    * Country: {{ '%s' % uid.profile.country.code + ' - ' + uid.profile.country.name if uid.profile.country else '-' }}

--- a/tests/cli/test_cmd_profile.py
+++ b/tests/cli/test_cmd_profile.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+import unittest.mock
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.profile import profile
+
+
+PROFILE_CMD_OP = """mutation {{
+  updateProfile(uuid: "{}", data: {{name: "{}", email: "{}", gender: "{}", countryCode: "{}"}}) {{
+    uidentity {{
+      uuid
+      profile {{
+        name
+        email
+        gender
+        isBot
+        country {{
+          code
+          name
+        }}
+      }}
+    }}
+  }}
+}}"""
+
+PROFILE_UUID_CMD_OP = """mutation {{
+  updateProfile(uuid: "{}", data: {{}}) {{
+    uidentity {{
+      uuid
+      profile {{
+        name
+        email
+        gender
+        isBot
+        country {{
+          code
+          name
+        }}
+      }}
+    }}
+  }}
+}}"""
+
+PROFILE_BOT_CMD_OP = """mutation {{
+  updateProfile(uuid: "{}", data: {{isBot: {}}}) {{
+    uidentity {{
+      uuid
+      profile {{
+        name
+        email
+        gender
+        isBot
+        country {{
+          code
+          name
+        }}
+      }}
+    }}
+  }}
+}}"""
+
+
+PROFILE_OUTPUT = """unique identity 17ab00ed3825ec2f50483e33c88df223264182ba
+
+Profile:
+    * Name: Jane Roe
+    * E-Mail: jroe@example.com
+    * Gender: female
+    * Bot: Yes
+    * Country: US - United States of America
+"""
+
+PROFILE_EMPTY_OUTPUT = """unique identity 17ab00ed3825ec2f50483e33c88df223264182ba
+
+Profile:
+    * Name: -
+    * E-Mail: -
+    * Gender: -
+    * Bot: No
+    * Country: -
+"""
+
+PROFILE_NOT_FOUND_ERROR = (
+    "FFFFFFFFFFFFFFF not found in the registry"
+)
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestProfileCommand(unittest.TestCase):
+    """Profile command unit tests"""
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_update_profile(self, mock_client):
+        """Check if it updates the profile"""
+
+        data = {
+            'uuid': '17ab00ed3825ec2f50483e33c88df223264182ba',
+            'profile': {
+                'name': 'Jane Roe',
+                'email': 'jroe@example.com',
+                'gender': 'female',
+                'isBot': True,
+                'country': {
+                    'code': 'US',
+                    'name': 'United States of America'
+                }
+            }
+        }
+        responses = [
+            {'data': {'updateProfile': {'uidentity': data}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Update the profile
+        params = [
+            '--name', 'Jane Roe',
+            '--email', 'jroe@example.com',
+            '--gender', 'female',
+            '--country', 'US',
+            '17ab00ed3825ec2f50483e33c88df223264182ba'
+        ]
+        result = runner.invoke(profile, params)
+
+        expected = PROFILE_CMD_OP.format('17ab00ed3825ec2f50483e33c88df223264182ba',
+                                         'Jane Roe', 'jroe@example.com',
+                                         'female', 'US')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, PROFILE_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_bot_profile(self, mock_client):
+        """Check if it bot argument is set or unset"""
+
+        data = {
+            'uuid': '17ab00ed3825ec2f50483e33c88df223264182ba',
+            'profile': {
+                'name': 'Jane Roe',
+                'email': 'jroe@example.com',
+                'gender': 'female',
+                'isBot': True,
+                'country': {
+                    'code': 'US',
+                    'name': 'United States of America'
+                }
+            }
+        }
+        responses = [
+            {'data': {'updateProfile': {'uidentity': data}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Update the profile
+        params = [
+            '--bot',
+            '17ab00ed3825ec2f50483e33c88df223264182ba'
+        ]
+        result = runner.invoke(profile, params)
+
+        expected = PROFILE_BOT_CMD_OP.format('17ab00ed3825ec2f50483e33c88df223264182ba',
+                                             'true')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, PROFILE_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_display_profile(self, mock_client):
+        """Check if it only displays a profile"""
+
+        data = {
+            'uuid': '17ab00ed3825ec2f50483e33c88df223264182ba',
+            'profile': {
+                'name': 'Jane Roe',
+                'email': 'jroe@example.com',
+                'gender': 'female',
+                'isBot': True,
+                'country': {
+                    'code': 'US',
+                    'name': 'United States of America'
+                }
+            }
+        }
+        responses = [
+            {'data': {'updateProfile': {'uidentity': data}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Show the profile
+        params = [
+            '17ab00ed3825ec2f50483e33c88df223264182ba'
+        ]
+        result = runner.invoke(profile, params)
+
+        expected = PROFILE_UUID_CMD_OP.format('17ab00ed3825ec2f50483e33c88df223264182ba')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, PROFILE_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_display_empty_profile(self, mock_client):
+        """Check if it displays an empty profile"""
+
+        data = {
+            'uuid': '17ab00ed3825ec2f50483e33c88df223264182ba',
+            'profile': {
+                'name': None,
+                'email': None,
+                'gender': None,
+                'isBot': False,
+                'country': None,
+            }
+        }
+
+        responses = [
+            {'data': {'updateProfile': {'uidentity': data}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Show the profile
+        params = [
+            '17ab00ed3825ec2f50483e33c88df223264182ba'
+        ]
+        result = runner.invoke(profile, params)
+
+        expected = PROFILE_UUID_CMD_OP.format('17ab00ed3825ec2f50483e33c88df223264182ba')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, PROFILE_EMPTY_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_error(self, mock_client):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': PROFILE_NOT_FOUND_ERROR,
+            'extensions': {
+                'code': 9
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = [
+            'FFFFFFFFFFFFFFF'
+        ]
+        result = runner.invoke(profile, params, obj=mock_client)
+
+        expected = PROFILE_UUID_CMD_OP.format('FFFFFFFFFFFFFFF')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        expected_err = "Error: " + PROFILE_NOT_FOUND_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 9)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The command 'profile' allows to update the profile information of a unique identity.

Fixes #261 