### PR TITLE
Rename mutations referencing identities

### DIFF
--- a/sortinghat/cli/client/schema.py
+++ b/sortinghat/cli/client/schema.py
@@ -228,7 +228,7 @@ class IdentityType(sgqlc.types.Type):
     individual = sgqlc.types.Field(sgqlc.types.non_null('IndividualType'), graphql_name='individual')
 
 
-class LockIdentity(sgqlc.types.Type):
+class Lock(sgqlc.types.Type):
     __schema__ = sh_schema
     __field_names__ = ('uuid', 'individual')
     uuid = sgqlc.types.Field(String, graphql_name='uuid')
@@ -375,7 +375,7 @@ class SortingHatMutation(sgqlc.types.Type):
     __schema__ = sh_schema
     __field_names__ = (
         'add_organization', 'delete_organization', 'add_domain', 'delete_domain', 'add_identity',
-        'delete_identity', 'update_profile', 'move_identity', 'lock_identity', 'unlock_identity',
+        'delete_identity', 'update_profile', 'move_identity', 'lock', 'unlock',
         'merge', 'unmerge_identities', 'enroll', 'withdraw',
         'token_auth', 'verify_token', 'refresh_token'
     )
@@ -428,13 +428,13 @@ class SortingHatMutation(sgqlc.types.Type):
             ('to_uuid', sgqlc.types.Arg(String, graphql_name='toUuid', default=None)),
         ))
     )
