### PR TITLE
[deps] Constrain numpy version to <= 1.18.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ sqlalchemy>=1.2
 jinja2==2.11.1
 python-dateutil>=2.6.0
 pandas>=0.22.0,<=0.25.3
+numpy<=1.18.3
 pyyaml>=3.12
 requests>=2.9
 urllib3>=1.22

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(name="sortinghat",
         'jinja2==2.11.1',
         'python-dateutil>=2.6.0',
         'pandas>=0.22.0,<=0.25.3',
+        'numpy<=1.18.3',
         'pyyaml>=3.12',
         'requests>=2.9',
         'urllib3>=1.22'


### PR DESCRIPTION
The numpy dependency is constrained to <= 1.18.3. This change is needed since from version 1.19.x the support for python 3.5 has been discontinued.

Refs:
- https://numpy.org/devdocs/release/1.19.0-notes.html#id1
- https://github.com/numpy/numpy/issues/16294