### PR TITLE
[client:split] Add command to unmerge identities

### DIFF
--- a/sortinghat/cli/cmds/split.py
+++ b/sortinghat/cli/cmds/split.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     display,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+@click.command()
+@sh_client_cmd_options
+@click.argument('uuid', nargs=-1, required=True)
+@sh_client
+def split(ctx, uuid, **extra):
+    """Separate one or more identities from their corresponding unique identities.
+
+    This command separates a list of identities, creating a unique
+    identity for each one.
+
+    A profile for each new unique identity will be created using
+    the 'name' and 'email' fields of the parent unique identity.
+
+    Nor the enrollments or the profile from any parent unique
+    identity of the input identities are modified.
+
+    When a given identity <uuid> is equal to the <uuid> of its
+    parent unique identity, there will be no effect. Also,
+    take into account all identities must exist before splitting
+    them. Otherwise, the command will abort the operation.
+
+    UUID: identities to split
+    """
+    with connect(ctx.obj) as conn:
+        uuids = sorted(list(set(uuid)))
+        result = _unmerge_identities(conn, uuids=uuids)
+        display('split.tmpl', nl=False, uuids=result)
+
+
+def _unmerge_identities(conn, **kwargs):
+    """Run a server operation to unmerge identities."""
+
+    args = {k: v for k, v in kwargs.items() if v is not None}
+
+    op = Operation(SortingHatSchema.SortingHatMutation)
+    op.unmerge_identities(**args)
+    op.unmerge_identities.uuids()
+
+    result = conn.execute(op)
+
+    return result['data']['unmergeIdentities']['uuids']

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -27,6 +27,7 @@ from .cmds.mv import mv
 from .cmds.orgs import orgs
 from .cmds.profile import profile
 from .cmds.rm import rm
+from .cmds.split import split
 from .cmds.withdraw import withdraw
 
 
@@ -44,4 +45,5 @@ sortinghat.add_command(mv)
 sortinghat.add_command(enroll)
 sortinghat.add_command(withdraw)
 sortinghat.add_command(merge)
+sortinghat.add_command(split)
 sortinghat.add_command(orgs)

--- a/sortinghat/cli/templates/split.tmpl
+++ b/sortinghat/cli/templates/split.tmpl
@@ -1,0 +1,3 @@
+{% for uuid in uuids %}
+New unique identity {{ uuid }} split
+{% endfor %}

--- a/tests/cli/test_cmd_split.py
+++ b/tests/cli/test_cmd_split.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+import unittest.mock
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.split import split
+
+
+SPLIT_CMD_OP = """mutation {{
+  unmergeIdentities(uuids: [{}]) {{
+    uuids
+  }}
+}}"""
+
+
+SPLIT_OUTPUT = """New unique identity 322397ed782a798ffd9d0bc7e293df4292fe075d split
+New unique identity a9b403e150dd4af8953a52a4bb841051e4b705d9 split
+New unique identity eda9f62ad321b1fbe5f283cc05e2484516203117 split
+New unique identity ffefc2e3f2a255e9450ac9e2d36f37c28f51bd73 split
+"""
+
+
+SPLIT_NOT_FOUND_ERROR = (
+    "FFFFFFFFFFFFFFF not found in the registry"
+)
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestSplitCommand(unittest.TestCase):
+    """Split command unit tests"""
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_split(self, mock_client):
+        """Check if it splits a set of identities"""
+
+        uuids = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'a9b403e150dd4af8953a52a4bb841051e4b705d9',
+            'eda9f62ad321b1fbe5f283cc05e2484516203117',
+            'ffefc2e3f2a255e9450ac9e2d36f37c28f51bd73'
+        ]
+
+        responses = [
+            {'data': {'unmergeIdentities': {'uuids': uuids}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Split into unique identities
+        params = uuids
+        result = runner.invoke(split, params)
+
+        uuids_str = '"{}", "{}", "{}", "{}"'.format(*params)
+
+        expected = SPLIT_CMD_OP.format(uuids_str)
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, SPLIT_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_split_dup(self, mock_client):
+        """Check if it ignores dup uuids while splitting"""
+
+        uuids = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'a9b403e150dd4af8953a52a4bb841051e4b705d9',
+            'eda9f62ad321b1fbe5f283cc05e2484516203117',
+            'ffefc2e3f2a255e9450ac9e2d36f37c28f51bd73',
+            'eda9f62ad321b1fbe5f283cc05e2484516203117'
+        ]
+
+        responses = [
+            {'data': {'unmergeIdentities': {'uuids': uuids[:-1]}}}
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        # Split into unique identities
+        params = uuids
+        result = runner.invoke(split, params)
+
+        # Last uuid was filtered and not sent in the operation
+        uuids_str = '"{}", "{}", "{}", "{}"'.format(*uuids[:-1])
+
+        expected = SPLIT_CMD_OP.format(uuids_str)
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        self.assertEqual(result.stdout, SPLIT_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_error(self, mock_client):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': SPLIT_NOT_FOUND_ERROR,
+            'extensions': {
+                'code': 9
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = [
+            '322397ed782a798ffd9d0bc7e293df4292fe075d',
+            'FFFFFFFFFFFFFFF'
+        ]
+        result = runner.invoke(split, params)
+
+        uuids_str = '"{}", "{}"'.format(*params)
+
+        expected = SPLIT_CMD_OP.format(uuids_str)
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        expected_err = "Error: " + SPLIT_NOT_FOUND_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 9)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The new command 'split' unmerges a set of identities.

Fixes #274 .