### PR TITLE
[client:lock] Add a command to lock and unlock identities

### DIFF
--- a/sortinghat/cli/cmds/lock.py
+++ b/sortinghat/cli/cmds/lock.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     display,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+@click.group()
+@sh_client_cmd_options
+@sh_client
+def lock(ctx, user, password, host, port, server_path, disable_ssl):
+    """Lock and unlock unique identities on the registry."""
+
+    pass
+
+
+@lock.command()
+@click.argument('uuid')
+@click.pass_obj
+def add(client, uuid):
+    """Add a lock to a unique identity so it cannot be modified.
+
+    This command adds a lock to the unique identity identified
+    by <uuid>. Therefore, this and its related entities such
+    as identities, enrollments or the profile cannot be
+    modified.
+
+    UUID: identifier of the unique identity which will be locked
+    """
+    with connect(client) as conn:
+        _lock_identity(conn, uuid=uuid)
+        display('lock.tmpl', uuid=uuid, unlocked=False)
+
+
+def _lock_identity(conn, **kwargs):
+    """Run a server operation to lock a unique identity."""
+
+    args = {k: v for k, v in kwargs.items() if v is not None}
+
+    op = Operation(SortingHatSchema.SortingHatMutation)
+    op.lock_identity(**args)
+    op.lock_identity.uuid()
+
+    result = conn.execute(op)
+
+    return result['data']['lockIdentity']['uuid']
+
+
+@lock.command()
+@click.argument('uuid')
+@click.pass_obj
+def rm(client, uuid):
+    """Remove a lock from a unique identity so it can be modified.
+
+    This command removes a lock from the unique identity
+    identified by <uuid>. Therefore, this and its related
+    entities such as identities, enrollments or the profile
+    can be modified.
+
+    UUID: identifier of the unique identity which will be unlocked
+    """
+    with connect(client) as conn:
+        _unlock_identity(conn, uuid=uuid)
+        display('lock.tmpl', uuid=uuid, unlocked=True)
+
+
+def _unlock_identity(conn, **kwargs):
+    """Run a server operation to unlock a unique identity."""
+
+    args = {k: v for k, v in kwargs.items() if v is not None}
+
+    op = Operation(SortingHatSchema.SortingHatMutation)
+    op.unlock_identity(**args)
+    op.unlock_identity.uuid()
+
+    result = conn.execute(op)
+
+    return result['data']['unlockIdentity']['uuid']

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -22,6 +22,7 @@ import click
 
 from .cmds.add import add
 from .cmds.enroll import enroll
+from .cmds.lock import lock
 from .cmds.merge import merge
 from .cmds.mv import mv
 from .cmds.orgs import orgs
@@ -46,4 +47,5 @@ sortinghat.add_command(enroll)
 sortinghat.add_command(withdraw)
 sortinghat.add_command(merge)
 sortinghat.add_command(split)
+sortinghat.add_command(lock)
 sortinghat.add_command(orgs)

--- a/sortinghat/cli/templates/lock.tmpl
+++ b/sortinghat/cli/templates/lock.tmpl
@@ -1,0 +1,1 @@
+Unique identity {{ uuid }} is {{ 'un' if unlocked }}locked

--- a/tests/cli/test_cmd_lock.py
+++ b/tests/cli/test_cmd_lock.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.lock import add, rm
+
+
+LOCK_ADD_CMD_OP = """mutation {{
+  lockIdentity(uuid: "{}") {{
+    uuid
+  }}
+}}"""
+
+LOCK_RM_CMD_OP = """mutation {{
+  unlockIdentity(uuid: "{}") {{
+    uuid
+  }}
+}}"""
+
+
+LOCK_ADD_OUTPUT = """Unique identity {} is locked\n"""
+
+LOCK_RM_OUTPUT = """Unique identity {} is unlocked\n"""
+
+
+LOCK_NOT_FOUND_ERROR = (
+    "FFFFFFFFFFFFFFF not found in the registry"
+)
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestLockAddCommand(unittest.TestCase):
+    """Lock add command unit tests"""
+
+    def test_lock_add(self):
+        """Check if it adds a lock to a unique identity"""
+
+        responses = [
+            {'data': {'lockIdentity': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
+        ]
+        mock_client = MockClient(responses)
+
+        runner = click.testing.CliRunner()
+
+        # Add lock
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d'
+        ]
+        result = runner.invoke(add, params, obj=mock_client)
+
+        expected = LOCK_ADD_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d')
+        self.assertEqual(len(mock_client.ops), 1)
+        self.assertEqual(str(mock_client.ops[0]), expected)
+
+        expected = LOCK_ADD_OUTPUT.format('322397ed782a798ffd9d0bc7e293df4292fe075d')
+        self.assertEqual(result.stdout, expected)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_error(self):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': LOCK_NOT_FOUND_ERROR,
+            'extensions': {
+                'code': 9
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        mock_client = MockClient(responses)
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = [
+            'FFFFFFFFFFFFFFF'
+        ]
+        result = runner.invoke(add, params, obj=mock_client)
+
+        expected = LOCK_ADD_CMD_OP.format('FFFFFFFFFFFFFFF')
+        self.assertEqual(len(mock_client.ops), 1)
+        self.assertEqual(str(mock_client.ops[0]), expected)
+
+        expected_err = "Error: " + LOCK_NOT_FOUND_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 9)
+
+
+class TestLockRmCommand(unittest.TestCase):
+    """Lock rm command unit tests"""
+
+    def test_lock_rm(self):
+        """Check if it removes a lock from a unique identity"""
+
+        responses = [
+            {'data': {'unlockIdentity': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
+        ]
+        mock_client = MockClient(responses)
+
+        runner = click.testing.CliRunner()
+
+        # Remove lock
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d'
+        ]
+        result = runner.invoke(rm, params, obj=mock_client)
+
+        expected = LOCK_RM_CMD_OP.format('322397ed782a798ffd9d0bc7e293df4292fe075d')
+        self.assertEqual(len(mock_client.ops), 1)
+        self.assertEqual(str(mock_client.ops[0]), expected)
+
+        expected = LOCK_RM_OUTPUT.format('322397ed782a798ffd9d0bc7e293df4292fe075d')
+        self.assertEqual(result.stdout, expected)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_error(self):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': LOCK_NOT_FOUND_ERROR,
+            'extensions': {
+                'code': 9
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        mock_client = MockClient(responses)
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = [
+            'FFFFFFFFFFFFFFF'
+        ]
+        result = runner.invoke(rm, params, obj=mock_client)
+
+        expected = LOCK_RM_CMD_OP.format('FFFFFFFFFFFFFFF')
+        self.assertEqual(len(mock_client.ops), 1)
+        self.assertEqual(str(mock_client.ops[0]), expected)
+
+        expected_err = "Error: " + LOCK_NOT_FOUND_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 9)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The command 'lock' implements two subcommands: 'add' to lock a unique identity; 'rm' to unlock it.

Fixes #275