### PR TITLE
Affiliation job

### DIFF
--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -1,6 +1,10 @@
 import sys
 import logging
 
+import django_rq.queues
+
+from fakeredis import FakeRedis, FakeStrictRedis
+
 # Graphene logs SortingHat exceptions and Django pritns them
 # to the standard error output. This code prevents Django
 # kind of errors are not shown.
@@ -63,3 +67,24 @@ GRAPHENE = {
 }
 
 DEFAULT_GRAPHQL_PAGE_SIZE = 10
+
+
+# Configuration to pretend there is a Redis service
+# available. We need to set up the connection before
+# RQ Django reads the settings.
+
+def fake_redis_connection(_, strict):
+    return FakeStrictRedis() if strict else FakeRedis()
+
+
+django_rq.queues.get_redis_connection = fake_redis_connection
+
+
+RQ_QUEUES = {
+    'default': {
+        'HOST': 'localhost',
+        'PORT': 6379,
+        'ASYNC': False,
+        'DB': 0
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ requests>=2.7.0
 uri>=2.0.1
 httpretty==0.9.7
 jinja2==2.11.1
+rq>=1.4.0
+django-rq>=2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,5 @@ uri>=2.0.1
 httpretty==0.9.7
 jinja2==2.11.1
 rq>=1.4.0
-django-rq>=2.3.0
+django-rq>=2.3.2
+fakeredis>=1.4.1

--- a/sortinghat/core/context.py
+++ b/sortinghat/core/context.py
@@ -23,4 +23,7 @@
 import collections
 
 
-SortingHatContext = collections.namedtuple('SortingHatContext', ['user'])
+SortingHatContext = collections.namedtuple(
+    'SortingHatContext', ['user', 'job_id']
+)
+SortingHatContext.__new__.__defaults__ = (None, None)

--- a/sortinghat/core/errors.py
+++ b/sortinghat/core/errors.py
@@ -28,6 +28,7 @@ CODE_VALUE_ERROR = 10
 CODE_CLOSED_TRANSACTION_ERROR = 12
 CODE_LOCKED_IDENTITY_ERROR = 13
 CODE_DUPLICATE_RANGE_ERROR = 14
+CODE_RECOMMENDATION_ERROR = 100
 CODE_TOKEN_EXPIRED = 126
 CODE_PERMISSION_DENIED = 127
 CODE_UNKNOWN_ERROR = 128
@@ -98,3 +99,10 @@ class DuplicateRangeError(BaseError):
 
     code = CODE_DUPLICATE_RANGE_ERROR
     message = "range date '%(start)s'-'%(end)s' is part of an existing range for %(org)s"
+
+
+class RecommendationEngineError(BaseError):
+    """Exception raised when there is an error in the recommendation engine"""
+
+    code = CODE_RECOMMENDATION_ERROR
+    message = "%(msg)s"

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import itertools
+
+import django_rq
+import rq
+
+from .api import enroll
+from .context import SortingHatContext
+from .errors import BaseError
+from .log import TransactionsLog
+from .models import Individual
+from .recommendations.engine import RecommendationEngine
+
+
+MAX_CHUNK_SIZE = 2000
+
+
+@django_rq.job
+def affiliate(ctx, uuids=None):
+    """Affiliate a set of individuals using recommendations.
+
+    This function automates the affiliation process obtaining
+    a list of recommendations where individuals can be
+    affiliated. After that, individuals are enrolled to them.
+    This job returns a dictionary with which individuals were
+    enrolled and the errors generated during this process.
+
+    Individuals are defined by any of their valid keys or UUIDs.
+    When the parameter `uuids` is empty, the job will take all
+    the individuals stored in the registry.
+
+    :param ctx: context where this job is run
+    :param uuids: list of individuals identifiers
+
+    :returns: a dictionary with which individuals were enrolled
+        and the errors found running the job
+    """
+    if not uuids:
+        uuids = Individual.objects.values_list('mk', flat=True).iterator()
+    else:
+        uuids = iter(uuids)
+
+    results = {}
+    errors = []
+    job_result = {
+        'results': results,
+        'errors': errors
+    }
+
+    engine = RecommendationEngine()
+
+    # Create a new context to include the reference
+    # to the job id that will perform the transaction.
+    job = rq.get_current_job()
+    job_ctx = SortingHatContext(ctx.user, job.id)
+
+    # Create an empty transaction to log which job
+    # will generate the enroll transactions.
+    trxl = TransactionsLog.open('affiliate', job_ctx)
+
+    for chunk in _iter_split(uuids, size=MAX_CHUNK_SIZE):
+        for rec in engine.recommend('affiliation', chunk):
+            affiliated, errs = _affiliate_individual(job_ctx, rec.key, rec.options)
+            results[rec.key] = affiliated
+            errors.extend(errs)
+
+    trxl.close()
+
+    return job_result
+
+
+def _affiliate_individual(job_ctx, uuid, organizations):
+    """Affiliate an individual to a list of organizations.
+
+    Returns a tuple with two elements: list of the organizations
+    the individual was enrolled to; list of the errors found
+    during the process.
+
+    :param job_ctx: job context
+    :param uuid: valid individual identifier
+    :param organizations: list of organization names
+
+    :returns: tuple with the organizations affiliated to the i
+    """
+    affiliated = []
+    errors = []
+
+    for name in organizations:
+        try:
+            enroll(job_ctx, uuid, name)
+        except BaseError as exc:
+            errors.append(str(exc))
+        else:
+            affiliated.append(name)
+    return affiliated, errors
+
+
+def _iter_split(iterator, size=None):
+    """Split an iterator in chunks of the same size.
+
+    When size is `None` the iterator will only return
+    one chunk.
+
+    :param iterator: iterator to split
+    :param size: size of the chunk;
+
+    :returns: generator of chunks
+    """
+    # This code is based on Ashley Waite's answer to StackOverflow question
+    # "split a generator/iterable every n items in python (splitEvery)"
+    # (https://stackoverflow.com/a/44320132).
+    while True:
+        slice_iter = itertools.islice(iterator, size)
+        peek = next(slice_iter)
+        yield itertools.chain([peek], slice_iter)

--- a/sortinghat/core/recommendations/__init__.py
+++ b/sortinghat/core/recommendations/__init__.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+from .affiliation import recommend_affiliations
+
+
+__all__ = [
+    recommend_affiliations
+]

--- a/sortinghat/core/recommendations/__init__.py
+++ b/sortinghat/core/recommendations/__init__.py
@@ -19,9 +19,9 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
-from .affiliation import recommend_affiliations
+from .engine import RecommendationEngine
 
 
 __all__ = [
-    recommend_affiliations
+    RecommendationEngine
 ]

--- a/sortinghat/core/recommendations/affiliation.py
+++ b/sortinghat/core/recommendations/affiliation.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import functools
+import re
+
+from ..db import (find_individual_by_uuid,
+                  find_domain,
+                  search_enrollments_in_period)
+from ..errors import NotFoundError
+
+
+EMAIL_ADDRESS_PATTERN = re.compile(r"^(?P<email>[^\s@]+@[^\s@.]+\.[^\s@]+)$")
+
+
+def recommend_affiliations(uuids):
+    """Recommend organizations for a list of individuals.
+
+    Returns a generator of affiliation recommendations
+    based on the email addresses of the individuals.
+
+    The function checks if the domains of these email
+    addresses of an individual match with any of the
+    domains stored on the registry. If this is the case,
+    the organization associated to that domain will be
+    recommended.
+
+    Each recommendation contains the uuid of the individual
+    and a list with the names of the organizations that the
+    individual might be enrolled.
+
+    When no affiliation is found, an empty list will be
+    returned for that uuid. When the individual is not
+    found, it will not be included in the result.
+
+    The function will not return the organizations in which
+    the individual is already enrolled.
+
+    :param uuids: list of individual keys
+
+    :returns: a generator of recommendations
+    """
+    for uuid in uuids:
+        try:
+            individual = find_individual_by_uuid(uuid)
+        except NotFoundError:
+            continue
+        else:
+            yield (uuid, _suggest_affiliations(individual))
+
+
+def _suggest_affiliations(individual):
+    """Generate a list of organizations where the individual is not affiliated."""
+
+    orgs = set()
+    domains = _retrieve_individual_email_domains(individual)
+
+    for domain in domains:
+        org_name = domain.organization.name
+
+        if _is_enrolled(individual, org_name):
+            continue
+
+        orgs.add(org_name)
+
+    return sorted(list(orgs))
+
+
+def _retrieve_individual_email_domains(individual):
+    """Return a list of possible domains linked to an individual."""
+
+    domains = set()
+
+    for identity in individual.identities.all():
+        # Only check email address to find new affiliations
+        if not identity.email:
+            continue
+        if not EMAIL_ADDRESS_PATTERN.match(identity.email):
+            continue
+
+        domain = identity.email.split('@')[-1]
+
+        if domain in domains:
+            continue
+
+        dom = _find_matching_domain(domain)
+
+        if dom:
+            domains.add(dom)
+
+    return domains
+
+
+def _is_enrolled(individual, org_name):
+    """Determine if an individual is enrolled to an organization."""
+
+    result = search_enrollments_in_period(individual.mk,
+                                          org_name)
+    return len(result) > 0
+
+
+@functools.lru_cache()
+def _find_matching_domain(domain):
+    """Look for domains and sub-domains that match with the given one."""
+
+    keep_looking = True
+
+    # Splits the domain into root domains until
+    # is found in the database.
+    while keep_looking:
+        try:
+            result = find_domain(domain)
+            keep_looking = False
+        except NotFoundError:
+            index = domain.find('.')
+            if index > -1:
+                domain = domain[index + 1:]
+            else:
+                result = None
+                keep_looking = False
+    return result

--- a/sortinghat/core/recommendations/engine.py
+++ b/sortinghat/core/recommendations/engine.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import collections
+
+from ..errors import RecommendationEngineError
+from .affiliation import recommend_affiliations
+
+
+Recommendation = collections.namedtuple(
+    'Recommendation',
+    ['key', 'type', 'options']
+)
+
+
+class RecommendationEngine:
+    """Recommender engine for SortingHat.
+
+    This class implements a basic recommendation system that
+    generates a set of suggestions regarding the data stored
+    on the registry.
+    """
+    RECOMMENDATION_TYPES = {
+        'affiliation': recommend_affiliations
+    }
+
+    def recommend(self, name, *args, **kwargs):
+        """Generate a list of recommendations.
+
+        Returns a generator of recommendations of type `name`.
+        Specific arguments can be passed using positional or
+        keyword arguments.
+
+        Recommendations are tuples of the class `Recommendation`,
+        that contain a `key` and a `type` to identify it, and
+        a list of `options` or suggestions.
+
+        When `name` is not a valid type of recommendation, the
+        method will raise a `RecommendationEngineError`
+        exception.
+
+        :param name: recommendation type
+        :param *args: positional arguments to run the engine
+        :param **args: keyword arguments to run the engine
+
+        :returns: a generator of `Recommendation`
+
+        :raises RecommendationEngineError: when any error is
+            found in the engine
+        """
+        try:
+            recommender = self.RECOMMENDATION_TYPES[name]
+        except KeyError:
+            msg = "Unknown '{}' recommendation type".format(name)
+            raise RecommendationEngineError(msg=msg)
+
+        return self._generate_recommendations(name,
+                                              recommender,
+                                              *args,
+                                              **kwargs)
+
+    @staticmethod
+    def _generate_recommendations(name, recommender, *args, **kwargs):
+        """Generator of recommendations."""
+
+        for rec in recommender(*args, **kwargs):
+            yield Recommendation(rec[0], name, rec[1])
+
+    @classmethod
+    def types(cls):
+        """List of supported types of recommendations."""
+
+        return [v for v in cls.RECOMMENDATION_TYPES.keys()]

--- a/tests/rec/test_affiliations.py
+++ b/tests/rec/test_affiliations.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from sortinghat.core import api
+from sortinghat.core.context import SortingHatContext
+from sortinghat.core.recommendations.affiliation import recommend_affiliations
+
+
+class TestRecommendAffiliations(TestCase):
+    """Unit tests for recommend_affiliations"""
+
+    def setUp(self):
+        """Initialize database with a set of organizations and domains"""
+
+        self.user = get_user_model().objects.create(username='test')
+        ctx = SortingHatContext(self.user)
+
+        # Organizations and domains
+        api.add_organization(ctx, 'Example')
+        api.add_domain(ctx, 'Example', 'example.com', is_top_domain=True)
+
+        api.add_organization(ctx, 'Example Int.')
+        api.add_domain(ctx, 'Example Int.', 'u.example.com',
+                       is_top_domain=True)
+        api.add_domain(ctx, 'Example Int.', 'es.u.example.com')
+        api.add_domain(ctx, 'Example Int.', 'en.u.example.com')
+
+        api.add_organization(ctx, 'Bitergia')
+        api.add_domain(ctx, 'Bitergia', 'bitergia.com')
+        api.add_domain(ctx, 'Bitergia', 'bitergia.org')
+
+        api.add_organization(ctx, 'LibreSoft')
+
+    def test_recommendations(self):
+        """Test if a set of recommendations is produced"""
+
+        # Add some cases
+        ctx = SortingHatContext(self.user)
+
+        # John Smith identity
+        jsmith = api.add_identity(ctx,
+                                  source='scm',
+                                  email='jsmith@us.example.com',
+                                  name='John Smith',
+                                  username='jsmith')
+        api.add_identity(ctx,
+                         source='scm',
+                         email='jsmith@example.net',
+                         name='John Smith',
+                         uuid=jsmith.uuid)
+        api.add_identity(ctx,
+                         source='scm',
+                         email='jsmith@bitergia.com',
+                         name='John Smith',
+                         username='jsmith',
+                         uuid=jsmith.uuid)
+        api.enroll(ctx, jsmith.uuid, 'Bitergia')
+
+        # Jane Roe identity
+        jroe = api.add_identity(ctx,
+                                source='scm',
+                                email='jroe@example.com',
+                                name='Jane Roe',
+                                username='jroe')
+        api.add_identity(ctx,
+                         source='scm',
+                         email='jroe@example.com',
+                         uuid=jroe.uuid)
+        api.add_identity(ctx,
+                         source='unknown',
+                         email='jroe@bitergia.com',
+                         uuid=jroe.uuid)
+
+        # Test
+        uuids = [jsmith.uuid, jroe.uuid]
+        recs = list(recommend_affiliations(uuids))
+
+        self.assertEqual(len(recs), 2)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], jsmith.uuid)
+        self.assertListEqual(rec[1], ['Example'])
+
+        rec = recs[1]
+        self.assertEqual(rec[0], jroe.uuid)
+        self.assertListEqual(rec[1], ['Bitergia', 'Example'])
+
+    def test_already_enrolled(self):
+        """Check if an organization is not included in the recommendation
+        when the individual is already enrolled to it"""
+
+        ctx = SortingHatContext(self.user)
+
+        jsmith = api.add_identity(ctx,
+                                  source='scm',
+                                  email='jsmith@example.com',
+                                  name='John Smith')
+        api.add_identity(ctx,
+                         source='scm',
+                         email='jsmith@bitergia.com',
+                         name='John Smith',
+                         username='jsmith',
+                         uuid=jsmith.uuid)
+        api.enroll(ctx, jsmith.uuid, 'Bitergia')
+
+        # Test
+        recs = list(recommend_affiliations([jsmith.uuid]))
+
+        self.assertEqual(len(recs), 1)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], jsmith.uuid)
+        # Bitergia is not included
+        self.assertListEqual(rec[1], ['Example'])
+
+    def test_multiple_top_domains(self):
+        """Check if it chooses the right domain when multiple top
+        domains are available"""
+
+        ctx = SortingHatContext(self.user)
+
+        jdoe = api.add_identity(ctx, source='scm',
+                                email='janedoe@it.u.example.com')
+
+        # Test
+        recs = list(recommend_affiliations([jdoe.uuid]))
+
+        self.assertEqual(len(recs), 1)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], jdoe.uuid)
+        self.assertListEqual(rec[1], ['Example Int.'])
+
+    def test_no_match(self):
+        """Check if empty recommendations are returned when there is
+        not match for a domain"""
+
+        ctx = SortingHatContext(self.user)
+
+        jsmith = api.add_identity(ctx,
+                                  source='scm',
+                                  email='jsmith@example.org',
+                                  name='John Smith',
+                                  username='jsmith')
+
+        # Test
+        recs = list(recommend_affiliations([jsmith.uuid]))
+
+        self.assertEqual(len(recs), 1)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], jsmith.uuid)
+        self.assertListEqual(rec[1], [])
+
+    def test_invalid_identity_email(self):
+        """Check if empty recommendations are returned for invalid emails"""
+
+        ctx = SortingHatContext(self.user)
+
+        noemail = api.add_identity(ctx,
+                                   source='unknown',
+                                   email='novalidemail@')
+
+        # Test
+        recs = list(recommend_affiliations([noemail.uuid]))
+
+        self.assertEqual(len(recs), 1)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], noemail.uuid)
+        self.assertListEqual(rec[1], [])
+
+    def test_empty_email(self):
+        """Check if empty recommendations are returned for empty
+        email addresses"""
+
+        ctx = SortingHatContext(self.user)
+
+        jdoe = api.add_identity(ctx,
+                                source='unknown',
+                                name='John Doe',
+                                username='jdoe')
+
+        # Test
+        recs = list(recommend_affiliations([jdoe.uuid]))
+
+        self.assertEqual(len(recs), 1)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], jdoe.uuid)
+        self.assertListEqual(rec[1], [])
+
+    def test_not_found_individual(self):
+        """Check if no recommendations are generated when an
+        individual does not exist"""
+
+        # Test
+        recs = list(recommend_affiliations('FFFFFFFFFFFFFFFFFF'))
+
+        self.assertListEqual(recs, [])

