### PR TITLE
Get matching identities recommendations from sets of individuals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ jinja2==2.11.1
 rq>=1.4.0
 django-rq>=2.3.2
 fakeredis>=1.4.1
+pandas>=1.0.5

--- a/sortinghat/core/recommendations/engine.py
+++ b/sortinghat/core/recommendations/engine.py
@@ -23,6 +23,7 @@ import collections
 
 from ..errors import RecommendationEngineError
 from .affiliation import recommend_affiliations
+from .matching import recommend_matches
 
 
 Recommendation = collections.namedtuple(
@@ -39,7 +40,8 @@ class RecommendationEngine:
     on the registry.
     """
     RECOMMENDATION_TYPES = {
-        'affiliation': recommend_affiliations
+        'affiliation': recommend_affiliations,
+        'matches': recommend_matches
     }
 
     def recommend(self, name, *args, **kwargs):

--- a/sortinghat/core/recommendations/matching.py
+++ b/sortinghat/core/recommendations/matching.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+
+import pandas
+
+from django.forms.models import model_to_dict
+
+from ..db import (find_individual_by_uuid)
+from ..errors import NotFoundError
+
+
+def recommend_matches(source_uuids, target_uuids, criteria, verbose=False):
+    """Recommend identity matches for a list of individuals.
+
+    Returns a generator of identity matches recommendations
+    based on a list of criteria composed by email addresses,
+    name and/or usernames of the individuals.
+
+    The function checks if any identity from each individual
+    matches with a given set of target individuals. First,
+    it filters by the fields from the criteria and then it
+    groups the matches by identity. Then, these groups are
+    turned into sets of matching identities found among all
+    the input identities set.
+
+    Each recommendation contains the uuid of the individual
+    provided in the input list and a list with the matching
+    individuals or the matching identities if the `verbose`
+    option is activated.
+
+    When no matching is found for a given individual, an empty
+    list is returned.
+
+    :param source_uuids: list of individual keys to find matches for
+    :param target_uuids: list of individual keys where to find matches
+    :param criteria: list of matching criteria (`email`, `name`, `username`).
+    :param verbose: if set to `True`, the list of results will include individual
+    identities. Otherwise, results will include main keys from individuals.
+
+    :returns: a generator of recommendations
+    """
+
+    def _get_identities(uuid):
+        """Get the identities from a given Individual based on one of its uuids"""
+
+        try:
+            individual = find_individual_by_uuid(uuid)
+        except NotFoundError:
+            identities = []
+        else:
+            identities = individual.identities.all()
+
+        return identities
+
+    aliases = {}
+    input_set = set()
+    target_set = set()
+    for uuid in source_uuids:
+        identities = _get_identities(uuid)
+        aliases[uuid] = [identity.uuid for identity in identities]
+        input_set.update(identities)
+    for uuid in target_uuids:
+        identities = _get_identities(uuid)
+        target_set.update(identities)
+
+    matched = _find_matches(input_set, target_set, criteria, verbose=verbose)
+    # Return filtered results
+    for uuid in source_uuids:
+        result = []
+        if uuid in matched.keys():
+            result = matched[uuid]
+        else:
+            for alias in aliases[uuid]:
+                if alias in matched.keys():
+                    result = matched[alias]
+        yield uuid, result
+
+
+def _find_matches(set_x, set_y, criteria, verbose):
+    """Find identities matches between two sets using Pandas' library.
+
+    This method find matches for the indentities in `set_x` looking at
+    the identities from `set_y` given a list of criteria.
+
+    The identities sets are transformed into Pandas dataframes and
+    they are filtered according to the different criteria, then
+    merged and grouped by the identities from `set_x`. The grouped
+    results are transformed into sets of results taking into account
+    the results from the rest of results to generate complete sets
+    of matches per each identity from `set_x`.
+
+    :param set_x: list of individual keys to find matches for
+    :param set_y: list of individual keys where to find matches
+    :param criteria: list of matching criteria (`email`, `name`, `username`).
+    :param verbose: if set to `True`, the list of results will include individual
+        identities. Otherwise, results will include main keys from individuals.
+
+    :returns: a dictionary including the set of matches found for each
+        identity from `set_x`.
+    """
+    def _to_df(data_set):
+        """Convert identities set into a Pandas `Dataframe` object"""
+        df = pandas.DataFrame(data_set)
+        return df.sort_values(['individual'])
+
+    def _filter_criteria(df, c):
+        """Filter dataframe creating a basic subset including a given column"""
+        cols = ['uuid', 'individual', c]
+        cdf = df[cols]
+        return cdf.dropna(subset=[c])
+
+    def _calculate_matches_groups(grouped_uids, verbose=False):
+        """Calculate groups of matching identities from identity groups.
+
+        For instance, given a list of matched unique identities like
+        A = {A, B}; B = {B,A,C}, C = {C,} and D = {D,} the output
+        for keys A, B and C will be the set {A, B, C}. As D has no matches,
+        it won't be included in any group and it won't be returned.
+
+        :param grouped_uids: groups of unique identities
+        :param verbose: if true, the grouping will be calculated using
+            unique identities (uuids) instead of main keys from individuals.
+
+        :returns: a dictionary including the set of matches for each
+            group key.
+        """
+        matches = {}
+        # Group by main keys from Individuals or by uuids from Identities
+        col_name = 'uuid_y' if verbose else 'individual_y'
+
+        sorted_keys = sorted(grouped_uids.groups.keys())
+
+        while sorted_keys:
+            group_key = sorted_keys.pop(0)
+            uuid_set = set()
+            for uuid in grouped_uids.get_group(group_key)[col_name]:
+                uuid_set.add(uuid)
+
+            for key in matches:
+                prev_match = matches[key]
+                if prev_match == uuid_set:
+                    continue
+                elif prev_match.intersection(uuid_set):
+                    prev_match.update(uuid_set)
+                    uuid_set = prev_match
+            matches[group_key] = uuid_set
+
+        return matches
+
+    data_x = [model_to_dict(fl) for fl in set_x]
+    data_y = [model_to_dict(fl) for fl in set_y]
+
+    if (not data_x) or (not data_y):
+        return {}
+
+    df_x = _to_df(data_x)
+    df_y = _to_df(data_y)
+
+    cdfs = []
+
+    for c in criteria:
+        cdf_x = _filter_criteria(df_x, c)
+        cdf_y = _filter_criteria(df_y, c)
+        cdf = pandas.merge(cdf_x, cdf_y, on=c, how='inner')
+        cdf = cdf[['individual_y', 'uuid_x', 'uuid_y']]
+        cdfs.append(cdf)
+
+    result = pandas.concat(cdfs)
+    result = result.drop_duplicates()
+
+    g_result = result.groupby(by=['uuid_x'],
+                              as_index=True, sort=True)
+
+    matched = _calculate_matches_groups(g_result, verbose=verbose)
+
+    return matched

--- a/tests/rec/test_engine.py
+++ b/tests/rec/test_engine.py
@@ -95,4 +95,4 @@ class TestRecommendationEngine(TestCase):
         """Test the list of supported recommendation types"""
 
         types = RecommendationEngine.types()
-        self.assertListEqual(types, ['affiliation'])
+        self.assertListEqual(types, ['affiliation', 'matches'])

--- a/tests/rec/test_matches.py
+++ b/tests/rec/test_matches.py
@@ -1,0 +1,242 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2020 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from sortinghat.core import api
+from sortinghat.core.context import SortingHatContext
+from sortinghat.core.recommendations.matching import recommend_matches
+
+
+class TestRecommendMatches(TestCase):
+    """Unit tests for recommend_matches"""
+
+    def setUp(self):
+        """Initialize database with a dataset"""
+
+        self.user = get_user_model().objects.create(username='test')
+        self.ctx = SortingHatContext(self.user)
+
+        # Individual 1
+        self.john_smith = api.add_identity(self.ctx,
+                                           email='jsmith@example.com',
+                                           name='John Smith',
+                                           source='scm')
+        self.js2 = api.add_identity(self.ctx,
+                                    name='John Smith',
+                                    source='scm',
+                                    uuid=self.john_smith.uuid)
+        self.js3 = api.add_identity(self.ctx,
+                                    username='jsmith',
+                                    source='scm',
+                                    uuid=self.john_smith.uuid)
+
+        # Individual 2
+        self.jsmith = api.add_identity(self.ctx,
+                                       name='J. Smith',
+                                       username='john_smith',
+                                       source='alt')
+        self.jsm2 = api.add_identity(self.ctx,
+                                     name='John Smith',
+                                     username='jsmith',
+                                     source='alt',
+                                     uuid=self.jsmith.uuid)
+        self.jsm3 = api.add_identity(self.ctx,
+                                     email='jsmith@example.com',
+                                     source='alt',
+                                     uuid=self.jsmith.uuid)
+
+        # Individual 3
+        self.jane_rae = api.add_identity(self.ctx,
+                                         name='Janer Rae',
+                                         source='mls')
+        self.jr2 = api.add_identity(self.ctx,
+                                    email='jane.rae@example.net',
+                                    name='Jane Rae Doe',
+                                    source='mls',
+                                    uuid=self.jane_rae.uuid)
+
+        # Individual 4
+        self.js_alt = api.add_identity(self.ctx,
+                                       name='J. Smith',
+                                       username='john_smith',
+                                       source='scm')
+        self.js_alt2 = api.add_identity(self.ctx,
+                                        email='JSmith@example.com',
+                                        username='john_smith',
+                                        source='mls',
+                                        uuid=self.js_alt.uuid)
+        self.js_alt3 = api.add_identity(self.ctx,
+                                        username='Smith. J',
+                                        source='mls',
+                                        uuid=self.js_alt.uuid)
+        self.js_alt4 = api.add_identity(self.ctx,
+                                        email='JSmith@example.com',
+                                        name='Smith. J',
+                                        source='mls',
+                                        uuid=self.js_alt.uuid)
+
+        # Individual 5
+        self.jrae = api.add_identity(self.ctx,
+                                     email='jrae@example.net',
+                                     name='Jane Rae Doe',
+                                     source='mls')
+        self.jrae2 = api.add_identity(self.ctx,
+                                      name='jrae',
+                                      source='mls',
+                                      uuid=self.jrae.uuid)
+        self.jrae3 = api.add_identity(self.ctx,
+                                      name='jrae',
+                                      source='scm',
+                                      uuid=self.jrae.uuid)
+
+    def test_recommend_matches(self):
+        """Check if recommendations are obtained for the specified individuals"""
+
+        # Test
+        expected = {
+            self.john_smith.uuid: sorted([self.john_smith.uuid,
+                                          self.jsmith.uuid]),
+            self.jrae3.uuid: sorted([self.jrae.uuid,
+                                     self.jane_rae.uuid]),
+            self.jr2.uuid: sorted([self.jrae.uuid,
+                                   self.jane_rae.uuid])
+        }
+
+        source_uuids = [self.john_smith.uuid, self.jrae3.uuid, self.jr2.uuid]
+        target_uuids = [self.john_smith.uuid, self.js2.uuid, self.js3.uuid,
+                        self.jsmith.uuid, self.jsm2.uuid, self.jsm3.uuid,
+                        self.jane_rae.uuid, self.jr2.uuid,
+                        self.js_alt.uuid, self.js_alt2.uuid,
+                        self.js_alt3.uuid, self.js_alt4.uuid,
+                        self.jrae.uuid, self.jrae2.uuid, self.jrae3.uuid]
+
+        criteria = ['email', 'name', 'username']
+
+        # Identities which don't have the fields in `criteria` won't be returned
+        recs = dict(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria))
+
+        # Preserve results order for the comparison against the expected results
+        result = {}
+        for key in recs:
+            result[key] = sorted(recs[key])
+
+        self.assertEqual(len(result), 3)
+        self.assertDictEqual(result, expected)
+
+    def test_recommend_matches_verbose(self):
+        """Check if recommendations are obtained for the specified individuals, at identity level"""
+
+        # Test
+        expected = {
+            self.john_smith.uuid: sorted([self.john_smith.uuid,
+                                          self.jsm2.uuid,
+                                          self.jsm3.uuid,
+                                          self.js2.uuid,
+                                          self.js3.uuid]),
+            self.jrae3.uuid: sorted([self.jrae2.uuid,
+                                     self.jrae3.uuid]),
+            self.jr2.uuid: sorted([self.jrae.uuid,
+                                   self.jr2.uuid])
+        }
+
+        source_uuids = [self.john_smith.uuid, self.jrae3.uuid, self.jr2.uuid]
+        target_uuids = [self.john_smith.uuid, self.js2.uuid, self.js3.uuid,
+                        self.jsmith.uuid, self.jsm2.uuid, self.jsm3.uuid,
+                        self.jane_rae.uuid, self.jr2.uuid,
+                        self.js_alt.uuid, self.js_alt2.uuid, self.js_alt3.uuid, self.js_alt4.uuid,
+                        self.jrae.uuid, self.jrae2.uuid, self.jrae3.uuid]
+
+        criteria = ['email', 'name', 'username']
+
+        # Identities which don't have the fields in `criteria` won't be returned
+        recs = dict(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria,
+                                      verbose=True))
+        # Preserve results order for the comparison against the expected results
+        result = {}
+        for key in recs:
+            result[key] = sorted(recs[key])
+
+        self.assertEqual(len(result), 3)
+        self.assertDictEqual(result, expected)
+
+    def test_recommend_source_not_mk(self):
+        """Check if recommendations work when the provided uuid is not an Individual's main key"""
+
+        # Test
+        expected = {
+            self.js3.uuid: [self.jsmith.uuid]
+        }
+
+        source_uuids = [self.js3.uuid]
+        target_uuids = [self.jsm3.uuid]
+        criteria = ['email', 'name', 'username']
+
+        recs = dict(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria))
+
+        # Preserve same format as in other tests.
+        # 1-element result is returned as {key: {result}} instead of {key: [result]}
+        result = {}
+        for key in recs:
+            result[key] = list(recs[key])
+
+        self.assertEqual(len(recs), 1)
+        self.assertDictEqual(result, expected)
+
+    def test_no_matches_found(self):
+        """Check whether it returns an empty result when there is no matches for the input identity"""
+
+        # Test
+        expected = {'880b3dfcb3a08712e5831bddc3dfe81fc5d7b331': []}
+
+        source_uuids = [self.john_smith.uuid]
+        target_uuids = [self.jrae.uuid]
+        criteria = ['email', 'name']
+
+        recs = dict(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria))
+
+        self.assertDictEqual(recs, expected)
+
+    def test_not_found_uuid_error(self):
+        """Check if the recommendation process returns no results when an individual is not found"""
+
+        # Test
+        expected = {'1234567890abcdefg': []}
+
+        source_uuids = ['1234567890abcdefg']
+        target_uuids = [self.john_smith.uuid]
+        criteria = ['email', 'name']
+
+        recs = dict(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria))
+
+        self.assertDictEqual(recs, expected)


### PR DESCRIPTION
Recommend identity matches for a list of individuals.

Note: This PR is related to issue #302 .

This job generates a list of recommendations with the matching identities which the input individuals can be merged with, based on a list of criteria composed by email addresses, name and/or usernames of the individuals.

The function behind the scenes checks if any identity from each individual matches with a given set of target individuals. First, it filters by the fields from the criteria and then it groups the matches by identity. Then, these groups are turned into sets of matching identities found among all the input identities set.

Each recommendation contains the uuid of the individual provided in the input list and a list with the matching individuals or the matching identities if the `verbose` option is activated.

When no matching is found for a given individual, an empty list will be returned for that individual.

Individuals both for `source_uuids` and `target_uuids` are defined by any of their valid keys or UUIDs. When the parameter `target_uuids` is empty, the job will take all the individuals stored in the registry, so matches will be found comparing the identities from the individuals in `source_uuids` against all the identities on the registry.
