### PR TITLE
[ui] Individuals and Organizations sections in ProfileCard as nested list

### DIFF
--- a/ui/src/components/ProfileCard.vue
+++ b/ui/src/components/ProfileCard.vue
@@ -1,47 +1,61 @@
 <template>
   <individual-card :name="name" style="width: 600px">
-    <v-subheader>Identities</v-subheader>
+    <v-list-group>
+      <template v-slot:activator>
+        <v-list-item-title>Identities ({{ identitiesCount }})</v-list-item-title>
+      </template>
 
-    <v-list-group
-      :prepend-icon="selectSourceIcon(source.name)"
-      :key="source.name"
-      v-for="source in identities"
-      value="true"
-    >
+      <v-list-group
+        sub-group
+        :key="source.name"
+        v-for="source in identities"
+        value="true"
+      >
+        <template v-slot:activator>
+          <v-list-item-icon>
+            <v-icon
+              v-text="selectSourceIcon(source.name)"
+              left
+            />
+          </v-list-item-icon>
+          <v-list-item-content>
+            <v-list-item-title>{{ source.name }}</v-list-item-title>
+          </v-list-item-content>
+        </template>
+
+        <v-list-item
+          v-for="identity in source.identities"
+          :key="identity.uuid"
+          @click=""
+        >
+          <v-list-item-content>
+            <identity
+              v-if="source.name.toLowerCase() !== 'others'"
+              :uuid="identity.uuid"
+              :name="identity.name"
+              :email="identity.email"
+              :username="identity.username"
+            />
+            <identity
+              v-else
+              :uuid="identity.uuid"
+              :name="identity.name"
+              :email="identity.email"
+              :username="identity.username"
+              :source="identity.source"
+            />
+          </v-list-item-content>
+        </v-list-item>
+      </v-list-group>
+    </v-list-group>
+
+    <v-list-group>
       <template v-slot:activator>
         <v-list-item-content>
-          <v-list-item-title>{{ source.name }}</v-list-item-title>
+          <v-list-item-title>Organizations ({{ enrollments.length }})</v-list-item-title>
         </v-list-item-content>
       </template>
 
-      <v-list-item
-        v-for="identity in source.identities"
-        :key="identity.uuid"
-        @click=""
-      >
-        <v-list-item-content>
-          <identity
-            v-if="source.name.toLowerCase() !== 'others'"
-            :uuid="identity.uuid"
-            :name="identity.name"
-            :email="identity.email"
-            :username="identity.username"
-          />
-          <identity
-            v-else
-            :uuid="identity.uuid"
-            :name="identity.name"
-            :email="identity.email"
-            :username="identity.username"
-            :source="identity.source"
-          />
-        </v-list-item-content>
-      </v-list-item>
-    </v-list-group>
-
-    <v-subheader>Organizations ({{ enrollments.length }})</v-subheader>
-
-    <v-list>
       <v-list-item
         v-for="enrollment in enrollments"
         :key="enrollment.organization.id"
@@ -60,7 +74,7 @@
           </v-row>
         </v-list-item-content>
       </v-list-item>
-    </v-list>
+    </v-list-group>
   </individual-card>
 </template>
 
