### PR TITLE
[client:show] Add command to display info about unique identities

### DIFF
--- a/sortinghat/cli/cmds/show.py
+++ b/sortinghat/cli/cmds/show.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     display,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+@click.command()
+@sh_client_cmd_options
+@click.argument('uuid', nargs=1, required=False)
+@sh_client
+def show(ctx, uuid, **extra):
+    """Show information about unique identities.
+
+    This command displays, by default, information about all
+    the unique identities stored in the registry. The information
+    shown includes identities and enrollments.
+
+    When <uuid> is given, it will show information about the unique
+    identity related to <uuid>.
+
+    UUID: unique identity to show
+    """
+    with connect(ctx.obj) as conn:
+        for uidentities in _fetch_unique_identities(conn, uuid=uuid):
+            display('show.tmpl', nl=False,
+                    uidentities=uidentities)
+
+
+def _fetch_unique_identities(client, uuid=None):
+    """Run a server operation to get the list of unique identities."""
+
+    page = 1
+    paginate = True
+
+    while paginate:
+        op = _generate_uidentities_operation(page, uuid)
+
+        result = client.execute(op)
+
+        data = op + result
+        paginate = data.uidentities.page_info.has_next
+        page += 1
+        yield data.uidentities.entities
+
+
+def _generate_uidentities_operation(page, uuid):
+    """Define an operation to get the list of organizations."""
+
+    args = {
+        'page': page
+    }
+    if uuid:
+        args['filters'] = {'uuid': uuid}
+
+    op = Operation(SortingHatSchema.Query)
+    op.uidentities(**args)
+
+    # Select page information
+    op.uidentities().page_info.has_next()
+
+    # Select identities information
+    uidentity = op.uidentities().entities()
+
+    uidentity.uuid()
+    uidentity.is_locked()
+    uidentity.profile().__fields__('name', 'email',
+                                   'gender', 'is_bot')
+    uidentity.profile().country().__fields__('code', 'name')
+
+    uidentity.identities().__fields__('id', 'email', 'name', 'username', 'source')
+    uidentity.enrollments().__fields__('start', 'end')
+    uidentity.enrollments().organization().name()
+
+    return op

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -29,6 +29,7 @@ from .cmds.orgs import orgs
 from .cmds.profile import profile
 from .cmds.rm import rm
 from .cmds.split import split
+from .cmds.show import show
 from .cmds.withdraw import withdraw
 
 
@@ -48,4 +49,5 @@ sortinghat.add_command(withdraw)
 sortinghat.add_command(merge)
 sortinghat.add_command(split)
 sortinghat.add_command(lock)
+sortinghat.add_command(show)
 sortinghat.add_command(orgs)

--- a/sortinghat/cli/templates/show.tmpl
+++ b/sortinghat/cli/templates/show.tmpl
@@ -1,0 +1,30 @@
+{% for uid in uidentities | sort(attribute='uuid') %}
+
+unique identity {{ uid.uuid }}{{'	(locked)' if uid.is_locked }}
+
+Profile:
+    * Name: {{ uid.profile.name|d('-', true) }}
+    * E-Mail: {{ uid.profile.email|d('-', true) }}
+    * Gender: {{ uid.profile.gender|d('-', true) }}
+    * Bot: {{ '%s' % 'Yes' if uid.profile.is_bot else 'No' }}
+    * Country: {{ '%s' % uid.profile.country.code + ' - ' + uid.profile.country.name if uid.profile.country else '-' }}
+
+{% if uid.identities %}
+Identities:
+{% for identity in uid.identities | sort(attribute='id') %}
+  {{ identity.id }}	{{ identity.name|d('-', true) }}	{{ identity.email|d('-', true) }}	{{ identity.username|d('-', true) }}	{{ identity.source }}
+{% endfor %}
+{% else %}
+No identities
+{% endif %}
+
+{% if uid.enrollments %}
+Enrollments:
+{% for rol in uid.enrollments %}
+  {{ rol.organization.name }}	{{ rol.start.strftime('%Y-%m-%d %H:%M:%S') }}	{{ rol.end.strftime('%Y-%m-%d %H:%M:%S') }}
+{% endfor %}
+{% else %}
+No enrollments
+{% endif %}
+
+{% endfor %}

