### PR TITLE
Add countries support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click==7.0
+click==7.1.1
 Django==2.1
 django-mysql>=3.2.0
 django-graphql-jwt>=0.3.0

--- a/sortinghat/cli/client/schema.py
+++ b/sortinghat/cli/client/schema.py
@@ -65,6 +65,13 @@ String = sgqlc.types.String
 # Input Objects
 ########################################################################
 
+class CountryFilterType(sgqlc.types.Input):
+    __schema__ = sh_schema
+    __field_names__ = ('code', 'term',)
+    code = sgqlc.types.Field(String, graphql_name='code')
+    term = sgqlc.types.Field(String, graphql_name='term')
+
+
 class IdentityFilterType(sgqlc.types.Input):
     __schema__ = sh_schema
     __field_names__ = ('uuid', 'is_locked')
@@ -132,6 +139,13 @@ class AddOrganization(sgqlc.types.Type):
     __schema__ = sh_schema
     __field_names__ = ('organization',)
     organization = sgqlc.types.Field('OrganizationType', graphql_name='organization')
+
+
+class CountryPaginatedType(sgqlc.types.Type):
+    __schema__ = sh_schema
+    __field_names__ = ('entities', 'page_info')
+    entities = sgqlc.types.Field(sgqlc.types.list_of('CountryType'), graphql_name='entities')
+    page_info = sgqlc.types.Field('PaginationType', graphql_name='pageInfo')
 
 
 class CountryType(sgqlc.types.Type):
@@ -312,7 +326,14 @@ class ProfileType(sgqlc.types.Type):
 
 class Query(sgqlc.types.Type):
     __schema__ = sh_schema