--- a/tests/rec/test_engine.py
+++ b/tests/rec/test_engine.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+from django.test import TestCase
+
+from sortinghat.core.errors import RecommendationEngineError
+from sortinghat.core.recommendations.engine import RecommendationEngine
+
+
+UNKNOWN_TYPE_ERROR = "Unknown '{}' recommendation type"
+ENGINE_ERROR = "Engine error"
+
+
+# Mock recommendations
+options = ['A', 'B', 'C']
+
+
+def generate_recommendations():
+    """Generate fake recommendations."""
+
+    for i in range(len(options)):
+        yield (i, options[0:i])
+
+
+def generate_error():
+    """Generate fake errors."""
+
+    raise RecommendationEngineError(msg=ENGINE_ERROR)
+
+
+class MockEngine(RecommendationEngine):
+    """Mocks RecommendationEngine"""
+
+    RECOMMENDATION_TYPES = {
+        'mock': generate_recommendations,
+        'error': generate_error
+    }
+
+
+class TestRecommendationEngine(TestCase):
+    """Unit tests for RecommendationEngine"""
+
+    def test_recommend(self):
+        """Check it the engine produces a list of recommendations"""
+
+        engine = MockEngine()
+        recs = [rec for rec in engine.recommend('mock')]
+
+        self.assertEqual(len(recs), 3)
+
+        for i in range(len(options)):
+            rec = recs[i]
+            self.assertEqual(rec.key, i)
+            self.assertEqual(rec.type, 'mock')
+            self.assertListEqual(rec.options, options[0:i])
+
+    def test_generator_error(self):
+        """Check if an error is raised when recommendations are generated"""
+
+        engine = MockEngine()
+
+        with self.assertRaisesRegex(RecommendationEngineError,
+                                    ENGINE_ERROR):
+            _ = [rec for rec in engine.recommend('error')]
+
+    def test_unknown_type(self):
+        """Check if an error is raised when a recommendation type does not exist"""
+
+        engine = RecommendationEngine()
+        error = UNKNOWN_TYPE_ERROR.format('mytype')
+
+        with self.assertRaisesRegex(RecommendationEngineError,
+                                    error):
+            engine.recommend('mytype')
+
+    def test_types(self):
+        """Test the list of supported recommendation types"""
+
+        types = RecommendationEngine.types()
+        self.assertListEqual(types, ['affiliation'])

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -29,7 +29,8 @@ from sortinghat.core.errors import (BaseError,
                                     InvalidValueError,
                                     ClosedTransactionError,
                                     LockedIdentityError,
-                                    DuplicateRangeError)
+                                    DuplicateRangeError,
+                                    RecommendationEngineError)
 
 
 # Mock classes to test BaseError class
