### PR TITLE
[travis] Upgrade setuptools and pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ services:
   - mysql
 
 install:
+  - pip install --upgrade setuptools
+  - pip install --upgrade pip
   - pip install coveralls
   - pip install cryptography
 


### PR DESCRIPTION
This code upgrades the setuptools and pip. This change stems from the fix at:
chaoss/grimoirelab-perceval#643 .
It was needed to fix the CI tests that were failing due to the following error:
```
File "../python3.5/site-packages/setuptools/sandbox.py", line 44, in _execfile
  code = compile(script, filename, 'exec')
File "/tmp/easy_install-wu9lgsxc/pandoc-2.0a4/setup.py", line 11
  error = f"pip is not installed, refer to <{url}> for instructions."
                                                                    ^
SyntaxError: invalid syntax
```

Signed-off-by: Ria Gupta <ria18405@iiitd.ac.in>