### PR TITLE
[ui] Support pagination arguments in getIndividuals query

### DIFF
--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -18,18 +18,27 @@ const GET_INDIVIDUAL_BYUUID = gql`
 `;
 
 const GET_INDIVIDUALS = gql`
-  query GetIndividuals {
-    individuals {
+  query GetIndividuals($page: Int!, $pageSize: Int!) {
+    individuals(page: $page, pageSize: $pageSize) {
       entities {
+        mk
         identities {
           name
-          email
-          username
         }
         profile {
           id
           name
         }
+      }
+      pageInfo {
+        page
+        pageSize
+        numPages
+        hasNext
+        hasPrev
+        startIndex
+        endIndex
+        totalResults
       }
     }
   }
@@ -45,8 +54,20 @@ const getIndividualByUuid = (apollo, uuid) => {
   return response;
 };
 
-const getIndividuals = apollo => {
-  let response = apollo.query({ query: GET_INDIVIDUALS });
+const getIndividuals = (apollo, page, pageSize) => {
+  if (!page) {
+    page = 1;
+  }
+  if (!pageSize) {
+    pageSize = 10;
+  }
+  let response = apollo.query({
+    query: GET_INDIVIDUALS,
+    variables: {
+      page: page,
+      pageSize: pageSize
+    }
+  });
   return response;
 };
 

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -24,6 +24,16 @@ describe("App", () => {
             }
           ],
           __typename: "IdentityPaginatedType"
+        },
+        pageInfo: {
+          page: 1,
+          pageSize: 10,
+          numPages: 1,
+          hasNext: false,
+          hasPrev: false,
+          startIndex: 1,
+          endIndex: 1,
+          totalResults: 1
         }
       }
     };

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -2,41 +2,42 @@ import { shallowMount } from "@vue/test-utils";
 import Vue from "vue";
 import Vuetify from "vuetify";
 import App from "@/App";
-import { getIndividuals } from "@/apollo/queries";
+import * as Queries from "@/apollo/queries";
 
 Vue.use(Vuetify);
 
+const responseMocked = {
+  data: {
+    individuals: {
+      entities: [
+        {
+          mk: "172188fd88c1df2dd6d187b6f32cb6aced544aee",
+          identities: [{ name: "test name", __typename: "IdentityType" }],
+          profile: {
+            id: "7",
+            name: "test name",
+            __typename: "ProfileType"
+          },
+          __typename: "IndividualType"
+        }
+      ],
+      __typename: "IdentityPaginatedType"
+    },
+    pageInfo: {
+      page: 1,
+      pageSize: 10,
+      numPages: 1,
+      hasNext: false,
+      hasPrev: false,
+      startIndex: 1,
+      endIndex: 1,
+      totalResults: 1
+    }
+  }
+};
+
 describe("App", () => {
   test("mock query for getIndividuals", async () => {
-    const responseMocked = {
-      data: {
-        individuals: {
-          entities: [
-            {
-              mk: "172188fd88c1df2dd6d187b6f32cb6aced544aee",
-              identities: [{ name: "test name", __typename: "IdentityType" }],
-              profile: {
-                id: "7",
-                name: "test name",
-                __typename: "ProfileType"
-              },
-              __typename: "IndividualType"
-            }
-          ],
-          __typename: "IdentityPaginatedType"
-        },
-        pageInfo: {
-          page: 1,
-          pageSize: 10,
-          numPages: 1,
-          hasNext: false,
-          hasPrev: false,
-          startIndex: 1,
-          endIndex: 1,
-          totalResults: 1
-        }
-      }
-    };
     const query = jest.fn(() => Promise.resolve(responseMocked));
     const wrapper = shallowMount(App, {
       Vue,
@@ -46,7 +47,7 @@ describe("App", () => {
         }
       }
     });
-    let response = await getIndividuals(wrapper.vm.$apollo);
+    let response = await Queries.getIndividuals(wrapper.vm.$apollo);
     let individuals_mocked = response.data;
     await wrapper.setData({
       individuals_mocked
@@ -55,5 +56,28 @@ describe("App", () => {
     expect(query).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();
     expect(wrapper.vm.individuals).toBe(responseMocked.data.individuals);
+  });
+
+  test("getIndividuals with arguments", async () => {
+    const getIndividualsSpied = spyOn(Queries, "getIndividuals");
+    
+    let response = await Queries.getIndividuals(undefined, 10, 100);
+    expect(getIndividualsSpied).toHaveBeenLastCalledWith(undefined, 10, 100);
+  });
+
+  test("getIndividuals without arguments in the App component", async () => {
+    const getIndividualsSpied = spyOn(Queries, "getIndividuals");
+    const query = jest.fn(() => Promise.resolve(responseMocked));
+    const wrapper = shallowMount(App, {
+      Vue,
+      mocks: {
+        $apollo: {
+          query
+        }
+      }
+    });
+
+    expect(getIndividualsSpied).toBeCalled();
+    expect(getIndividualsSpied).toHaveBeenCalledWith(wrapper.vm.$apollo);
   });
 });


### PR DESCRIPTION
This PR allows the getIndividuals query to use the pagination functionality, adding the next arguments:

- page: integer in order to ask the page (by default, 1)
- pageSize: integer in order to define the size of the query (by default, 10) 

Moreover, the query returns all the data related to the pagination (pageInfo).

This PR is related to #303 