### PR TITLE
Fix ui test warnings

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -55,7 +55,9 @@ export default {
   }),
   async created() {
     let response = await getIndividuals(this.$apollo);
-    this.individuals = response.data.individuals;
+    if (response) {
+      this.individuals = response.data.individuals;
+    }
   }
 };
 </script>

--- a/ui/src/components/Indentity.stories.js
+++ b/ui/src/components/Indentity.stories.js
@@ -25,6 +25,9 @@ export const Default = () => ({
     },
     username: {
       default: "triddle"
+    },
+    source: {
+      default: null
     }
   }
 });

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -45,6 +45,11 @@ describe("App", () => {
         $apollo: {
           query
         }
+      },
+      data() {
+        return {
+          individuals_mocked: null
+        }
       }
     });
     let response = await Queries.getIndividuals(wrapper.vm.$apollo);
@@ -60,7 +65,7 @@ describe("App", () => {
 
   test("getIndividuals with arguments", async () => {
     const getIndividualsSpied = spyOn(Queries, "getIndividuals");
-    
+
     let response = await Queries.getIndividuals(undefined, 10, 100);
     expect(getIndividualsSpied).toHaveBeenLastCalledWith(undefined, 10, 100);
   });


### PR DESCRIPTION
This PR fixes the three Vue warnings that are raised when running the ui tests described on #314 .
Two of them were due to some variables not having been declared before being used or assigned a value, and one was caused by a failing query on App.vue that didn't have any error control.