@@ -104,6 +118,11 @@ export default {
     },
     formatDate(dateTime) {
       return dateTime.split('T')[0]
+    }
+  },
+  computed: {
+    identitiesCount() {
+      return this.identities.reduce((a,b) => a + b.identities.length, 0)
     }
   }
 };

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -549,35 +549,47 @@ exports[`Storyshots ProfileCard Default 1`] = `
       </div>
        
       <div
-        class="v-subheader theme--light"
-      >
-        Identities
-      </div>
-       
-      <div
-        class="v-list-group v-list-group--active primary--text"
+        class="v-list-group"
       >
         <div
-          aria-expanded="true"
-          class="v-list-group__header v-list-item v-list-item--active v-list-item--link theme--light"
+          aria-expanded="false"
+          class="v-list-group__header v-list-item v-list-item--link theme--light"
           role="button"
           tabindex="0"
         >
           <div
-            class="v-list-item__icon v-list-group__header__prepend-icon"
+            class="v-list-item__title"
+          >
+            Identities (4)
+          </div>
+          <div
+            class="v-list-item__icon v-list-group__header__append-icon"
           >
             <i
               aria-hidden="true"
-              class="v-icon notranslate mdi mdi-github theme--light"
+              class="v-icon notranslate mdi mdi-chevron-down theme--light"
             />
           </div>
+        </div>
+        <!---->
+      </div>
+       
+      <div
+        class="v-list-group"
+      >
+        <div
+          aria-expanded="false"
+          class="v-list-group__header v-list-item v-list-item--link theme--light"
+          role="button"
+          tabindex="0"
+        >
           <div
             class="v-list-item__content"
           >
             <div
               class="v-list-item__title"
             >
-              GitHub
+              Organizations (2)
             </div>
           </div>
           <div
@@ -589,405 +601,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
             />
           </div>
         </div>
-        <div
-          class="v-list-group__items"
-        >
-           
-          <div
-            class="v-list-item v-list-item--link theme--light"
-            tabindex="0"
-          >
-            <div
-              class="v-list-item__content"
-            >
-              <div
-                class="row no-gutters"
-              >
-                <div
-                  class="col col-2"
-                >
-                  <span
-                    class="text-center v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
-                  >
-                    <span
-                      class="v-chip__content"
-                    >
-                      
-      006afa
-    
-                    </span>
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    Tom Marvolo Riddle
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    triddle@example.net
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    triddle
-                  </span>
-                </div>
-                 
-                <!---->
-              </div>
-            </div>
-          </div>
-          <div
-            class="v-list-item v-list-item--link theme--light"
-            tabindex="0"
-          >
-            <div
-              class="v-list-item__content"
-            >
-              <div
-                class="row no-gutters"
-              >
-                <div
-                  class="col col-2"
-                >
-                  <span
-                    class="text-center v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
-                  >
-                    <span
-                      class="v-chip__content"
-                    >
-                      
-      808b18
-    
-                    </span>
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    Voldemort
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    -
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    voldemort
-                  </span>
-                </div>
-                 
-                <!---->
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="v-list-group v-list-group--active primary--text"
-      >
-        <div
-          aria-expanded="true"
-          class="v-list-group__header v-list-item v-list-item--active v-list-item--link theme--light"
-          role="button"
-          tabindex="0"
-        >
-          <div
-            class="v-list-item__icon v-list-group__header__prepend-icon"
-          >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-git theme--light"
-            />
-          </div>
-          <div
-            class="v-list-item__content"
-          >
-            <div
-              class="v-list-item__title"
-            >
-              Git
-            </div>
-          </div>
-          <div
-            class="v-list-item__icon v-list-group__header__append-icon"
-          >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-chevron-down theme--light"
-            />
-          </div>
-        </div>
-        <div
-          class="v-list-group__items"
-        >
-           
-          <div
-            class="v-list-item v-list-item--link theme--light"
-            tabindex="0"
-          >
-            <div
-              class="v-list-item__content"
-            >
-              <div
-                class="row no-gutters"
-              >
-                <div
-                  class="col col-2"
-                >
-                  <span
-                    class="text-center v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
-                  >
-                    <span
-                      class="v-chip__content"
-                    >
-                      
-      abce32
-    
-                    </span>
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    voldemort
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    voldemort@example.net
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    voldemort
-                  </span>
-                </div>
-                 
-                <!---->
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div
-        class="v-list-group v-list-group--active primary--text"
-      >
-        <div
-          aria-expanded="true"
-          class="v-list-group__header v-list-item v-list-item--active v-list-item--link theme--light"
-          role="button"
-          tabindex="0"
-        >
-          <div
-            class="v-list-item__icon v-list-group__header__prepend-icon"
-          >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-account-multiple theme--light"
-            />
-          </div>
-          <div
-            class="v-list-item__content"
-          >
-            <div
-              class="v-list-item__title"
-            >
-              Others
-            </div>
-          </div>
-          <div
-            class="v-list-item__icon v-list-group__header__append-icon"
-          >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-chevron-down theme--light"
-            />
-          </div>
-        </div>
-        <div
-          class="v-list-group__items"
-        >
-           
-          <div
-            class="v-list-item v-list-item--link theme--light"
-            tabindex="0"
-          >
-            <div
-              class="v-list-item__content"
-            >
-              <div
-                class="row no-gutters"
-              >
-                <div
-                  class="col col-2"
-                >
-                  <span
-                    class="text-center v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
-                  >
-                    <span
-                      class="v-chip__content"
-                    >
-                      
-      4ce562
-    
-                    </span>
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    -
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    -
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    voldemort
-                  </span>
-                </div>
-                 
-                <div
-                  class="ma-2 text-center col"
-                >
-                  <span>
-                    irc
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-       
-      <div
-        class="v-subheader theme--light"
-      >
-        Organizations (2)
-      </div>
-       
-      <div
-        class="v-list v-sheet v-sheet--tile theme--light"
-        role="list"
-      >
-        <div
-          class="v-list-item theme--light"
-          role="listitem"
-          tabindex="-1"
-        >
-          <div
-            class="v-list-item__content"
-          >
-            <div
-              class="row no-gutters"
-            >
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  Hogwarts School of Witchcraft and Wizardry
-                </span>
-              </div>
-               
-              <div
-                class="col-3 ma-2 text-center col"
-              >
-                <span>
-                  1938-09-01
-                </span>
-              </div>
-               
-              <div
-                class="col-3 ma-2 text-center col"
-              >
-                <span>
-                  1945-06-02
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="v-list-item theme--light"
-          role="listitem"
-          tabindex="-1"
-        >
-          <div
-            class="v-list-item__content"
-          >
-            <div
-              class="row no-gutters"
-            >
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  Slytherin House
-                </span>
-              </div>
-               
-              <div
-                class="col-3 ma-2 text-center col"
-              >
-                <span>
-                  1938-09-01
-                </span>
-              </div>
-               
-              <div
-                class="col-3 ma-2 text-center col"
-              >
-                <span>
-                  1998-05-02
-                </span>
-              </div>
-            </div>
-          </div>
-        </div>
+        <!---->
       </div>
     </div>
   </div>


### PR DESCRIPTION
This PR turns the `Organizations` and `Individuals` sections
in ProfileCard.vue into nested, expandable lists, and adds a
count to the 'Individuals' header as requested in #317 

![imagen](https://user-images.githubusercontent.com/26812577/93779001-c4dd0f80-fc26-11ea-8418-ebab4edfceac.png)