--- a/tests/cli/test_cmd_show.py
+++ b/tests/cli/test_cmd_show.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+import unittest.mock
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.show import show
+
+
+SHOW_CMD_OP = """query {{
+  uidentities({}) {{
+    pageInfo {{
+      hasNext
+    }}
+    entities {{
+      uuid
+      isLocked
+      profile {{
+        name
+        email
+        gender
+        isBot
+        country {{
+          code
+          name
+        }}
+      }}
+      identities {{
+        id
+        email
+        name
+        username
+        source
+      }}
+      enrollments {{
+        start
+        end
+        organization {{
+          name
+        }}
+      }}
+    }}
+  }}
+}}"""
+
+
+SHOW_OUTPUT = """
+unique identity 0000000000000000000000000000000000000000\t(locked)
+
+Profile:
+    * Name: -
+    * E-Mail: -
+    * Gender: -
+    * Bot: Yes
+    * Country: -
+
+No identities
+
+No enrollments
+
+
+unique identity 17ab00ed3825ec2f50483e33c88df223264182ba
+
+Profile:
+    * Name: Jane Roe
+    * E-Mail: jroe@example.com
+    * Gender: female
+    * Bot: No
+    * Country: US - United States of America
+
+Identities:
+  17ab00ed3825ec2f50483e33c88df223264182ba\tJane Roe\tjroe@example.com\tjroe\tscm
+  22d1b20763c6f5822bdda8508957486c547bb9de\t-\tjroe@bitergia.com\t-\tunknown
+  322397ed782a798ffd9d0bc7e293df4292fe075d\t-\tjroe@example.com\t-\tscm
+
+Enrollments:
+  Bitergia\t1999-01-01 00:00:00\t2000-01-01 00:00:00
+  Bitergia\t2006-01-01 00:00:00\t2008-01-01 00:00:00
+  Example\t1900-01-01 00:00:00\t2100-01-01 00:00:00
+
+
+unique identity a9b403e150dd4af8953a52a4bb841051e4b705d9
+
+Profile:
+    * Name: -
+    * E-Mail: jsmith@example.com
+    * Gender: male
+    * Bot: Yes
+    * Country: -
+
+Identities:
+  880b3dfcb3a08712e5831bddc3dfe81fc5d7b331\tJohn Smith\tjsmith@example.com\t-\tscm
+  a9b403e150dd4af8953a52a4bb841051e4b705d9\tJohn Smith\tjsmith@example.com\tjsmith\tscm
+
+Enrollments:
+  Example\t1900-01-01 00:00:00\t2100-01-01 00:00:00
+
+"""
+
+SHOW_UUID_OUTPUT = """
+unique identity 17ab00ed3825ec2f50483e33c88df223264182ba
+
+Profile:
+    * Name: Jane Roe
+    * E-Mail: jroe@example.com
+    * Gender: female
+    * Bot: No
+    * Country: US - United States of America
+
+Identities:
+  17ab00ed3825ec2f50483e33c88df223264182ba\tJane Roe\tjroe@example.com\tjroe\tscm
+  22d1b20763c6f5822bdda8508957486c547bb9de\t-\tjroe@bitergia.com\t-\tunknown
+  322397ed782a798ffd9d0bc7e293df4292fe075d\t-\tjroe@example.com\t-\tscm
+
+Enrollments:
+  Bitergia\t1999-01-01 00:00:00\t2000-01-01 00:00:00
+  Bitergia\t2006-01-01 00:00:00\t2008-01-01 00:00:00
+  Example\t1900-01-01 00:00:00\t2100-01-01 00:00:00
+
+"""
+
+SHOW_EMPTY_OUTPUT = """"""
+
+
+SHOW_UKNOWN_ERROR = (
+    "unknown error"
+)
+
+
+EMPTY_ID_PROFILE = {
+    'name': None,
+    'email': None,
+    'gender': None,
+    'isBot': True,
+    'country': None
+}
+
+JANE_ROE_PROFILE = {
+    'name': 'Jane Roe',
+    'email': 'jroe@example.com',
+    'gender': 'female',
+    'isBot': False,
+    'country': {
+        'code': 'US',
+        'name': 'United States of America'
+    }
+}
+JANE_ROE_IDENTITIES = [
+    {
+        'id': '17ab00ed3825ec2f50483e33c88df223264182ba',
+        'email': 'jroe@example.com',
+        'name': 'Jane Roe',
+        'username': 'jroe',
+        'source': 'scm'
+    },
+    {
+        'id': '22d1b20763c6f5822bdda8508957486c547bb9de',
+        'email': 'jroe@bitergia.com',
+        'name': None,
+        'username': None,
+        'source': 'unknown'
+    },
+    {
+        'id': '322397ed782a798ffd9d0bc7e293df4292fe075d',
+        'email': 'jroe@example.com',
+        'name': None,
+        'username': None,
+        'source': 'scm'
+    }
+]
+JANE_ROE_ENROLLMENTS = [
+    {
+        'start': '1999-01-01T00:00:00Z',
+        'end': '2000-01-01T00:00:00Z',
+        'organization': {
+            'name': 'Bitergia'
+        }
+    },
+    {
+        'start': '2006-01-01T00:00:00Z',
+        'end': '2008-01-01T00:00:00Z',
+        'organization': {
+            'name': 'Bitergia'
+        }
+    },
+    {
+        'start': '1900-01-01T00:00:00Z',
+        'end': '2100-01-01T00:00:00Z',
+        'organization': {
+            'name': 'Example'
+        }
+    }
+]
+
+JSMITH_PROFILE = {
+    'name': None,
+    'email': 'jsmith@example.com',
+    'gender': 'male',
+    'isBot': True,
+    'country': None
+}
+JSMITH_IDENTITIES = [
+    {
+        'id': '880b3dfcb3a08712e5831bddc3dfe81fc5d7b331',
+        'email': 'jsmith@example.com',
+        'name': 'John Smith',
+        'username': None,
+        'source': 'scm'
+    },
+    {
+        'id': 'a9b403e150dd4af8953a52a4bb841051e4b705d9',
+        'email': 'jsmith@example.com',
+        'name': 'John Smith',
+        'username': 'jsmith',
+        'source': 'scm'
+    }
+]
+JSMITH_ENROLLMENTS = [
+    {
+        'start': '1900-01-01T00:00:00Z',
+        'end': '2100-01-01T00:00:00Z',
+        'organization': {
+            'name': 'Example'
+        }
+    }
+]
+
+EMPTY_ID_DATA = {
+    'uuid': '0000000000000000000000000000000000000000',
+    'isLocked': True,
+    'profile': EMPTY_ID_PROFILE,
+    'identities': [],
+    'enrollments': []
+}
+JANE_ROE_ID_DATA = {
+    'uuid': '17ab00ed3825ec2f50483e33c88df223264182ba',
+    'isLocked': False,
+    'profile': JANE_ROE_PROFILE,
+    'identities': JANE_ROE_IDENTITIES,
+    'enrollments': JANE_ROE_ENROLLMENTS
+}
+JSMITH_ID_DATA = {
+    'uuid': 'a9b403e150dd4af8953a52a4bb841051e4b705d9',
+    'isLocked': False,
+    'profile': JSMITH_PROFILE,
+    'identities': JSMITH_IDENTITIES,
+    'enrollments': JSMITH_ENROLLMENTS
+}
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestShowCommand(unittest.TestCase):
+    """Show command unit tests"""
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_show(self, mock_client):
+        """Check if it displays information of unique identities"""
+
+        entities = [
+            EMPTY_ID_DATA,
+            JANE_ROE_ID_DATA,
+            JSMITH_ID_DATA
+        ]
+
+        # Split entities into pages
+        responses = [
+            {
+                'data': {
+                    'uidentities': {
+                        'pageInfo': {'hasNext': True},
+                        'entities': entities[0:2]
+                    }
+                }
+            },
+            {
+                'data': {
+                    'uidentities': {
+                        'pageInfo': {'hasNext': False},
+                        'entities': entities[2:]
+                    }
+                }
+            }
+        ]
+
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(show)
+
+        self.assertEqual(len(client.ops), 2)
+        expected = SHOW_CMD_OP.format('page: 1')
+        op = str(client.ops[0])
+        self.assertEqual(op, expected)
+
+        expected = SHOW_CMD_OP.format('page: 2')
+        op = str(client.ops[1])
+        self.assertEqual(op, expected)
+
+        self.assertEqual(result.stdout, SHOW_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_show_uuid(self, mock_client):
+        """Check if it displays information of the given unique identity"""
+
+        entities = [
+            JANE_ROE_ID_DATA
+        ]
+
+        # Split entities into pages
+        responses = [
+            {
+                'data': {
+                    'uidentities': {
+                        'pageInfo': {'hasNext': False},
+                        'entities': entities
+                    }
+                }
+            }
+        ]
+
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        params = ['17ab00ed3825ec2f50483e33c88df223264182ba']
+        result = runner.invoke(show, params)
+
+        self.assertEqual(len(client.ops), 1)
+
+        filters = 'page: {}, filters: {{uuid: "{}"}}'
+        filters = filters.format('1', '17ab00ed3825ec2f50483e33c88df223264182ba')
+        expected = SHOW_CMD_OP.format(filters)
+        op = str(client.ops[0])
+        self.assertEqual(op, expected)
+
+        self.assertEqual(result.stdout, SHOW_UUID_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_show_empty(self, mock_client):
+        """Check if it shows an empty list of unique identities"""
+
+        responses = [
+            {
+                'data': {
+                    'uidentities': {
+                        'pageInfo': {'hasNext': False},
+                        'entities': []
+                    }
+                }
+            }
+        ]
+
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        result = runner.invoke(show)
+
+        self.assertEqual(len(client.ops), 1)
+
+        expected = SHOW_CMD_OP.format('page: 1')
+        op = str(client.ops[0])
+        self.assertEqual(op, expected)
+
+        self.assertEqual(result.stdout, SHOW_EMPTY_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_error(self, mock_client):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': SHOW_UKNOWN_ERROR,
+            'extensions': {
+                'code': 128
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        result = runner.invoke(show)
+
+        expected = SHOW_CMD_OP.format('page: 1')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        expected_err = "Error: " + SHOW_UKNOWN_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 128)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The command 'show' prints to the standard output information about the unique identities on the
registry.

The main difference with the original command is that `term` argument is not available yet because the server does not support to filter by it.

Fixes #276 