-    lock_identity = sgqlc.types.Field(
-        LockIdentity, graphql_name='lockIdentity', args=sgqlc.types.ArgDict((
+    lock = sgqlc.types.Field(
+        Lock, graphql_name='lock', args=sgqlc.types.ArgDict((
             ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
         ))
     )
-    unlock_identity = sgqlc.types.Field(
-        'UnlockIdentity', graphql_name='unlockIdentity', args=sgqlc.types.ArgDict((
+    unlock = sgqlc.types.Field(
+        'Unlock', graphql_name='unlock', args=sgqlc.types.ArgDict((
             ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
         ))
     )
@@ -515,7 +515,7 @@ class IndividualType(sgqlc.types.Type):
     enrollments = sgqlc.types.Field(sgqlc.types.list_of(EnrollmentType), graphql_name='enrollments')
 
 
-class UnlockIdentity(sgqlc.types.Type):
+class Unlock(sgqlc.types.Type):
     __schema__ = sh_schema
     __field_names__ = ('uuid', 'individual')
     uuid = sgqlc.types.Field(String, graphql_name='uuid')

--- a/sortinghat/cli/client/schema.py
+++ b/sortinghat/cli/client/schema.py
@@ -235,7 +235,7 @@ class LockIdentity(sgqlc.types.Type):
     individual = sgqlc.types.Field('IndividualType', graphql_name='individual')
 
 
-class MergeIdentities(sgqlc.types.Type):
+class Merge(sgqlc.types.Type):
     __schema__ = sh_schema
     __field_names__ = ('uuid', 'individual')
     uuid = sgqlc.types.Field(String, graphql_name='uuid')
@@ -376,7 +376,7 @@ class SortingHatMutation(sgqlc.types.Type):
     __field_names__ = (
         'add_organization', 'delete_organization', 'add_domain', 'delete_domain', 'add_identity',
         'delete_identity', 'update_profile', 'move_identity', 'lock_identity', 'unlock_identity',
-        'merge_identities', 'unmerge_identities', 'enroll', 'withdraw',
+        'merge', 'unmerge_identities', 'enroll', 'withdraw',
         'token_auth', 'verify_token', 'refresh_token'
     )
     add_organization = sgqlc.types.Field(
@@ -438,8 +438,8 @@ class SortingHatMutation(sgqlc.types.Type):
             ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
         ))
     )
-    merge_identities = sgqlc.types.Field(
-        MergeIdentities, graphql_name='mergeIdentities', args=sgqlc.types.ArgDict((
+    merge = sgqlc.types.Field(
+        Merge, graphql_name='merge', args=sgqlc.types.ArgDict((
             ('from_uuids', sgqlc.types.Arg(sgqlc.types.list_of(String), graphql_name='fromUuids', default=None)),
             ('to_uuid', sgqlc.types.Arg(String, graphql_name='toUuid', default=None)),
         ))

--- a/sortinghat/cli/cmds/lock.py
+++ b/sortinghat/cli/cmds/lock.py
@@ -63,12 +63,12 @@ def _lock_identity(conn, **kwargs):
     args = {k: v for k, v in kwargs.items() if v is not None}
 
     op = Operation(SortingHatSchema.SortingHatMutation)
-    op.lock_identity(**args)
-    op.lock_identity.uuid()
+    op.lock(**args)
+    op.lock.uuid()
 
     result = conn.execute(op)
 
-    return result['data']['lockIdentity']['uuid']
+    return result['data']['lock']['uuid']
 
 
 @lock.command()
@@ -85,19 +85,19 @@ def rm(client, uuid):
     UUID: identifier of the individual which will be unlocked
     """
     with connect(client) as conn:
-        _unlock_identity(conn, uuid=uuid)
+        _unlock_individual(conn, uuid=uuid)
         display('lock.tmpl', uuid=uuid, unlocked=True)
 
 
-def _unlock_identity(conn, **kwargs):
+def _unlock_individual(conn, **kwargs):
     """Run a server operation to unlock an individual."""
 
     args = {k: v for k, v in kwargs.items() if v is not None}
 
     op = Operation(SortingHatSchema.SortingHatMutation)
-    op.unlock_identity(**args)
-    op.unlock_identity.uuid()
+    op.unlock(**args)
+    op.unlock.uuid()
 
     result = conn.execute(op)
 
-    return result['data']['unlockIdentity']['uuid']
+    return result['data']['unlock']['uuid']

--- a/sortinghat/cli/cmds/merge.py
+++ b/sortinghat/cli/cmds/merge.py
@@ -57,19 +57,19 @@ def merge(ctx, to_uuid, from_uuid, **extra):
     FROM_UUID: individual to merge
     """
     with connect(ctx.obj) as conn:
-        _merge_identities(conn, from_uuids=list(from_uuid),
-                          to_uuid=to_uuid)
+        _merge_individuals(conn, from_uuids=list(from_uuid),
+                           to_uuid=to_uuid)
 
 
-def _merge_identities(conn, **kwargs):
-    """Run a server operation to merge identities."""
+def _merge_individuals(conn, **kwargs):
+    """Run a server operation to merge individuals."""
 
     args = {k: v for k, v in kwargs.items() if v is not None}
 
     op = Operation(SortingHatSchema.SortingHatMutation)
-    op.merge_identities(**args)
-    op.merge_identities.uuid()
+    op.merge(**args)
+    op.merge.uuid()
 
     result = conn.execute(op)
 
-    return result['data']['mergeIdentities']['uuid']
+    return result['data']['merge']['uuid']

--- a/sortinghat/core/api.py
+++ b/sortinghat/core/api.py
@@ -821,18 +821,19 @@ def withdraw(ctx, uuid, organization, from_date=None, to_date=None):
 
 
 @django.db.transaction.atomic
-def merge_identities(ctx, from_uuids, to_uuid):
+def merge(ctx, from_uuids, to_uuid):
     """
     Merge one or more individuals into another.
 
-    Use this function to join a list of `from_uuid` individuals into
-    `to_uuid`. Identities and enrollments related to each `from_uuid` will be
-    assigned to `to_uuid`. In addition, each `from_uuid` will be removed
-    from the registry. Duplicated enrollments will be also removed from
-    the registry while overlapped enrollments will be merged.
+    Use this function to join a list of individuals, defined in `from_uuid`
+    by any of their valid identities ids, into `to_uuid` individual.
+    Identities and enrollments related to each `from_uuid` will be assigned
+    to `to_uuid`. In addition, each `from_uuid` will be removed from the
+    registry. Duplicated enrollments will be also removed from the registry
+    while overlapped enrollments will be merged.
 
-    Take into account that individuals are identified by any of
-    UUIDs assigned to their identities.
+    Take into account that individuals are identified by any of the UUIDs
+    assigned to their identities.
 
     This function also merges two or more profiles. When a field on `to_uuid`
     profile is `None` or empty, it will be updated with the value on the
@@ -961,7 +962,7 @@ def merge_identities(ctx, from_uuids, to_uuid):
     if to_uuid == '':
         raise InvalidValueError(msg="'to_uuid' cannot be an empty string")
 
-    trxl = TransactionsLog.open('merge_identities', ctx)
+    trxl = TransactionsLog.open('merge', ctx)
 
     try:
         to_individual = find_individual_by_uuid(to_uuid)

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -353,7 +353,7 @@ class DeleteIdentity(graphene.Mutation):
         )
 
 
-class LockIdentity(graphene.Mutation):
+class Lock(graphene.Mutation):
     class Arguments:
         uuid = graphene.String()
 
@@ -367,13 +367,13 @@ class LockIdentity(graphene.Mutation):
 
         individual = lock(ctx, uuid)
 
-        return LockIdentity(
+        return Lock(
             uuid=uuid,
             individual=individual
         )
 
 
-class UnlockIdentity(graphene.Mutation):
+class Unlock(graphene.Mutation):
     class Arguments:
         uuid = graphene.String()
 
@@ -387,7 +387,7 @@ class UnlockIdentity(graphene.Mutation):
 
         individual = unlock(ctx, uuid)
 
-        return UnlockIdentity(
+        return Unlock(
             uuid=uuid,
             individual=individual
         )
@@ -663,8 +663,8 @@ class SortingHatMutation(graphene.ObjectType):
     delete_identity = DeleteIdentity.Field()
     update_profile = UpdateProfile.Field()
     move_identity = MoveIdentity.Field()
-    lock_identity = LockIdentity.Field()
-    unlock_identity = UnlockIdentity.Field()
+    lock = Lock.Field()
+    unlock = Unlock.Field()
     merge = Merge.Field()
     unmerge_identities = UnmergeIdentities.Field()
     enroll = Enroll.Field()

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -43,7 +43,7 @@ from .api import (add_identity,
                   move_identity,
                   lock,
                   unlock,
-                  merge_identities,
+                  merge,
                   unmerge_identities,
                   add_organization,
                   add_domain,
@@ -435,7 +435,7 @@ class MoveIdentity(graphene.Mutation):
         )
 
 
-class MergeIdentities(graphene.Mutation):
+class Merge(graphene.Mutation):
     class Arguments:
         from_uuids = graphene.List(graphene.String)
         to_uuid = graphene.String()
@@ -448,9 +448,9 @@ class MergeIdentities(graphene.Mutation):
         user = info.context.user
         ctx = SortingHatContext(user)
 
-        individual = merge_identities(ctx, from_uuids, to_uuid)
+        individual = merge(ctx, from_uuids, to_uuid)
 
-        return MergeIdentities(
+        return Merge(
             uuid=individual.mk,
             individual=individual
         )
@@ -665,7 +665,7 @@ class SortingHatMutation(graphene.ObjectType):
     move_identity = MoveIdentity.Field()
     lock_identity = LockIdentity.Field()
     unlock_identity = UnlockIdentity.Field()
-    merge_identities = MergeIdentities.Field()
+    merge = Merge.Field()
     unmerge_identities = UnmergeIdentities.Field()
     enroll = Enroll.Field()
     withdraw = Withdraw.Field()

--- a/tests/cli/test_cmd_lock.py
+++ b/tests/cli/test_cmd_lock.py
@@ -29,13 +29,13 @@ from sortinghat.cli.cmds.lock import add, rm
 
 
 LOCK_ADD_CMD_OP = """mutation {{
-  lockIdentity(uuid: "{}") {{
+  lock(uuid: "{}") {{
     uuid
   }}
 }}"""
 
 LOCK_RM_CMD_OP = """mutation {{
-  unlockIdentity(uuid: "{}") {{
+  unlock(uuid: "{}") {{
     uuid
   }}
 }}"""
@@ -81,7 +81,7 @@ class TestLockAddCommand(unittest.TestCase):
         """Check if it adds a lock to an individual"""
 
         responses = [
-            {'data': {'lockIdentity': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
+            {'data': {'lock': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
         ]
         mock_client = MockClient(responses)
 
@@ -139,7 +139,7 @@ class TestLockRmCommand(unittest.TestCase):
         """Check if it removes a lock from an individual"""
 
         responses = [
-            {'data': {'unlockIdentity': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
+            {'data': {'unlock': {'uuid': '322397ed782a798ffd9d0bc7e293df4292fe075d'}}}
         ]
         mock_client = MockClient(responses)
 

--- a/tests/cli/test_cmd_merge.py
+++ b/tests/cli/test_cmd_merge.py
@@ -30,7 +30,7 @@ from sortinghat.cli.cmds.merge import merge
 
 
 MERGE_CMD_OP = """mutation {{
-  mergeIdentities(fromUuids: [{}], toUuid: "{}") {{
+  merge(fromUuids: [{}], toUuid: "{}") {{
     uuid
   }}
 }}"""
@@ -71,7 +71,7 @@ class TestMergeCommand(unittest.TestCase):
         """Check if it merges a set of individuals"""
 
         responses = [
-            {'data': {'mergeIdentities': {'uuid': 'eda9f62ad321b1fbe5f283cc05e2484516203117'}}}
+            {'data': {'merge': {'uuid': 'eda9f62ad321b1fbe5f283cc05e2484516203117'}}}
         ]
         client = MockClient(responses)
         mock_client.return_value = client

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3707,8 +3707,8 @@ class TestWithdraw(TestCase):
         self.assertEqual(op5_args['end'], str(datetime_to_utc(datetime.datetime(2014, 1, 1))))
 
 
-class TestMergeIdentities(TestCase):
-    """Unit tests for merge_identities"""
+class TestMergeIndividuals(TestCase):
+    """Unit tests for merge"""
 
     def setUp(self):
         """Load initial dataset"""
@@ -3811,9 +3811,9 @@ class TestMergeIdentities(TestCase):
                            is_bot=True,
                            country_code='US')
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                          to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        individual = api.merge(self.ctx,
+                               from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                               to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         # Tests
         self.assertIsInstance(individual, Individual)
@@ -3866,7 +3866,7 @@ class TestMergeIdentities(TestCase):
         self.assertEqual(rol2.start, datetime.datetime(2017, 6, 2, tzinfo=UTC))
         self.assertEqual(rol2.end, datetime.datetime(2100, 1, 1, tzinfo=UTC))
 
-    def test_merge_multiple_identities(self):
+    def test_merge_multiple_individuals(self):
         """Check whether it merges more than two individuals, merging their ids, enrollments and profiles"""
 
         api.update_profile(self.ctx,
@@ -3883,10 +3883,10 @@ class TestMergeIdentities(TestCase):
                            is_bot=True,
                            country_code='US')
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3',
-                                                      '1c13fec7a328201fc6a230fe43eb81df0e20626e'],
-                                          to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        individual = api.merge(self.ctx,
+                               from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3',
+                                           '1c13fec7a328201fc6a230fe43eb81df0e20626e'],
+                               to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         # Tests
         self.assertIsInstance(individual, Individual)
@@ -3954,7 +3954,7 @@ class TestMergeIdentities(TestCase):
         self.assertEqual(rol2.start, datetime.datetime(2017, 6, 2, tzinfo=UTC))
         self.assertEqual(rol2.end, datetime.datetime(2100, 1, 1, tzinfo=UTC))
 
-    def test_merge_multiple_identities_from_any_uuid(self):
+    def test_merge_multiple_individuals_from_any_uuid(self):
         """
         Check whether it merges more than two individuals
         using any valid identity uuid
@@ -3973,10 +3973,10 @@ class TestMergeIdentities(TestCase):
                            is_bot=True,
                            country_code='US')
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['67fc4f8a56aa12ab981d2a4c1de065bb9936c9f6',
-                                                      'c2f5aa44e920b4fbe3cd36894b18e80a2606deba'],
-                                          to_uuid='9225e296be341c20c11c4bae76df4190a5c4a918')
+        individual = api.merge(self.ctx,
+                               from_uuids=['67fc4f8a56aa12ab981d2a4c1de065bb9936c9f6',
+                                           'c2f5aa44e920b4fbe3cd36894b18e80a2606deba'],
+                               to_uuid='9225e296be341c20c11c4bae76df4190a5c4a918')
 
         # Tests
         self.assertIsInstance(individual, Individual)
@@ -4050,9 +4050,9 @@ class TestMergeIdentities(TestCase):
         trx_date = datetime_utcnow()  # After this datetime no transactions should be created
 
         with self.assertRaisesRegex(InvalidValueError, FROM_UUIDS_NONE_OR_EMPTY_ERROR):
-            api.merge_identities(self.ctx,
-                                 from_uuids=[],
-                                 to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+            api.merge(self.ctx,
+                      from_uuids=[],
+                      to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         # Check if there are no transactions created when there is an error
         transactions = Transaction.objects.filter(created_at__gt=trx_date)
@@ -4064,9 +4064,9 @@ class TestMergeIdentities(TestCase):
         trx_date = datetime_utcnow()  # After this datetime no transactions should be created
 
         with self.assertRaisesRegex(InvalidValueError, FROM_UUID_NONE_OR_EMPTY_ERROR):
-            api.merge_identities(self.ctx,
-                                 from_uuids=[''],
-                                 to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+            api.merge(self.ctx,
+                      from_uuids=[''],
+                      to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         # Check if there are no transactions created when there is an error
         transactions = Transaction.objects.filter(created_at__gt=trx_date)
@@ -4078,9 +4078,9 @@ class TestMergeIdentities(TestCase):
         trx_date = datetime_utcnow()  # After this datetime no transactions should be created
 
         with self.assertRaisesRegex(InvalidValueError, TO_UUID_NONE_OR_EMPTY_ERROR):
-            api.merge_identities(self.ctx,
-                                 from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                 to_uuid='')
+            api.merge(self.ctx,
+                      from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                      to_uuid='')
 
         # Check if there are no transactions created when there is an error
         transactions = Transaction.objects.filter(created_at__gt=trx_date)
@@ -4092,9 +4092,9 @@ class TestMergeIdentities(TestCase):
         trx_date = datetime_utcnow()  # After this datetime no transactions should be created
 
         with self.assertRaisesRegex(InvalidValueError, FROM_UUID_TO_UUID_EQUAL_ERROR):
-            api.merge_identities(self.ctx,
-                                 from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                 to_uuid='e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
+            api.merge(self.ctx,
+                      from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                      to_uuid='e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
 
         # Check if there are no transactions created when there is an error
         transactions = Transaction.objects.filter(created_at__gt=trx_date)
@@ -4103,9 +4103,9 @@ class TestMergeIdentities(TestCase):
     def test_moved_enrollments(self):
         """Check whether it merges two individuals, merging their enrollments with multiple periods"""
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['ebe8f55d8988fce02997389d530579ad939f1698'],
-                                          to_uuid='437386d9d072320387d0c802f772a5401cddc3e6')
+        individual = api.merge(self.ctx,
+                               from_uuids=['ebe8f55d8988fce02997389d530579ad939f1698'],
+                               to_uuid='437386d9d072320387d0c802f772a5401cddc3e6')
 
         enrollments = individual.enrollments.all()
         self.assertEqual(len(enrollments), 3)
@@ -4128,9 +4128,9 @@ class TestMergeIdentities(TestCase):
     def test_overlapping_enrollments(self):
         """Check whether it merges two individuals having overlapping enrollments"""
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['4dd0fdcd06a6be6f0b7893bf1afcef3e3191753a'],
-                                          to_uuid='e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
+        individual = api.merge(self.ctx,
+                               from_uuids=['4dd0fdcd06a6be6f0b7893bf1afcef3e3191753a'],
+                               to_uuid='e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
 
         enrollments = individual.enrollments.all()
         self.assertEqual(len(enrollments), 1)
@@ -4143,9 +4143,9 @@ class TestMergeIdentities(TestCase):
     def test_overlapping_enrollments_different_orgs(self):
         """Check whether it merges two individuals having overlapping periods in different organizations"""
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                          to_uuid='a11604f983f8786913e6d1449f2eac1618b0b2ee')
+        individual = api.merge(self.ctx,
+                               from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                               to_uuid='a11604f983f8786913e6d1449f2eac1618b0b2ee')
 
         enrollments = individual.enrollments.all()
         self.assertEqual(len(enrollments), 2)
@@ -4163,9 +4163,9 @@ class TestMergeIdentities(TestCase):
     def test_duplicate_enrollments(self):
         """Check whether it merges two individuals having duplicate enrollments"""
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['f29b50520d35d046db0d53b301418ad9aa16e7e3'],
-                                          to_uuid='e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
+        individual = api.merge(self.ctx,
+                               from_uuids=['f29b50520d35d046db0d53b301418ad9aa16e7e3'],
+                               to_uuid='e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
 
         enrollments = individual.enrollments.all()
         self.assertEqual(len(enrollments), 1)
@@ -4209,9 +4209,9 @@ class TestMergeIdentities(TestCase):
 
         # Merge identities
         before_merge_dt = datetime_utcnow()
-        indv = api.merge_identities(self.ctx,
-                                    from_uuids=['b6bee805956c03699b59e15175261f85a10d43f3'],
-                                    to_uuid='a033ed6d1498a58f7cf91bd56e3c746d7ddb9874')
+        indv = api.merge(self.ctx,
+                         from_uuids=['b6bee805956c03699b59e15175261f85a10d43f3'],
+                         to_uuid='a033ed6d1498a58f7cf91bd56e3c746d7ddb9874')
         after_merge_dt = datetime_utcnow()
 
         self.assertLessEqual(before_dt, indv.last_modified)
@@ -4261,9 +4261,9 @@ class TestMergeIdentities(TestCase):
                            uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed', name='John Smith',
                            email='jsmith@profile-email', is_bot=True, country_code='US')
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                          to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        individual = api.merge(self.ctx,
+                               from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                               to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         profile = individual.profile
         self.assertEqual(profile.name, 'John Smith')
@@ -4284,9 +4284,9 @@ class TestMergeIdentities(TestCase):
                            uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed', name='John Smith',
                            email='jsmith@profile-email')
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                          to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        individual = api.merge(self.ctx,
+                               from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                               to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         profile = individual.profile
         self.assertEqual(profile.name, 'John Smith')
@@ -4306,9 +4306,9 @@ class TestMergeIdentities(TestCase):
                            uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed',
                            name='', email='', gender='', country_code='')
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                          to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        individual = api.merge(self.ctx,
+                               from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                               to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         profile = individual.profile
         self.assertEqual(profile.name, 'J. Smith')
@@ -4328,9 +4328,9 @@ class TestMergeIdentities(TestCase):
                            uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed',
                            name='', email='', gender='', country_code='')
 
-        individual = api.merge_identities(self.ctx,
-                                          from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                                          to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        individual = api.merge(self.ctx,
+                               from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                               to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         profile = individual.profile
         self.assertEqual(profile.name, None)
@@ -4351,25 +4351,25 @@ class TestMergeIdentities(TestCase):
 
         msg = UUID_LOCKED_ERROR.format(uuid=from_uuid)
         with self.assertRaisesRegex(LockedIdentityError, msg):
-            api.merge_identities(self.ctx,
-                                 from_uuids=[from_uuid],
-                                 to_uuid=to_uuid)
+            api.merge(self.ctx,
+                      from_uuids=[from_uuid],
+                      to_uuid=to_uuid)
 
     def test_transaction(self):
         """Check if a transaction is created when merging identities"""
 
         timestamp = datetime_utcnow()
 
-        api.merge_identities(self.ctx,
-                             from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                             to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        api.merge(self.ctx,
+                  from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                  to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         transactions = Transaction.objects.filter(created_at__gte=timestamp)
         self.assertEqual(len(transactions), 1)
 
         trx = transactions[0]
         self.assertIsInstance(trx, Transaction)
-        self.assertEqual(trx.name, 'merge_identities')
+        self.assertEqual(trx.name, 'merge')
         self.assertGreater(trx.created_at, timestamp)
         self.assertEqual(trx.authored_by, self.ctx.user.username)
 
@@ -4378,9 +4378,9 @@ class TestMergeIdentities(TestCase):
 
         timestamp = datetime_utcnow()
 
-        api.merge_identities(self.ctx,
-                             from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
-                             to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
+        api.merge(self.ctx,
+                  from_uuids=['e8284285566fdc1f41c8a22bb84a295fc3c4cbb3'],
+                  to_uuid='caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         transactions = Transaction.objects.filter(created_at__gte=timestamp)
         trx = transactions[0]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2699,12 +2699,12 @@ class TestDeleteIdentityMutation(django.test.TestCase):
         self.assertEqual(msg, AUTHENTICATION_ERROR)
 
 
-class TestLockIdentityMutation(django.test.TestCase):
-    """Unit tests for mutation to lock identities"""
+class TestLockMutation(django.test.TestCase):
+    """Unit tests for mutation to lock individuals"""
 
-    SH_LOCK_IDENTITY = """
-          mutation lockId($uuid: String) {
-            lockIdentity(uuid: $uuid) {
+    SH_LOCK_INDIVIDUAL = """
+          mutation lockIndv($uuid: String) {
+            lock(uuid: $uuid) {
               uuid
               individual {
                 mk
@@ -2736,15 +2736,15 @@ class TestLockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': 'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3',
         }
-        executed = client.execute(self.SH_LOCK_IDENTITY,
+        executed = client.execute(self.SH_LOCK_INDIVIDUAL,
                                   context_value=self.context_value,
                                   variables=params)
 
         # Check results
-        uuid = executed['data']['lockIdentity']['uuid']
+        uuid = executed['data']['lock']['uuid']
         self.assertEqual(uuid, 'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
 
-        individual = executed['data']['lockIdentity']['individual']
+        individual = executed['data']['lock']['individual']
         self.assertEqual(individual['mk'], 'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
         self.assertEqual(individual['isLocked'], True)
 
@@ -2758,7 +2758,7 @@ class TestLockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': 'FFFFFFFFFFFFFFF',
         }
-        executed = client.execute(self.SH_LOCK_IDENTITY,
+        executed = client.execute(self.SH_LOCK_INDIVIDUAL,
                                   context_value=self.context_value,
                                   variables=params)
 
@@ -2775,7 +2775,7 @@ class TestLockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': '',
         }
-        executed = client.execute(self.SH_LOCK_IDENTITY,
+        executed = client.execute(self.SH_LOCK_INDIVIDUAL,
                                   context_value=self.context_value,
                                   variables=params)
 
@@ -2795,7 +2795,7 @@ class TestLockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': '1387b129ab751a3657312c09759caa41dfd8d07d',
         }
-        executed = client.execute(self.SH_LOCK_IDENTITY,
+        executed = client.execute(self.SH_LOCK_INDIVIDUAL,
                                   context_value=context_value,
                                   variables=params)
 
@@ -2803,12 +2803,12 @@ class TestLockIdentityMutation(django.test.TestCase):
         self.assertEqual(msg, AUTHENTICATION_ERROR)
 
 
-class TestUnlockIdentityMutation(django.test.TestCase):
-    """Unit tests for mutation to unlock identities"""
+class TestUnlockMutation(django.test.TestCase):
+    """Unit tests for mutation to unlock individuals"""
 
-    SH_UNLOCK_IDENTITY = """
-          mutation unlockId($uuid: String) {
-            unlockIdentity(uuid: $uuid) {
+    SH_UNLOCK_INDIVIDUAL = """
+          mutation unlockIndv($uuid: String) {
+            unlock(uuid: $uuid) {
               uuid
               individual {
                 mk
@@ -2840,15 +2840,15 @@ class TestUnlockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': 'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3',
         }
-        executed = client.execute(self.SH_UNLOCK_IDENTITY,
+        executed = client.execute(self.SH_UNLOCK_INDIVIDUAL,
                                   context_value=self.context_value,
                                   variables=params)
 
         # Check results
-        uuid = executed['data']['unlockIdentity']['uuid']
+        uuid = executed['data']['unlock']['uuid']
         self.assertEqual(uuid, 'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
 
-        individual = executed['data']['unlockIdentity']['individual']
+        individual = executed['data']['unlock']['individual']
         self.assertEqual(individual['mk'], 'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3')
         self.assertEqual(individual['isLocked'], False)
 
@@ -2862,7 +2862,7 @@ class TestUnlockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': 'FFFFFFFFFFFFFFF',
         }
-        executed = client.execute(self.SH_UNLOCK_IDENTITY,
+        executed = client.execute(self.SH_UNLOCK_INDIVIDUAL,
                                   context_value=self.context_value,
                                   variables=params)
 
@@ -2879,7 +2879,7 @@ class TestUnlockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': '',
         }
-        executed = client.execute(self.SH_UNLOCK_IDENTITY,
+        executed = client.execute(self.SH_UNLOCK_INDIVIDUAL,
                                   context_value=self.context_value,
                                   variables=params)
 
@@ -2899,7 +2899,7 @@ class TestUnlockIdentityMutation(django.test.TestCase):
         params = {
             'uuid': 'e8284285566fdc1f41c8a22bb84a295fc3c4cbb3',
         }
-        executed = client.execute(self.SH_UNLOCK_IDENTITY,
+        executed = client.execute(self.SH_UNLOCK_INDIVIDUAL,
                                   context_value=context_value,
                                   variables=params)
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4029,12 +4029,12 @@ class TestWithdrawMutation(django.test.TestCase):
         self.assertEqual(msg, AUTHENTICATION_ERROR)
 
 
-class TestMergeIdentitiesMutation(django.test.TestCase):
+class TestMergeMutation(django.test.TestCase):
     """Unit tests for mutation to merge individuals"""
 
     SH_MERGE = """
           mutation mergeIds($fromUuids: [String], $toUuid: String) {
-            mergeIdentities(fromUuids: $fromUuids, toUuid: $toUuid) {
+            merge(fromUuids: $fromUuids, toUuid: $toUuid) {
               uuid
               individual {
                 mk
@@ -4060,7 +4060,7 @@ class TestMergeIdentitiesMutation(django.test.TestCase):
         self.ctx = SortingHatContext(self.user)
 
         # Transaction
-        self.trxl = TransactionsLog.open('merge_identities', self.ctx)
+        self.trxl = TransactionsLog.open('merge', self.ctx)
 
         db.add_organization(self.trxl, 'Example')
         db.add_organization(self.trxl, 'Bitergia')
@@ -4108,7 +4108,7 @@ class TestMergeIdentitiesMutation(django.test.TestCase):
                            uuid='1c13fec7a328201fc6a230fe43eb81df0e20626e', name='John Smith',
                            email='jsmith@profile-email', is_bot=False, country_code='US')
 
-    def test_merge_identities(self):
+    def test_merge_individuals(self):
         """Check whether it merges two individuals, merging their ids, enrollments and profiles"""
 
         client = graphene.test.Client(schema)
@@ -4123,7 +4123,7 @@ class TestMergeIdentitiesMutation(django.test.TestCase):
                                   variables=params)
 
         # Check results, identities were merged
-        identities = executed['data']['mergeIdentities']['individual']['identities']
+        identities = executed['data']['merge']['individual']['identities']
 
         self.assertEqual(len(identities), 4)
 
@@ -4151,7 +4151,7 @@ class TestMergeIdentitiesMutation(django.test.TestCase):
         self.assertEqual(identity['email'], 'jsmith@example')
         self.assertEqual(identity['source'], 'scm')
 
-        uuid = executed['data']['mergeIdentities']['uuid']
+        uuid = executed['data']['merge']['uuid']
         self.assertEqual(uuid, 'caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         # Check database objects
@@ -4208,7 +4208,7 @@ class TestMergeIdentitiesMutation(django.test.TestCase):
         self.assertEqual(rol2.start, datetime.datetime(2017, 6, 2, tzinfo=UTC))
         self.assertEqual(rol2.end, datetime.datetime(2100, 1, 1, tzinfo=UTC))
 
-    def test_merge_multiple_identities(self):
+    def test_merge_multiple_individuals(self):
         """Check whether it merges more than two individuals, merging their ids, enrollments and profiles"""
 
         client = graphene.test.Client(schema)
@@ -4224,7 +4224,7 @@ class TestMergeIdentitiesMutation(django.test.TestCase):
                                   variables=params)
 
         # Check results, identities were merged
-        identities = executed['data']['mergeIdentities']['individual']['identities']
+        identities = executed['data']['merge']['individual']['identities']
 
         self.assertEqual(len(identities), 7)
 
@@ -4270,7 +4270,7 @@ class TestMergeIdentitiesMutation(django.test.TestCase):
         self.assertEqual(identity['email'], 'jsmith@example')
         self.assertEqual(identity['source'], 'scm')
 
-        uuid = executed['data']['mergeIdentities']['uuid']
+        uuid = executed['data']['merge']['uuid']
         self.assertEqual(uuid, 'caa5ebfe833371e23f0a3566f2b7ef4a984c4fed')
 
         # Check database objects


### PR DESCRIPTION
This PR renames the mutations that make reference to identities. It renames `mergeIdentities` to `merge` and, `lockIdentity` and `unlockIdentity` to `lock` and `unlock.

This PR is related to #286.