### PR TITLE
Visualize indentities data

### DIFF
--- a/ui/src/components/Identity.vue
+++ b/ui/src/components/Identity.vue
@@ -1,0 +1,50 @@
+<template>
+  <v-row no-gutters>
+    <v-col cols="2">
+      <v-chip class="text-center" outlined tile>
+        {{ uuid }}
+      </v-chip>
+    </v-col>
+    <v-col class="ma-2 text-center">
+      <span>{{ name }}</span>
+    </v-col>
+    <v-col class="ma-2 text-center">
+      <span>{{ email }}</span>
+    </v-col>
+    <v-col class="ma-2 text-center">
+      <span>{{ username }}</span>
+    </v-col>
+    <v-col class="ma-2 text-center" v-if="source !== null">
+      <span>{{ source }}</span>
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  name: "identity",
+  props: {
+    uuid: {
+      type: String,
+      required: true
+    },
+    name: {
+      type: String,
+      required: true
+    },
+    email: {
+      type: String,
+      required: true
+    },
+    username: {
+      type: String,
+      required: true
+    },
+    source: {
+      type: String,
+      required: false,
+      default: null
+    }
+  }
+};
+</script>

--- a/ui/src/components/Indentity.stories.js
+++ b/ui/src/components/Indentity.stories.js
@@ -1,0 +1,52 @@
+import { storiesOf } from "@storybook/vue";
+
+import Identity from "./Identity.vue";
+
+export default {
+  title: "Identity",
+  excludeStories: /.*Data$/
+};
+
+const identityTemplate =
+  '<identity :uuid="uuid" :name="name" :email="email" :username="username" :source="source"/>';
+
+export const Default = () => ({
+  components: { Identity },
+  template: identityTemplate,
+  props: {
+    uuid: {
+      default: "10f546"
+    },
+    name: {
+      default: "Tom Marvolo Riddle"
+    },
+    email: {
+      default: "triddle@example.net"
+    },
+    username: {
+      default: "triddle"
+    }
+  }
+});
+
+export const Source = () => ({
+  components: { Identity },
+  template: identityTemplate,
+  props: {
+    uuid: {
+      default: "10f546"
+    },
+    name: {
+      default: "Tom Marvolo Riddle"
+    },
+    email: {
+      default: "triddle@example.net"
+    },
+    username: {
+      default: "triddle"
+    },
+    source: {
+      default: "github"
+    }
+  }
+});

--- a/ui/src/components/IndividualCard.vue
+++ b/ui/src/components/IndividualCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card class="mx-auto" max-width="344" raised>
+  <v-card class="mx-auto" raised>
     <v-list-item class="grow">
       <v-list-item-avatar color="grey">
         {{ getNameInitials }}
@@ -9,6 +9,7 @@
         <v-list-item-title>{{ name }}</v-list-item-title>
       </v-list-item-content>
     </v-list-item>
+    <slot />
   </v-card>
 </template>
 

--- a/ui/src/components/ProfileCard.stories.js
+++ b/ui/src/components/ProfileCard.stories.js
@@ -1,0 +1,65 @@
+import { storiesOf } from "@storybook/vue";
+
+import ProfileCard from "./ProfileCard.vue";
+
+export default {
+  title: "ProfileCard",
+  excludeStories: /.*Data$/
+};
+
+const profileCardTemplate =
+  '<profile-card :name="name" :identities="identities" />';
+
+export const Default = () => ({
+  components: { ProfileCard },
+  template: profileCardTemplate,
+  props: {
+    name: {
+      default: "Tom Marvolo Riddle"
+    },
+    identities: {
+      default: () => [
+        {
+          name: "GitHub",
+          identities: [
+            {
+              uuid: "006afa",
+              name: "Tom Marvolo Riddle",
+              email: "triddle@example.net",
+              username: "triddle"
+            },
+            {
+              uuid: "808b18",
+              name: "Voldemort",
+              email: "-",
+              username: "voldemort"
+            }
+          ]
+        },
+        {
+          name: "Git",
+          identities: [
+            {
+              uuid: "abce32",
+              name: "voldemort",
+              email: "voldemort@example.net",
+              username: "voldemort"
+            }
+          ]
+        },
+        {
+          name: "Others",
+          identities: [
+            {
+              uuid: "4ce562",
+              name: "-",
+              email: "-",
+              username: "voldemort",
+              source: "irc"
+            }
+          ]
+        }
+      ]
+    }
+  }
+});

--- a/ui/src/components/ProfileCard.vue
+++ b/ui/src/components/ProfileCard.vue
@@ -1,0 +1,80 @@
+<template>
+  <individual-card :name="name" style="width: 600px">
+    <v-subheader>Identities</v-subheader>
+
+    <v-list-group
+      :prepend-icon="selectSourceIcon(source.name)"
+      :key="source.name"
+      v-for="source in identities"
+      value="true"
+    >
+      <template v-slot:activator>
+        <v-list-item-content>
+          <v-list-item-title>{{ source.name }}</v-list-item-title>
+        </v-list-item-content>
+      </template>
+
+      <v-list-item
+        v-for="identity in source.identities"
+        :key="identity.uuid"
+        @click=""
+      >
+        <v-list-item-content>
+          <identity
+            v-if="source.name.toLowerCase() !== 'others'"
+            :uuid="identity.uuid"
+            :name="identity.name"
+            :email="identity.email"
+            :username="identity.username"
+          />
+          <identity
+            v-else
+            :uuid="identity.uuid"
+            :name="identity.name"
+            :email="identity.email"
+            :username="identity.username"
+            :source="identity.source"
+          />
+        </v-list-item-content>
+      </v-list-item>
+    </v-list-group>
+  </individual-card>
+</template>
+
+<script>
+import Identity from "./Identity.vue";
+import IndividualCard from "./IndividualCard.vue";
+
+export default {
+  name: "profilecard",
+  components: {
+    Identity,
+    IndividualCard
+  },
+  props: {
+    name: {
+      type: String,
+      required: true
+    },
+    identities: {
+      type: Array,
+      required: true
+    }
+  },
+  methods: {
+    selectSourceIcon(source) {
+      var datasource = source.toLowerCase();
+
+      if (datasource === "github") {
+        return "mdi-github";
+      } else if (datasource === "git") {
+        return "mdi-git";
+      } else if (datasource === "gitlab") {
+        return "mdi-gitlab";
+      } else if (datasource === "others") {
+        return "mdi-account-multiple";
+      }
+    }
+  }
+};
+</script>


### PR DESCRIPTION
This PR adds two new components to visualize identities data: `Identity`, and `ProfileCard`. These two components allow to visualize data as was designed in #298.

![imagen](https://user-images.githubusercontent.com/833352/84299267-baec4080-ab50-11ea-840f-de45f090c0ec.png)