@@ -200,3 +201,22 @@ class TestEnrollmentRangeError(TestCase):
         """
         kwargs = {}
         self.assertRaises(KeyError, DuplicateRangeError, **kwargs)
+
+
+class TestRecommendationEngineError(TestCase):
+    """Unit tests for RecommendationEngineError"""
+
+    def test_message(self):
+        """Make sure that prints the right error"""
+
+        e = RecommendationEngineError(msg="invalid engine")
+        self.assertEqual("invalid engine", str(e))
+
+    def test_no_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {}
+        self.assertRaises(KeyError, RecommendationEngineError,
+                          **kwargs)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import datetime
+import unittest.mock
+
+from dateutil.tz import UTC
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from grimoirelab_toolkit.datetime import datetime_utcnow
+
+from sortinghat.core import api
+from sortinghat.core.context import SortingHatContext
+from sortinghat.core.errors import DuplicateRangeError, NotFoundError
+from sortinghat.core.jobs import affiliate
+from sortinghat.core.models import Individual, Transaction
+
+
+class TestAffiliateIndividuals(TestCase):
+    """Unit tests for affiliate"""
+
+    def setUp(self):
+        """Initialize database with a dataset"""
+
+        self.user = get_user_model().objects.create(username='test')
+        ctx = SortingHatContext(self.user)
+
+        # Organizations and domains
+        api.add_organization(ctx, 'Example')
+        api.add_domain(ctx, 'Example', 'example.com', is_top_domain=True)
+
+        api.add_organization(ctx, 'Example Int.')
+        api.add_domain(ctx, 'Example Int.', 'u.example.com',
+                       is_top_domain=True)
+        api.add_domain(ctx, 'Example Int.', 'es.u.example.com')
+        api.add_domain(ctx, 'Example Int.', 'en.u.example.com')
+
+        api.add_organization(ctx, 'Bitergia')
+        api.add_domain(ctx, 'Bitergia', 'bitergia.com')
+        api.add_domain(ctx, 'Bitergia', 'bitergia.org')
+
+        api.add_organization(ctx, 'LibreSoft')
+
+        # John Smith identity
+        self.jsmith = api.add_identity(ctx,
+                                       source='scm',
+                                       email='jsmith@us.example.com',
+                                       name='John Smith',
+                                       username='jsmith')
+        api.add_identity(ctx,
+                         source='scm',
+                         email='jsmith@example.net',
+                         name='John Smith',
+                         uuid=self.jsmith.uuid)
+
+        # Add John Doe identity
+        self.jdoe = api.add_identity(ctx,
+                                     source='unknown',
+                                     email=None,
+                                     name='John Doe',
+                                     username='jdoe')
+
+        # Jane Roe identity
+        self.jroe = api.add_identity(ctx,
+                                     source='scm',
+                                     email='jroe@example.com',
+                                     name='Jane Roe',
+                                     username='jroe')
+        api.add_identity(ctx,
+                         source='scm',
+                         email='jroe@example.com',
+                         uuid=self.jroe.uuid)
+        api.add_identity(ctx,
+                         source='unknown',
+                         email='jroe@bitergia.com',
+                         uuid=self.jroe.uuid)
+
+    def test_affiliate(self):
+        """Check if all the individuals stored in the registry are affiliated"""
+
+        ctx = SortingHatContext(self.user)
+
+        # Test
+        expected = {
+            'results': {
+                '0c1e1701bc819495acf77ef731023b7d789a9c71': [],
+                '17ab00ed3825ec2f50483e33c88df223264182ba': ['Bitergia', 'Example'],
+                'dc31d2afbee88a6d1dbc1ef05ec827b878067744': ['Example']
+            },
+            'errors': []
+        }
+
+        job = affiliate.delay(ctx)
+        result = job.result
+
+        self.assertDictEqual(result, expected)
+
+        # Check database objects
+        individual_db = Individual.objects.get(mk=self.jroe.uuid)
+        enrollments_db = individual_db.enrollments.all()
+        self.assertEqual(len(enrollments_db), 2)
+
+        enrollment_db = enrollments_db[0]
+        self.assertEqual(enrollment_db.organization.name, 'Example')
+        self.assertEqual(enrollment_db.start, datetime.datetime(1900, 1, 1, tzinfo=UTC))
+        self.assertEqual(enrollment_db.end, datetime.datetime(2100, 1, 1, tzinfo=UTC))
+
+        enrollment_db = enrollments_db[1]
+        self.assertEqual(enrollment_db.organization.name, 'Bitergia')
+        self.assertEqual(enrollment_db.start, datetime.datetime(1900, 1, 1, tzinfo=UTC))
+        self.assertEqual(enrollment_db.end, datetime.datetime(2100, 1, 1, tzinfo=UTC))
+
+        individual_db = Individual.objects.get(mk=self.jsmith.uuid)
+        enrollments_db = individual_db.enrollments.all()
+        self.assertEqual(len(enrollments_db), 1)
+
+        enrollment_db = enrollments_db[0]
+        self.assertEqual(enrollment_db.organization.name, 'Example')
+        self.assertEqual(enrollment_db.start, datetime.datetime(1900, 1, 1, tzinfo=UTC))
+        self.assertEqual(enrollment_db.end, datetime.datetime(2100, 1, 1, tzinfo=UTC))
+
+        # John Doe was not affiliated
+        individual_db = Individual.objects.get(mk=self.jdoe.uuid)
+        enrollments_db = individual_db.enrollments.all()
+        self.assertEqual(len(enrollments_db), 0)
+
+    def test_affiliate_uuid(self):
+        """Check if only the given individuals are affiliated"""
+
+        ctx = SortingHatContext(self.user)
+
+        # Test
+        expected = {
+            'results': {
+                'dc31d2afbee88a6d1dbc1ef05ec827b878067744': ['Example']
+            },
+            'errors': []
+        }
+
+        uuids = ['dc31d2afbee88a6d1dbc1ef05ec827b878067744']
+        job = affiliate.delay(ctx, uuids=uuids)
+
+        result = job.result
+
+        self.assertDictEqual(result, expected)
+
+        # Check database objects
+
+        # Only John Smith was affiliated
+        individual_db = Individual.objects.get(mk=self.jsmith.uuid)
+        enrollments_db = individual_db.enrollments.all()
+        self.assertEqual(len(enrollments_db), 1)
+
+        enrollment_db = enrollments_db[0]
+        self.assertEqual(enrollment_db.organization.name, 'Example')
+        self.assertEqual(enrollment_db.start, datetime.datetime(1900, 1, 1, tzinfo=UTC))
+        self.assertEqual(enrollment_db.end, datetime.datetime(2100, 1, 1, tzinfo=UTC))
+
+        # Jane Roe and John Doe were not affiliated
+        individual_db = Individual.objects.get(mk=self.jroe.uuid)
+        enrollments_db = individual_db.enrollments.all()
+        self.assertEqual(len(enrollments_db), 0)
+
+        individual_db = Individual.objects.get(mk=self.jdoe.uuid)
+        enrollments_db = individual_db.enrollments.all()
+        self.assertEqual(len(enrollments_db), 0)
+
+    @unittest.mock.patch('sortinghat.core.api.find_individual_by_uuid')
+    def test_not_found_uuid_error(self, mock_find_indv):
+        """Check if the affiliation process logs the error when an individual is not found"""
+
+        exc = NotFoundError(entity='dc31d2afbee88a6d1dbc1ef05ec827b878067744')
+        mock_find_indv.side_effect = exc
+
+        ctx = SortingHatContext(self.user)
+
+        # Test
+        expected = {
+            'results': {
+                'dc31d2afbee88a6d1dbc1ef05ec827b878067744': []
+            },
+            'errors': [
+                "dc31d2afbee88a6d1dbc1ef05ec827b878067744 not found in the registry"
+            ]
+        }
+
+        uuids = ['dc31d2afbee88a6d1dbc1ef05ec827b878067744']
+        job = affiliate.delay(ctx, uuids=uuids)
+        result = job.result
+
+        self.assertDictEqual(result, expected)
+
+    @unittest.mock.patch('sortinghat.core.api.add_enrollment')
+    def test_enrollment_errors(self, mock_enroll):
+        """Check if the affiliation process logs the errors there are errors
+        adding enrollments"""
+
+        exc = DuplicateRangeError(start='1900-01-01',
+                                  end='2100-01-01',
+                                  org='Example')
+        mock_enroll.side_effect = exc
+
+        ctx = SortingHatContext(self.user)
+
+        # Test
+        expected = {
+            'results': {
+                'dc31d2afbee88a6d1dbc1ef05ec827b878067744': []
+            },
+            'errors': [
+                "range date '1900-01-01'-'2100-01-01' is part of an existing range for Example"
+            ]
+        }
+
+        uuids = ['dc31d2afbee88a6d1dbc1ef05ec827b878067744']
+        job = affiliate.delay(ctx, uuids=uuids)
+        result = job.result
+
+        self.assertDictEqual(result, expected)
+
+    def test_transactions(self):
+        """Check if the right transactions were created"""
+
+        timestamp = datetime_utcnow()
+
+        ctx = SortingHatContext(self.user)
+
+        affiliate.delay(ctx, job_id='1234-5678-90AB-CDEF')
+
+        transactions = Transaction.objects.filter(created_at__gte=timestamp)
+        self.assertEqual(len(transactions), 4)
+
+        trx = transactions[0]
+        self.assertIsInstance(trx, Transaction)
+        self.assertEqual(trx.name, 'affiliate-1234-5678-90AB-CDEF')
+        self.assertGreater(trx.created_at, timestamp)
+        self.assertEqual(trx.authored_by, ctx.user.username)
+
+        for trx in transactions[1:]:
+            self.assertIsInstance(trx, Transaction)
+            self.assertEqual(trx.name, 'enroll-1234-5678-90AB-CDEF')
+            self.assertGreater(trx.created_at, timestamp)
+            self.assertEqual(trx.authored_by, ctx.user.username)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -110,6 +110,18 @@ class TestLogTransaction(TestCase):
         with self.assertRaisesRegex(TypeError, TRANSACTION_CTX_INVALID_ERROR):
             TransactionsLog.open('test', ctx)
 
+    def test_name_job_id(self):
+        """Check if the job id is included in the name when was defined on the context"""
+
+        ctx = SortingHatContext(self.user, '1234-5678-ABCD-90EF')
+
+        trxl = TransactionsLog.open('test', ctx)
+        self.assertIsInstance(trxl, TransactionsLog)
+
+        trx_db = Transaction.objects.get(tuid=trxl.trx.tuid)
+        self.assertIsInstance(trx_db, Transaction)
+        self.assertEqual(trx_db.name, 'test-1234-5678-ABCD-90EF')
+
     def test_context_anonymous_user(self):
         """Check if a new transaction is added when the user is anonymous"""
 


### PR DESCRIPTION
This PR addresses the request in #292 adding several features to the branch. I was tempted to split them into different PRs but I don't think it makes sense because they need to work as a whole.

* **Recommendations system engine**, which allows to generate recommendations based on the data stored in the registry. The only recommendation type available now is `affiliations`.
* **Affiliation recommender**, which  generates a list of which organizations can be enrolled to which individuals.
* **Job manager**, to schedule and execute long-running jobs, such as recommendations or affiliation, in the asynchronously.
* **Affiliation job**, which runs the affiliation process based in a series of recommendations
* **Mutation to affiliate**, which allows to schedule an affiliation job
* **Mutation to get the status of the jobs**, which giving a job id returns the information about that job.

This PR adds a new dependency: `django_rq`. This  [library](https://github.com/rq/django-rq) provides the job manager to schedule and run jobs. You will need to add this configuration in the Django config file (see the `testing.py` file for an example):
```
INSTALLED_APPS = [
    'django_rq',
    'graphene_django',
    'sortinghat.core',
    'django.contrib.admin',
    'django.contrib.auth',
    'django.contrib.contenttypes',
    'django.contrib.sessions',
    'django.contrib.messages',
    'django.contrib.staticfiles',
]


RQ_QUEUES = {
    'default': {
        'HOST': 'localhost',
        'PORT': 6379,
        'DB': 0
    }
}
```
RQ uses Redis, so you will need to have a Redis server running or use `fakeredis` to pretend you are running it. If that's the case,  add this to your configuration (**before** the declaration of `RQ_QUEUES`).

```import django_rq.queues

from fakeredis import FakeRedis, FakeStrictRedis

class FakeRedisConn:
    """Singleton FakeRedis connection."""

    def __init__(self):
        self.conn = None

    def __call__(self, _, strict):
        if not self.conn:
            self.conn = FakeStrictRedis() if strict else FakeRedis()
        return self.conn

django_rq.queues.get_redis_connection = FakeRedisConn()

RQ_QUEUES = {
    'default': {
        'HOST': 'localhost',
        'PORT': 6379,
        'ASYNC': False,
        'DB': 0
    }
}
```

If you prefer to run it as in production, you will need to run some RQ workers to perform the jobs. You can run them with the command:
```
./manage.py rqworker --settings=<config>
```

To test the PR, add some organizations and individuals; call the mutation `affiliation` and check the results calling `job` query.