-    __field_names__ = ('organizations', 'uidentities', 'transactions', 'operations')
+    __field_names__ = ('countries', 'organizations', 'uidentities', 'transactions', 'operations')
+    countries = sgqlc.types.Field(
+        CountryPaginatedType, graphql_name='countries', args=sgqlc.types.ArgDict((
+            ('page_size', sgqlc.types.Arg(Int, graphql_name='pageSize', default=None)),
+            ('page', sgqlc.types.Arg(Int, graphql_name='page', default=None)),
+            ('filters', sgqlc.types.Arg(CountryFilterType, graphql_name='filters', default=None)),
+        ))
+    )
     organizations = sgqlc.types.Field(
         OrganizationPaginatedType, graphql_name='organizations', args=sgqlc.types.ArgDict((
             ('page_size', sgqlc.types.Arg(Int, graphql_name='pageSize', default=None)),

--- a/sortinghat/cli/cmds/countries.py
+++ b/sortinghat/cli/cmds/countries.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import click
+
+from sgqlc.operation import Operation
+
+from ..client import SortingHatSchema
+from ..utils import (connect,
+                     display,
+                     sh_client_cmd_options,
+                     sh_client)
+
+
+def validate_code(ctx, param, value):
+    if value is None:
+        return None
+    elif len(value) == 2 and value.isalpha():
+        return value
+    else:
+        msg = "country code must be a 2 alpha characters long"
+        raise click.BadParameter(msg)
+
+
+def validate_term(ctx, param, value):
+    if value is None:
+        return None
+    elif len(value) > 2:
+        return value
+    else:
+        msg = "term must be at least 3 characters long"
+        raise click.BadParameter(msg)
+
+
+@click.command()
+@sh_client_cmd_options
+@click.option('--code', callback=validate_code,
+              help="Country code to search for.")
+@click.option('--term', callback=validate_term,
+              help="Look for countries which match this term.")
+@sh_client
+def countries(ctx, code, term, **extra):
+    """Show information about countries.
+
+    This command displays information related to the countries
+    stored in the registry.
+
+    When <code> or <term> are given, the command will look for
+    those countries that match the criteria. Take into account
+    <code> is a country identifier composed by two letters
+    (e.g ES or US).
+    """
+    with connect(ctx.obj) as conn:
+        for cs in _fetch_countries(conn, code=code, term=term):
+            display('countries.tmpl', nl=False, countries=cs)
+
+
+def _fetch_countries(client, **kwargs):
+    """Run a server operation to get the list of countries."""
+
+    filters = {k: v for k, v in kwargs.items() if v is not None}
+    page = 1
+    paginate = True
+
+    while paginate:
+        op = _generate_countries_operation(page, filters)
+
+        result = client.execute(op)
+
+        data = op + result
+        paginate = data.countries.page_info.has_next
+        page += 1
+        yield data.countries.entities
+
+
+def _generate_countries_operation(page, filters):
+    """Define an operation to get the list of countries."""
+
+    args = {
+        'page': page
+    }
+
+    if filters:
+        args['filters'] = filters
+
+    op = Operation(SortingHatSchema.Query)
+    op.countries(**args)
+
+    # Select page information
+    op.countries().page_info.has_next()
+
+    # Select countries information
+    country = op.countries().entities()
+
+    country.code()
+    country.name()
+
+    return op

--- a/sortinghat/cli/sortinghat.py
+++ b/sortinghat/cli/sortinghat.py
@@ -28,6 +28,7 @@ from .cmds.config import (config,
                           CONFIG_OPTIONS,
                           SORTINGHAT_CFG_FILE_NAME,
                           SORTINGHAT_CFG_DIR_NAME)
+from .cmds.countries import countries
 from .cmds.enroll import enroll
 from .cmds.lock import lock
 from .cmds.merge import merge
@@ -75,6 +76,7 @@ sortinghat.add_command(split)
 sortinghat.add_command(lock)
 sortinghat.add_command(show)
 sortinghat.add_command(orgs)
+sortinghat.add_command(countries)
 
 
 def _read_config_file(filepath):

--- a/sortinghat/cli/templates/countries.tmpl
+++ b/sortinghat/cli/templates/countries.tmpl
@@ -1,0 +1,3 @@
+{% for country in countries %}
+{{ country.code }}	{{ country.name }}
+{% endfor -%}

--- a/sortinghat/core/fixtures/countries.json
+++ b/sortinghat/core/fixtures/countries.json
@@ -1,0 +1,1994 @@
+[
+    {
+        "fields": {
+            "alpha3": "AFG",
+            "code": "AF",
+            "name": "Afghanistan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ALA",
+            "code": "AX",
+            "name": "\u00c5land Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ALB",
+            "code": "AL",
+            "name": "Albania"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "DZA",
+            "code": "DZ",
+            "name": "Algeria"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ASM",
+            "code": "AS",
+            "name": "American Samoa"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "AND",
+            "code": "AD",
+            "name": "Andorra"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "AGO",
+            "code": "AO",
+            "name": "Angola"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "AIA",
+            "code": "AI",
+            "name": "Anguilla"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ATA",
+            "code": "AQ",
+            "name": "Antarctica"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ATG",
+            "code": "AG",
+            "name": "Antigua and Barbuda"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ARG",
+            "code": "AR",
+            "name": "Argentina"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ARM",
+            "code": "AM",
+            "name": "Armenia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ABW",
+            "code": "AW",
+            "name": "Aruba"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "AUS",
+            "code": "AU",
+            "name": "Australia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "AUT",
+            "code": "AT",
+            "name": "Austria"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "AZE",
+            "code": "AZ",
+            "name": "Azerbaijan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BHS",
+            "code": "BS",
+            "name": "Bahamas"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BHR",
+            "code": "BH",
+            "name": "Bahrain"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BGD",
+            "code": "BD",
+            "name": "Bangladesh"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BRB",
+            "code": "BB",
+            "name": "Barbados"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BLR",
+            "code": "BY",
+            "name": "Belarus"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BEL",
+            "code": "BE",
+            "name": "Belgium"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BLZ",
+            "code": "BZ",
+            "name": "Belize"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BEN",
+            "code": "BJ",
+            "name": "Benin"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BMU",
+            "code": "BM",
+            "name": "Bermuda"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BTN",
+            "code": "BT",
+            "name": "Bhutan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BOL",
+            "code": "BO",
+            "name": "Bolivia (Plurinational State of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BES",
+            "code": "BQ",
+            "name": "Bonaire, Sint Eustatius and Saba"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BIH",
+            "code": "BA",
+            "name": "Bosnia and Herzegovina"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BWA",
+            "code": "BW",
+            "name": "Botswana"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BVT",
+            "code": "BV",
+            "name": "Bouvet Island"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BRA",
+            "code": "BR",
+            "name": "Brazil"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "IOT",
+            "code": "IO",
+            "name": "British Indian Ocean Territory"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BRN",
+            "code": "BN",
+            "name": "Brunei Darussalam"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BGR",
+            "code": "BG",
+            "name": "Bulgaria"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BFA",
+            "code": "BF",
+            "name": "Burkina Faso"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BDI",
+            "code": "BI",
+            "name": "Burundi"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KHM",
+            "code": "KH",
+            "name": "Cambodia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CMR",
+            "code": "CM",
+            "name": "Cameroon"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CAN",
+            "code": "CA",
+            "name": "Canada"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CPV",
+            "code": "CV",
+            "name": "Cabo Verde"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CYM",
+            "code": "KY",
+            "name": "Cayman Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CAF",
+            "code": "CF",
+            "name": "Central African Republic"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TCD",
+            "code": "TD",
+            "name": "Chad"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CHL",
+            "code": "CL",
+            "name": "Chile"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CHN",
+            "code": "CN",
+            "name": "China"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CXR",
+            "code": "CX",
+            "name": "Christmas Island"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CCK",
+            "code": "CC",
+            "name": "Cocos (Keeling) Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "COL",
+            "code": "CO",
+            "name": "Colombia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "COM",
+            "code": "KM",
+            "name": "Comoros"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "COG",
+            "code": "CG",
+            "name": "Congo"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "COD",
+            "code": "CD",
+            "name": "Congo (Democratic Republic of the)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "COK",
+            "code": "CK",
+            "name": "Cook Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CRI",
+            "code": "CR",
+            "name": "Costa Rica"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CIV",
+            "code": "CI",
+            "name": "C\u00f4te d'Ivoire"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "HRV",
+            "code": "HR",
+            "name": "Croatia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CUB",
+            "code": "CU",
+            "name": "Cuba"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CUW",
+            "code": "CW",
+            "name": "Cura\u00e7ao"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CYP",
+            "code": "CY",
+            "name": "Cyprus"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CZE",
+            "code": "CZ",
+            "name": "Czech Republic"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "DNK",
+            "code": "DK",
+            "name": "Denmark"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "DJI",
+            "code": "DJ",
+            "name": "Djibouti"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "DMA",
+            "code": "DM",
+            "name": "Dominica"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "DOM",
+            "code": "DO",
+            "name": "Dominican Republic"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ECU",
+            "code": "EC",
+            "name": "Ecuador"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "EGY",
+            "code": "EG",
+            "name": "Egypt"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SLV",
+            "code": "SV",
+            "name": "El Salvador"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GNQ",
+            "code": "GQ",
+            "name": "Equatorial Guinea"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ERI",
+            "code": "ER",
+            "name": "Eritrea"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "EST",
+            "code": "EE",
+            "name": "Estonia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ETH",
+            "code": "ET",
+            "name": "Ethiopia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "FLK",
+            "code": "FK",
+            "name": "Falkland Islands (Malvinas)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "FRO",
+            "code": "FO",
+            "name": "Faroe Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "FJI",
+            "code": "FJ",
+            "name": "Fiji"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "FIN",
+            "code": "FI",
+            "name": "Finland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "FRA",
+            "code": "FR",
+            "name": "France"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GUF",
+            "code": "GF",
+            "name": "French Guiana"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PYF",
+            "code": "PF",
+            "name": "French Polynesia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ATF",
+            "code": "TF",
+            "name": "French Southern Territories"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GAB",
+            "code": "GA",
+            "name": "Gabon"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GMB",
+            "code": "GM",
+            "name": "Gambia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GEO",
+            "code": "GE",
+            "name": "Georgia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "DEU",
+            "code": "DE",
+            "name": "Germany"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GHA",
+            "code": "GH",
+            "name": "Ghana"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GIB",
+            "code": "GI",
+            "name": "Gibraltar"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GRC",
+            "code": "GR",
+            "name": "Greece"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GRL",
+            "code": "GL",
+            "name": "Greenland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GRD",
+            "code": "GD",
+            "name": "Grenada"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GLP",
+            "code": "GP",
+            "name": "Guadeloupe"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GUM",
+            "code": "GU",
+            "name": "Guam"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GTM",
+            "code": "GT",
+            "name": "Guatemala"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GGY",
+            "code": "GG",
+            "name": "Guernsey"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GIN",
+            "code": "GN",
+            "name": "Guinea"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GNB",
+            "code": "GW",
+            "name": "Guinea-Bissau"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GUY",
+            "code": "GY",
+            "name": "Guyana"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "HTI",
+            "code": "HT",
+            "name": "Haiti"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "HMD",
+            "code": "HM",
+            "name": "Heard Island and McDonald Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "VAT",
+            "code": "VA",
+            "name": "Holy See"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "HND",
+            "code": "HN",
+            "name": "Honduras"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "HKG",
+            "code": "HK",
+            "name": "Hong Kong"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "HUN",
+            "code": "HU",
+            "name": "Hungary"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ISL",
+            "code": "IS",
+            "name": "Iceland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "IND",
+            "code": "IN",
+            "name": "India"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "IDN",
+            "code": "ID",
+            "name": "Indonesia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "IRN",
+            "code": "IR",
+            "name": "Iran (Islamic Republic of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "IRQ",
+            "code": "IQ",
+            "name": "Iraq"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "IRL",
+            "code": "IE",
+            "name": "Ireland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "IMN",
+            "code": "IM",
+            "name": "Isle of Man"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ISR",
+            "code": "IL",
+            "name": "Israel"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ITA",
+            "code": "IT",
+            "name": "Italy"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "JAM",
+            "code": "JM",
+            "name": "Jamaica"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "JPN",
+            "code": "JP",
+            "name": "Japan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "JEY",
+            "code": "JE",
+            "name": "Jersey"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "JOR",
+            "code": "JO",
+            "name": "Jordan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KAZ",
+            "code": "KZ",
+            "name": "Kazakhstan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KEN",
+            "code": "KE",
+            "name": "Kenya"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KIR",
+            "code": "KI",
+            "name": "Kiribati"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PRK",
+            "code": "KP",
+            "name": "Korea (Democratic People's Republic of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KOR",
+            "code": "KR",
+            "name": "Korea (Republic of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KWT",
+            "code": "KW",
+            "name": "Kuwait"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KGZ",
+            "code": "KG",
+            "name": "Kyrgyzstan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LAO",
+            "code": "LA",
+            "name": "Lao People's Democratic Republic"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LVA",
+            "code": "LV",
+            "name": "Latvia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LBN",
+            "code": "LB",
+            "name": "Lebanon"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LSO",
+            "code": "LS",
+            "name": "Lesotho"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LBR",
+            "code": "LR",
+            "name": "Liberia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LBY",
+            "code": "LY",
+            "name": "Libya"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LIE",
+            "code": "LI",
+            "name": "Liechtenstein"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LTU",
+            "code": "LT",
+            "name": "Lithuania"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LUX",
+            "code": "LU",
+            "name": "Luxembourg"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MAC",
+            "code": "MO",
+            "name": "Macao"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MKD",
+            "code": "MK",
+            "name": "Macedonia (the former Yugoslav Republic of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MDG",
+            "code": "MG",
+            "name": "Madagascar"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MWI",
+            "code": "MW",
+            "name": "Malawi"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MYS",
+            "code": "MY",
+            "name": "Malaysia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MDV",
+            "code": "MV",
+            "name": "Maldives"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MLI",
+            "code": "ML",
+            "name": "Mali"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MLT",
+            "code": "MT",
+            "name": "Malta"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MHL",
+            "code": "MH",
+            "name": "Marshall Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MTQ",
+            "code": "MQ",
+            "name": "Martinique"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MRT",
+            "code": "MR",
+            "name": "Mauritania"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MUS",
+            "code": "MU",
+            "name": "Mauritius"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MYT",
+            "code": "YT",
+            "name": "Mayotte"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MEX",
+            "code": "MX",
+            "name": "Mexico"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "FSM",
+            "code": "FM",
+            "name": "Micronesia (Federated States of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MDA",
+            "code": "MD",
+            "name": "Moldova (Republic of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MCO",
+            "code": "MC",
+            "name": "Monaco"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MNG",
+            "code": "MN",
+            "name": "Mongolia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MNE",
+            "code": "ME",
+            "name": "Montenegro"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MSR",
+            "code": "MS",
+            "name": "Montserrat"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MAR",
+            "code": "MA",
+            "name": "Morocco"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MOZ",
+            "code": "MZ",
+            "name": "Mozambique"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MMR",
+            "code": "MM",
+            "name": "Myanmar"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NAM",
+            "code": "NA",
+            "name": "Namibia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NRU",
+            "code": "NR",
+            "name": "Nauru"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NPL",
+            "code": "NP",
+            "name": "Nepal"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NLD",
+            "code": "NL",
+            "name": "Netherlands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NCL",
+            "code": "NC",
+            "name": "New Caledonia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NZL",
+            "code": "NZ",
+            "name": "New Zealand"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NIC",
+            "code": "NI",
+            "name": "Nicaragua"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NER",
+            "code": "NE",
+            "name": "Niger"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NGA",
+            "code": "NG",
+            "name": "Nigeria"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NIU",
+            "code": "NU",
+            "name": "Niue"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NFK",
+            "code": "NF",
+            "name": "Norfolk Island"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MNP",
+            "code": "MP",
+            "name": "Northern Mariana Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "NOR",
+            "code": "NO",
+            "name": "Norway"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "OMN",
+            "code": "OM",
+            "name": "Oman"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PAK",
+            "code": "PK",
+            "name": "Pakistan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PLW",
+            "code": "PW",
+            "name": "Palau"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PSE",
+            "code": "PS",
+            "name": "Palestina, State of"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PAN",
+            "code": "PA",
+            "name": "Panama"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PNG",
+            "code": "PG",
+            "name": "Papua New Guinea"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PRY",
+            "code": "PY",
+            "name": "Paraguay"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PER",
+            "code": "PE",
+            "name": "Peru"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PHL",
+            "code": "PH",
+            "name": "Philippines"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PCN",
+            "code": "PN",
+            "name": "Pitcairn"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "POL",
+            "code": "PL",
+            "name": "Poland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PRT",
+            "code": "PT",
+            "name": "Portugal"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "PRI",
+            "code": "PR",
+            "name": "Puerto Rico"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "QAT",
+            "code": "QA",
+            "name": "Qatar"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "REU",
+            "code": "RE",
+            "name": "R\u00e9union"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ROU",
+            "code": "RO",
+            "name": "Romania"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "RUS",
+            "code": "RU",
+            "name": "Russian Federation"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "RWA",
+            "code": "RW",
+            "name": "Rwanda"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "BLM",
+            "code": "BL",
+            "name": "Saint Barth\u00e9lemy"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SHN",
+            "code": "SH",
+            "name": "Saint Helena, Ascension and Tristan da Cunha"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "KNA",
+            "code": "KN",
+            "name": "Saint Kitts and Nevis"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LCA",
+            "code": "LC",
+            "name": "Saint Lucia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "MAF",
+            "code": "MF",
+            "name": "Saint Martin (French part)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SPM",
+            "code": "PM",
+            "name": "Saint Pierre and Miquelon"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "VCT",
+            "code": "VC",
+            "name": "Saint Vincent and the Grenadines"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "WSM",
+            "code": "WS",
+            "name": "Samoa"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SMR",
+            "code": "SM",
+            "name": "San Marino"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "STP",
+            "code": "ST",
+            "name": "Sao Tome and Principe"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SAU",
+            "code": "SA",
+            "name": "Saudi Arabia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SEN",
+            "code": "SN",
+            "name": "Senegal"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SRB",
+            "code": "RS",
+            "name": "Serbia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SYC",
+            "code": "SC",
+            "name": "Seychelles"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SLE",
+            "code": "SL",
+            "name": "Sierra Leone"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SGP",
+            "code": "SG",
+            "name": "Singapore"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SXM",
+            "code": "SX",
+            "name": "Sint Maarten (Dutch part)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SVK",
+            "code": "SK",
+            "name": "Slovakia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SVN",
+            "code": "SI",
+            "name": "Slovenia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SLB",
+            "code": "SB",
+            "name": "Solomon Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SOM",
+            "code": "SO",
+            "name": "Somalia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ZAF",
+            "code": "ZA",
+            "name": "South Africa"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SGS",
+            "code": "GS",
+            "name": "South Georgia and the South Sandwich Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SSD",
+            "code": "SS",
+            "name": "South Sudan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ESP",
+            "code": "ES",
+            "name": "Spain"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "LKA",
+            "code": "LK",
+            "name": "Sri Lanka"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SDN",
+            "code": "SD",
+            "name": "Sudan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SUR",
+            "code": "SR",
+            "name": "Suriname"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SJM",
+            "code": "SJ",
+            "name": "Svalbard and Jan Mayen"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SWZ",
+            "code": "SZ",
+            "name": "Swaziland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SWE",
+            "code": "SE",
+            "name": "Sweden"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "CHE",
+            "code": "CH",
+            "name": "Switzerland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "SYR",
+            "code": "SY",
+            "name": "Syrian Arab Republic"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TWN",
+            "code": "TW",
+            "name": "Taiwan, Province of China"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TJK",
+            "code": "TJ",
+            "name": "Tajikistan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TZA",
+            "code": "TZ",
+            "name": "Tanzania, United Republic of"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "THA",
+            "code": "TH",
+            "name": "Thailand"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TLS",
+            "code": "TL",
+            "name": "Timor-Leste"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TGO",
+            "code": "TG",
+            "name": "Togo"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TKL",
+            "code": "TK",
+            "name": "Tokelau"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TON",
+            "code": "TO",
+            "name": "Tonga"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TTO",
+            "code": "TT",
+            "name": "Trinidad and Tobago"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TUN",
+            "code": "TN",
+            "name": "Tunisia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TUR",
+            "code": "TR",
+            "name": "Turkey"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TKM",
+            "code": "TM",
+            "name": "Turkmenistan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TCA",
+            "code": "TC",
+            "name": "Turks and Caicos Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "TUV",
+            "code": "TV",
+            "name": "Tuvalu"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "UGA",
+            "code": "UG",
+            "name": "Uganda"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "UKR",
+            "code": "UA",
+            "name": "Ukraine"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ARE",
+            "code": "AE",
+            "name": "United Arab Emirates"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "GBR",
+            "code": "GB",
+            "name": "United Kingdom of Great Britain and Northern Ireland"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "USA",
+            "code": "US",
+            "name": "United States of America"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "UMI",
+            "code": "UM",
+            "name": "United States Minor Outlying Islands"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "URY",
+            "code": "UY",
+            "name": "Uruguay"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "UZB",
+            "code": "UZ",
+            "name": "Uzbekistan"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "VUT",
+            "code": "VU",
+            "name": "Vanuatu"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "VEN",
+            "code": "VE",
+            "name": "Venezuela (Bolivarian Republic of)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "VNM",
+            "code": "VN",
+            "name": "Viet Nam"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "VGB",
+            "code": "VG",
+            "name": "Virgin Islands (British)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "VIR",
+            "code": "VI",
+            "name": "Virgin Islands (U.S.)"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "WLF",
+            "code": "WF",
+            "name": "Wallis and Futuna"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ESH",
+            "code": "EH",
+            "name": "Western Sahara"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "YEM",
+            "code": "YE",
+            "name": "Yemen"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ZMB",
+            "code": "ZM",
+            "name": "Zambia"
+        },
+        "model": "core.country"
+    },
+    {
+        "fields": {
+            "alpha3": "ZWE",
+            "code": "ZW",
+            "name": "Zimbabwe"
+        },
+        "model": "core.country"
+    }
+]

--- a/tests/cli/test_cmd_countries.py
+++ b/tests/cli/test_cmd_countries.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import unittest
+import unittest.mock
+
+import click.testing
+
+from sortinghat.cli.client import SortingHatClientError
+from sortinghat.cli.cmds.countries import countries
+
+
+COUNTRIES_CMD_OP = """query {{
+  countries({}) {{
+    pageInfo {{
+      hasNext
+    }}
+    entities {{
+      code
+      name
+    }}
+  }}
+}}"""
+
+COUNTRIES_OUTPUT = """ES\tSpain
+GB\tUnited Kingdom
+US\tUnited States of America
+"""
+
+COUNTRIES_CODE_OUTPUT = """ES\tSpain\n"""
+
+COUNTRIES_TERM_OUTPUT = """GB\tUnited Kingdom
+US\tUnited States of America
+"""
+
+COUNTRIES_EMPTY_OUTPUT = """"""
+
+COUNTRIES_UKNOWN_ERROR = (
+    "unknown error"
+)
+
+COUNTRIES_CODE_ERROR = (
+    "Error: Invalid value for '--code': "
+    "country code must be a 2 alpha characters long"
+)
+COUNTRIES_TERM_ERROR = (
+    "Error: Invalid value for '--term': "
+    "term must be at least 3 characters long"
+)
+
+
+class MockClient:
+    """Mock client"""
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.ops = []
+
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def execute(self, operation):
+        self.ops.append(operation)
+        response = self.responses.pop(0)
+
+        if isinstance(response, SortingHatClientError):
+            raise response
+        else:
+            return response
+
+
+class TestCountriesCommand(unittest.TestCase):
+    """Countries command unit tests"""
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_countries(self, mock_client):
+        """Check if it displays information of countries"""
+
+        # Split entities into pages
+        responses = [
+            {
+                'data': {
+                    'countries': {
+                        'pageInfo': {'hasNext': True},
+                        'entities': [
+                            {
+                                'code': 'ES',
+                                'name': 'Spain'
+                            },
+                            {
+                                'code': 'GB',
+                                'name': 'United Kingdom'
+                            }
+                        ]
+                    }
+                }
+            },
+            {
+                'data': {
+                    'countries': {
+                        'pageInfo': {'hasNext': False},
+                        'entities': [
+                            {
+                                'code': 'US',
+                                'name': 'United States of America'
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(countries)
+
+        self.assertEqual(len(client.ops), 2)
+        expected = COUNTRIES_CMD_OP.format('page: 1')
+        op = str(client.ops[0])
+        self.assertEqual(op, expected)
+
+        expected = COUNTRIES_CMD_OP.format('page: 2')
+        op = str(client.ops[1])
+        self.assertEqual(op, expected)
+
+        self.assertEqual(result.stdout, COUNTRIES_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_countries_code(self, mock_client):
+        """Check if it displays information of countries when code is set"""
+
+        # Split entities into pages
+        responses = [
+            {
+                'data': {
+                    'countries': {
+                        'pageInfo': {'hasNext': False},
+                        'entities': [
+                            {
+                                'code': 'ES',
+                                'name': 'Spain'
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        params = ['--code', 'ES']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(len(client.ops), 1)
+
+        filters = 'page: {}, filters: {{code: "{}"}}'
+        filters = filters.format('1', 'ES')
+        expected = COUNTRIES_CMD_OP.format(filters)
+        op = str(client.ops[0])
+        self.assertEqual(op, expected)
+
+        self.assertEqual(result.stdout, COUNTRIES_CODE_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_countries_invalid_code(self):
+        """Check if it fails when code is invalid"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = ['--code', 'E']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(result.stderr.split('\n')[-2],
+                         COUNTRIES_CODE_ERROR)
+        self.assertEqual(result.exit_code, 2)
+
+        params = ['--code', '']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(result.stderr.split('\n')[-2],
+                         COUNTRIES_CODE_ERROR)
+        self.assertEqual(result.exit_code, 2)
+
+        params = ['--code', 'AAA']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(result.stderr.split('\n')[-2],
+                         COUNTRIES_CODE_ERROR)
+        self.assertEqual(result.exit_code, 2)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_countries_term(self, mock_client):
+        """Check if it displays information of countries when term is set"""
+
+        # Split entities into pages
+        responses = [
+            {
+                'data': {
+                    'countries': {
+                        'pageInfo': {'hasNext': False},
+                        'entities': [
+                            {
+                                'code': 'GB',
+                                'name': 'United Kingdom'
+                            },
+                            {
+                                'code': 'US',
+                                'name': 'United States of America'
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        params = ['--term', 'unit']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(len(client.ops), 1)
+
+        filters = 'page: {}, filters: {{term: "{}"}}'
+        filters = filters.format('1', 'unit')
+        expected = COUNTRIES_CMD_OP.format(filters)
+        op = str(client.ops[0])
+        self.assertEqual(op, expected)
+
+        self.assertEqual(result.stdout, COUNTRIES_TERM_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    def test_countries_invalid_term(self):
+        """Check if it fails when term is invalid"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        params = ['--term', 'E']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(result.stderr.split('\n')[-2],
+                         COUNTRIES_TERM_ERROR)
+        self.assertEqual(result.exit_code, 2)
+
+        params = ['--term', '']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(result.stderr.split('\n')[-2],
+                         COUNTRIES_TERM_ERROR)
+        self.assertEqual(result.exit_code, 2)
+
+        params = ['--term', 'AA']
+        result = runner.invoke(countries, params)
+
+        self.assertEqual(result.stderr.split('\n')[-2],
+                         COUNTRIES_TERM_ERROR)
+        self.assertEqual(result.exit_code, 2)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_countries_empty(self, mock_client):
+        """Check if it displays an empty list of countries"""
+
+        responses = [
+            {
+                'data': {
+                    'countries': {
+                        'pageInfo': {'hasNext': False},
+                        'entities': []
+                    }
+                }
+            }
+        ]
+
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner()
+
+        result = runner.invoke(countries)
+
+        self.assertEqual(len(client.ops), 1)
+
+        expected = COUNTRIES_CMD_OP.format('page: 1')
+        op = str(client.ops[0])
+        self.assertEqual(op, expected)
+
+        self.assertEqual(result.stdout, COUNTRIES_EMPTY_OUTPUT)
+        self.assertEqual(result.exit_code, 0)
+
+    @unittest.mock.patch('sortinghat.cli.utils.SortingHatClient')
+    def test_error(self, mock_client):
+        """"Check if it fails when an error is sent by the server"""
+
+        error = {
+            'message': COUNTRIES_UKNOWN_ERROR,
+            'extensions': {
+                'code': 128
+            }
+        }
+
+        responses = [
+            SortingHatClientError(error['message'], errors=[error])
+        ]
+        client = MockClient(responses)
+        mock_client.return_value = client
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        result = runner.invoke(countries)
+
+        expected = COUNTRIES_CMD_OP.format('page: 1')
+        self.assertEqual(len(client.ops), 1)
+        self.assertEqual(str(client.ops[0]), expected)
+
+        expected_err = "Error: " + COUNTRIES_UKNOWN_ERROR + '\n'
+        self.assertEqual(result.stderr, expected_err)
+        self.assertEqual(result.exit_code, 128)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds three functionalities. First, it adds the list of countries that we have in the master branch. This list has been added as a fixture. Therefore, when the database is created, the list of countries can be imported using the command:

```
$ manage.py loaddata --settings <filename> countries.json
```

Second, it adds the GraphQL query `countries` to fetch the list of countries stored on the system.

Finally, the command `countries` has been also added to the client to display this list. This command allows to filter countries using the options `--code` and `--term`.

Fixes #285 