### PR TITLE
[client:enroll] Add command to enroll identities to organizations

### DIFF
--- a/sortinghat/cli/cmds/enroll.py
+++ b/sortinghat/cli/cmds/enroll.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from grimoirelab_toolkit.datetime import (str_to_datetime,
+                                          InvalidDateError)
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+@click.command()
+@sh_client_cmd_options
+@click.argument('uuid')
+@click.argument('organization')
+@click.option('--from-date',
+              help="Date when the enrollment starts")
+@click.option('--to-date',
+              help="Date when the enrollment ends")
+@sh_client
+def enroll(ctx, uuid, organization, from_date, to_date, **extra):
+    """Enroll a unique identity in an organization.
+
+    This command enrolls the unique identity <uuid> in the
+    given <organization>. Both identity and organization must
+    exist before adding the new enrollment to the registry.
+
+    The period of the enrollment can be given with the options
+    <from_date> and <to_date>, where 'from_date <= to_date'.
+    Valid dates should follow ISO 8601 standard (e.g
+    'YYYY-MM-DD' for dates; 'YYYY-MM-DD hh:mm:ss±hhmm' for
+    timestamps). The default values for these dates are
+    '1900-01-01' and '2100-01-01' in UTC.
+
+    Existing enrollments for the same unique identity and
+    organization which overlap with the new period will be
+    automatically merged into a single enrollment.
+
+    If the given period for that enrollment is enclosed by
+    one already stored, the command will return an error.
+
+    UUID: unique identity to enroll
+
+    ORGANIZATION: name of organization
+    """
+    with connect(ctx.obj) as conn:
+        try:
+            if from_date:
+                from_date = str_to_datetime(from_date)
+            if to_date:
+                to_date = str_to_datetime(to_date)
+        except InvalidDateError as exc:
+            raise click.ClickException(str(exc))
+
+        _enroll_identity(conn, uuid=uuid,
+                         organization=organization,
+                         from_date=from_date,
+                         to_date=to_date)
+
+
+def _enroll_identity(conn, **kwargs):
+    """Run a server operation to enroll an identity."""
+
+    args = {k: v for k, v in kwargs.items() if v is not None}
+
+    op = Operation(SortingHatSchema.SortingHatMutation)
+    op.enroll(**args)
+    op.enroll.uuid()
+
+    result = conn.execute(op)
+
+    return result['data']['enroll']['uuid']

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -21,6 +21,7 @@ import click
 
 
 from .cmds.add import add
+from .cmds.enroll import enroll
 from .cmds.mv import mv
 from .cmds.orgs import orgs
 from .cmds.profile import profile
@@ -38,4 +39,5 @@ sortinghat.add_command(add)
 sortinghat.add_command(rm)
 sortinghat.add_command(profile)
 sortinghat.add_command(mv)
+sortinghat.add_command(enroll)
 sortinghat.add_command(orgs)

--- a/tests/cli/test_cmd_enroll.py
+++ b/tests/cli/test_cmd_enroll.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+import unittest.mock
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.enroll import enroll
+
+
+ENROLL_CMD_OP = """mutation {{
+  enroll(
+      uuid: "{}"
+      organization: "{}"
+      fromDate: "{}"
+      toDate: "{}"
+    ) {{
+    uuid
+  }}
+}}"""
+
+ENROLL_DEFAULT_CMD_OP = """mutation {{
+  enroll(uuid: "{}", organization: "{}") {{
+    uuid
+  }}
+}}"""
+
+
+ENROLL_NOT_FOUND_ERROR = (
+    "FFFFFFFFFFFFFFF not found in the registry"
+)
+
+ENROLL_INVALID_DATE_ERROR = (
+    "{} is not a valid date"
+)
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestEnrollCommand(unittest.TestCase):
+    """Enroll command unit tests"""
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_enroll(self, mock_client):
+        """Check if it creates a new enrollment"""
+
+        responses = [
+            {'data': {'enroll': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Create a new enrollment
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'Example',
+            '--from-date', '2012-01-01',
+            '--to-date', '2013-01-01'
+        ]
+        result = runner.invoke(enroll, params)
+
+        expected = ENROLL_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d',
+                                        'Example',
+                                        '2012-01-01T00:00:00+00:00',
+                                        '2013-01-01T00:00:00+00:00')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_enroll_default_dates(self, mock_client):
+        """Check if it creates a new enrollment with default dates"""
+
+        responses = [
+            {'data': {'enroll': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Create a new enrollment
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'Example'
+        ]
+        result = runner.invoke(enroll, params)
+
+        expected = ENROLL_DEFAULT_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d',
+                                                'Example')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_invalid_dates_error(self, mock_client):
+        """"Check if it fails when an invalid date is given"""
+
+        client = MockClient([])
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'Example',
+            '--from-date', '2011-13-01'
+        ]
+        result = runner.invoke(enroll, params)
+
+        self.assertEqual(len(client.ops), 0)
+
+        expected_err = "Error: " + ENROLL_INVALID_DATE_ERROR.format('2011-13-01') + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 1)
+
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'Example',
+            '--to-date', 'AAAAAA'
+        ]
+        result = runner.invoke(enroll, params)
+
+        self.assertEqual(len(client.ops), 0)
+
+        expected_err = "Error: " + ENROLL_INVALID_DATE_ERROR.format('AAAAAA') + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 1)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_error(self, mock_client):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': ENROLL_NOT_FOUND_ERROR,
+            'extensions': {
+                'code': 9
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'FFFFFFFFFFFFFFF'
+        ]
+        result = runner.invoke(enroll, params)
+
+        expected = ENROLL_DEFAULT_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d',
+                                                'FFFFFFFFFFFFFFF')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        expected_err = "Error: " + ENROLL_NOT_FOUND_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 9)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The command 'enroll' allows to create enrollments of unique identities in organizations.

The main difference with the original command is that it merges ranges of enrollments always, so the option `--merge` is not available anymore.

Fixes #259 