### PR TITLE
[ui] Allow to lock individuals

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -1,0 +1,45 @@
+import gql from "graphql-tag";
+
+const LOCK_INDIVIDUAL = gql`
+  mutation LockIndividual($uuid: String!) {
+    lock(uuid: $uuid) {
+      uuid
+      individual {
+        isLocked
+      }
+    }
+  }
+`;
+
+const UNLOCK_INDIVIDUAL = gql`
+  mutation UnlockIndividual($uuid: String!) {
+    unlock(uuid: $uuid) {
+      uuid
+      individual {
+        isLocked
+      }
+    }
+  }
+`;
+
+const lockIndividual = (apollo, uuid) => {
+  let response = apollo.mutate({
+    mutation: LOCK_INDIVIDUAL,
+    variables: {
+      uuid: uuid
+    }
+  });
+  return response;
+};
+
+const unlockIndividual = (apollo, uuid) => {
+  let response = apollo.mutate({
+    mutation: UNLOCK_INDIVIDUAL,
+    variables: {
+      uuid: uuid
+    }
+  });
+  return response;
+};
+
+export { lockIndividual, unlockIndividual };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -26,6 +26,7 @@ const GET_INDIVIDUALS = gql`
         identities {
           name
           source
+          uuid
         }
         profile {
           id

--- a/ui/src/components/IndividualCard.stories.js
+++ b/ui/src/components/IndividualCard.stories.js
@@ -7,7 +7,7 @@ export default {
   excludeStories: /.*Data$/
 };
 
-const individualCardTemplate = '<individual-card :name="name" :sources="sources" :is-locked="isLocked" />';
+const individualCardTemplate = '<individual-card :name="name" :sources="sources" :is-locked="isLocked" :uuid="uuid" />';
 
 export const Default = () => ({
   components: { IndividualCard },
@@ -21,6 +21,9 @@ export const Default = () => ({
     },
     isLocked: {
       default: false
+    },
+    uuid: {
+      default: "10f546"
     }
   }
 });
@@ -36,6 +39,9 @@ export const SingleInitial = () => ({
     },
     isLocked: {
       default: false
+    },
+    uuid: {
+      default: "10f546"
     }
   }
 });
@@ -56,6 +62,9 @@ export const Sources = () => ({
     },
     isLocked: {
       default: false
+    },
+    uuid: {
+      default: "10f546"
     }
   }
 });
@@ -71,6 +80,9 @@ export const Locked = () => ({
     },
     isLocked: {
       default: true
+    },
+    uuid: {
+      default: "10f546"
     }
   }
 });

--- a/ui/src/components/IndividualCard.vue
+++ b/ui/src/components/IndividualCard.vue
@@ -18,8 +18,8 @@
       </v-list-item-content>
 
       <v-list-item-icon>
-        <v-btn text icon>
-          <v-icon small @click="toggleLockedStatus">
+        <v-btn text icon @click="toggleLockedStatus">
+          <v-icon small>
             {{ locked ? "mdi-lock" : "mdi-lock-open-outline" }}
           </v-icon>
         </v-btn>
@@ -104,7 +104,14 @@ export default {
             text: error.toString()
           };
         }
+      } else if (this.$root.STORYBOOK_COMPONENT) {
+        this.locked = !this.locked;
       }
+    }
+  },
+  watch: {
+    isLocked(value) {
+      this.locked = value;
     }
   }
 };

--- a/ui/src/components/IndividualCard.vue
+++ b/ui/src/components/IndividualCard.vue
@@ -25,6 +25,7 @@
         </v-btn>
       </v-list-item-icon>
     </v-list-item>
+    <slot />
     <v-snackbar v-model="snackbar.value" color="error">
       {{ snackbar.text || "Error" }}
     </v-snackbar>
@@ -95,8 +96,13 @@ export default {
             : lockIndividual(this.$apollo, this.uuid);
           const response = await mutation;
 
-          if (response) {
+          if (response && !response.errors) {
             this.locked = !this.locked;
+          } else {
+            this.snackbar = {
+              value: true,
+              text: response.errors[0].message
+            };
           }
         } catch (error) {
           this.snackbar = {

--- a/ui/src/components/IndividualsGrid.stories.js
+++ b/ui/src/components/IndividualsGrid.stories.js
@@ -24,7 +24,8 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "GitLab"
+              source: "GitLab",
+              uuid: "10f546"
             },
           ]
         },
@@ -36,13 +37,16 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "GitHub"
+              source: "GitHub",
+              uuid: "10f546"
             },
             {
-              source: "git"
+              source: "git",
+              uuid: "10f546"
             },
             {
-              source: "Others"
+              source: "Others",
+              uuid: "10f546"
             }
           ]
         },
@@ -54,7 +58,8 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "GitLab"
+              source: "GitLab",
+              uuid: "10f546"
             },
           ]
         },
@@ -66,13 +71,16 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "GitHub"
+              source: "GitHub",
+              uuid: "10f546"
             },
             {
-              source: "git"
+              source: "git",
+              uuid: "10f546"
             },
             {
-              source: "Others"
+              source: "Others",
+              uuid: "10f546"
             }
           ]
         },
@@ -84,10 +92,12 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "GitHub"
+              source: "GitHub",
+              uuid: "10f546"
             },
             {
-              source: "git"
+              source: "git",
+              uuid: "10f546"
             }
           ]
         },
@@ -99,13 +109,16 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "GitHub"
+              source: "GitHub",
+              uuid: "10f546"
             },
             {
-              source: "git"
+              source: "git",
+              uuid: "10f546"
             },
             {
-              source: "Others"
+              source: "Others",
+              uuid: "10f546"
             }
           ]
         },
@@ -117,13 +130,16 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "GitLab"
+              source: "GitLab",
+              uuid: "10f546"
             },
             {
-              source: "GitHub"
+              source: "GitHub",
+              uuid: "10f546"
             },
             {
-              source: "git"
+              source: "git",
+              uuid: "10f546"
             }
           ]
         },
@@ -135,10 +151,12 @@ export const Default = () => ({
           },
           identities: [
             {
-              source: "Git"
+              source: "Git",
+              uuid: "10f546"
             },
             {
-              source: "Others"
+              source: "Others",
+              uuid: "10f546"
             }
           ]
         }

--- a/ui/src/components/IndividualsGrid.vue
+++ b/ui/src/components/IndividualsGrid.vue
@@ -7,6 +7,7 @@
             :name="individual.profile.name"
             :sources="getSources(individual.identities)"
             :is-locked="individual.isLocked"
+            :uuid="individual.identities[0].uuid"
           />
         </v-col>
       </v-row>

--- a/ui/src/components/ProfileCard.vue
+++ b/ui/src/components/ProfileCard.vue
@@ -1,5 +1,11 @@
 <template>
-  <individual-card :name="name" :sources="sources" :is-locked="isLocked" style="width: 600px">
+  <individual-card
+    :name="name"
+    :sources="sources"
+    :is-locked="isLocked"
+    :uuid="identities[0].identities[0].uuid"
+    style="width: 600px"
+  >
     <v-list-group>
       <template v-slot:activator>
         <v-list-item-title>Identities ({{ identitiesCount }})</v-list-item-title>

--- a/ui/tests/unit/IndividualCard.spec.js
+++ b/ui/tests/unit/IndividualCard.spec.js
@@ -1,0 +1,175 @@
+import { shallowMount, mount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import IndividualCard from "@/components/IndividualCard";
+import * as Mutations from "@/apollo/mutations";
+
+Vue.use(Vuetify);
+
+const lockResponseMocked = {
+  data: {
+    lock: {
+      uuid: "375458370ac0323bfb2e5a153e086551ef628d53",
+      individual: {
+        isLocked: true,
+        __typename: "IndividualType"
+      },
+      __typename: "Lock"
+    }
+  }
+};
+
+const unlockResponseMocked = {
+  data: {
+    unlock: {
+      uuid: "375458370ac0323bfb2e5a153e086551ef628d53",
+      individual: {
+        isLocked: false,
+        __typename: "IndividualType"
+      },
+      __typename: "Unlock"
+    }
+  }
+};
+
+const errorResponseMocked = {
+  errors: [
+    {
+      message: "abc not found in the registry",
+      locations:[{line:2,column:3}],
+      path:["lock"],
+      extensions:{
+        code:9
+      }
+    }],
+    data:{
+      lock:null
+    }};
+
+describe("IndividualCard", () => {
+  test("Mock query for lockIndividual", async () => {
+    const mutate = jest.fn(() => Promise.resolve(lockResponseMocked));
+    const wrapper = shallowMount(IndividualCard, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      },
+      propsData: {
+        name: 'Test',
+        uuid: "375458370ac0323bfb2e5a153e086551ef628d53",
+        isLocked: false
+      }
+    });
+
+    const response = await Mutations.lockIndividual(wrapper.vm.$apollo, wrapper.vm.uuid);
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+    });
+
+    test("Mock query for unlockIndividual", async () => {
+      const mutate = jest.fn(() => Promise.resolve(unlockResponseMocked));
+      const wrapper = shallowMount(IndividualCard, {
+        Vue,
+        mocks: {
+          $apollo: {
+            mutate
+          }
+        },
+        propsData: {
+          name: 'Test',
+          uuid: "375458370ac0323bfb2e5a153e086551ef628d53",
+          isLocked: true
+        }
+      });
+
+      const response = await Mutations.unlockIndividual(wrapper.vm.$apollo, wrapper.vm.uuid);
+
+      expect(mutate).toBeCalled();
+      expect(wrapper.element).toMatchSnapshot();
+      });
+
+      test("Lock individual on click", async () => {
+        const mutate = jest.fn(() => Promise.resolve(lockResponseMocked));
+        const lockIndividual = jest.spyOn(Mutations, 'lockIndividual');
+        const wrapper = mount(IndividualCard, {
+          Vue,
+          mocks: {
+            $apollo: {
+              mutate
+            }
+          },
+          propsData: {
+            name: 'Test',
+            uuid: "375458370ac0323bfb2e5a153e086551ef628d53",
+            isLocked: false
+          }
+        });
+
+        wrapper.find('button').trigger('click');
+
+        expect(mutate).toBeCalled();
+        expect(lockIndividual).toHaveBeenCalledWith(wrapper.vm.$apollo, "375458370ac0323bfb2e5a153e086551ef628d53");
+        await Vue.nextTick();
+        expect(wrapper.vm.locked).toBe(true);
+        await Vue.nextTick();
+        expect(wrapper.find('.mdi-lock').exists()).toBe(true);
+        expect(wrapper.element).toMatchSnapshot();
+      });
+
+      test("Unlock individual on click", async () => {
+        const mutate = jest.fn(() => Promise.resolve(unlockResponseMocked));
+        const unlockIndividual = jest.spyOn(Mutations, 'unlockIndividual');
+        const wrapper = mount(IndividualCard, {
+          Vue,
+          mocks: {
+            $apollo: {
+              mutate
+            }
+          },
+          propsData: {
+            name: 'Test',
+            uuid: "375458370ac0323bfb2e5a153e086551ef628d53",
+            isLocked: true
+          }
+        });
+
+        wrapper.find('button').trigger('click');
+
+        expect(mutate).toBeCalled();
+        expect(unlockIndividual).toHaveBeenCalledWith(wrapper.vm.$apollo, "375458370ac0323bfb2e5a153e086551ef628d53");
+        await Vue.nextTick();
+        expect(wrapper.vm.locked).toBe(false);
+        await Vue.nextTick();
+        expect(wrapper.find('.mdi-lock-open-outline').exists()).toBe(true);
+        expect(wrapper.element).toMatchSnapshot();
+      });
+
+      test("Show snackbar on error", async () => {
+        const mutate = jest.fn(() => Promise.resolve(errorResponseMocked));
+        const wrapper = mount(IndividualCard, {
+          Vue,
+          mocks: {
+            $apollo: {
+              mutate
+            }
+          },
+          propsData: {
+            name: 'Test',
+            uuid: "abc",
+            isLocked: true
+          }
+        });
+
+        wrapper.find('button').trigger('click');
+
+        expect(mutate).toBeCalled();
+        await Vue.nextTick();
+        expect(wrapper.vm.snackbar.text).toBe("abc not found in the registry");
+        await Vue.nextTick();
+        expect(wrapper.find('.v-snack').exists()).toBe(true);
+        expect(wrapper.element).toMatchSnapshot();
+      });
+  });

--- a/ui/tests/unit/__snapshots__/IndividualCard.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/IndividualCard.spec.js.snap
@@ -1,0 +1,299 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IndividualCard Lock individual on click 1`] = `
+<div
+  class="mx-auto v-card v-card--raised v-sheet theme--light"
+>
+  <div
+    class="grow v-list-item theme--light"
+    tabindex="-1"
+  >
+    <div
+      class="v-avatar v-list-item__avatar grey"
+      style="height: 40px; min-width: 40px; width: 40px;"
+    >
+      
+      T
+    
+    </div>
+     
+    <div
+      class="v-list-item__content"
+    >
+      <div
+        class="v-list-item__title"
+      >
+        Test
+      </div>
+       
+      <div
+        class="v-list-item__subtitle"
+      />
+    </div>
+     
+    <div
+      class="v-list-item__icon"
+    >
+      <button
+        class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          <i
+            aria-hidden="true"
+            class="v-icon notranslate mdi mdi-lock theme--light"
+            style="font-size: 16px;"
+          />
+        </span>
+      </button>
+    </div>
+  </div>
+    
+  <!---->
+</div>
+`;
+
+exports[`IndividualCard Mock query for lockIndividual 1`] = `
+<v-card-stub
+  class="mx-auto"
+  loaderheight="4"
+  raised="true"
+  tag="div"
+>
+  <v-list-item-stub
+    activeclass=""
+    class="grow"
+    tag="div"
+  >
+    <v-list-item-avatar-stub
+      color="grey"
+      size="40"
+    >
+      
+      T
+    
+    </v-list-item-avatar-stub>
+     
+    <v-list-item-content-stub>
+      <v-list-item-title-stub>
+        Test
+      </v-list-item-title-stub>
+       
+      <v-list-item-subtitle-stub />
+    </v-list-item-content-stub>
+     
+    <v-list-item-icon-stub>
+      <v-btn-stub
+        activeclass=""
+        icon="true"
+        tag="button"
+        text="true"
+        type="button"
+      >
+        <v-icon-stub
+          small=""
+        >
+          
+          mdi-lock-open-outline
+        
+        </v-icon-stub>
+      </v-btn-stub>
+    </v-list-item-icon-stub>
+  </v-list-item-stub>
+    
+  <v-snackbar-stub
+    color="error"
+    timeout="6000"
+  >
+    
+    Error
+  
+  </v-snackbar-stub>
+</v-card-stub>
+`;
+
+exports[`IndividualCard Mock query for unlockIndividual 1`] = `
+<v-card-stub
+  class="mx-auto"
+  loaderheight="4"
+  raised="true"
+  tag="div"
+>
+  <v-list-item-stub
+    activeclass=""
+    class="grow"
+    tag="div"
+  >
+    <v-list-item-avatar-stub
+      color="grey"
+      size="40"
+    >
+      
+      T
+    
+    </v-list-item-avatar-stub>
+     
+    <v-list-item-content-stub>
+      <v-list-item-title-stub>
+        Test
+      </v-list-item-title-stub>
+       
+      <v-list-item-subtitle-stub />
+    </v-list-item-content-stub>
+     
+    <v-list-item-icon-stub>
+      <v-btn-stub
+        activeclass=""
+        icon="true"
+        tag="button"
+        text="true"
+        type="button"
+      >
+        <v-icon-stub
+          small=""
+        >
+          
+          mdi-lock
+        
+        </v-icon-stub>
+      </v-btn-stub>
+    </v-list-item-icon-stub>
+  </v-list-item-stub>
+    
+  <v-snackbar-stub
+    color="error"
+    timeout="6000"
+  >
+    
+    Error
+  
+  </v-snackbar-stub>
+</v-card-stub>
+`;
+
+exports[`IndividualCard Show snackbar on error 1`] = `
+<div
+  class="mx-auto v-card v-card--raised v-sheet theme--light"
+>
+  <div
+    class="grow v-list-item theme--light"
+    tabindex="-1"
+  >
+    <div
+      class="v-avatar v-list-item__avatar grey"
+      style="height: 40px; min-width: 40px; width: 40px;"
+    >
+      
+      T
+    
+    </div>
+     
+    <div
+      class="v-list-item__content"
+    >
+      <div
+        class="v-list-item__title"
+      >
+        Test
+      </div>
+       
+      <div
+        class="v-list-item__subtitle"
+      />
+    </div>
+     
+    <div
+      class="v-list-item__icon"
+    >
+      <button
+        class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          <i
+            aria-hidden="true"
+            class="v-icon notranslate mdi mdi-lock theme--light"
+            style="font-size: 16px;"
+          />
+        </span>
+      </button>
+    </div>
+  </div>
+    
+  <div
+    class="v-snack v-snack--active v-snack--bottom v-snack-transition-enter v-snack-transition-enter-active"
+  >
+    <div
+      class="v-snack__wrapper error"
+      role="alert"
+    >
+      <div
+        class="v-snack__content"
+      >
+        
+    abc not found in the registry
+  
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`IndividualCard Unlock individual on click 1`] = `
+<div
+  class="mx-auto v-card v-card--raised v-sheet theme--light"
+>
+  <div
+    class="grow v-list-item theme--light"
+    tabindex="-1"
+  >
+    <div
+      class="v-avatar v-list-item__avatar grey"
+      style="height: 40px; min-width: 40px; width: 40px;"
+    >
+      
+      T
+    
+    </div>
+     
+    <div
+      class="v-list-item__content"
+    >
+      <div
+        class="v-list-item__title"
+      >
+        Test
+      </div>
+       
+      <div
+        class="v-list-item__subtitle"
+      />
+    </div>
+     
+    <div
+      class="v-list-item__icon"
+    >
+      <button
+        class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          <i
+            aria-hidden="true"
+            class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+            style="font-size: 16px;"
+          />
+        </span>
+      </button>
+    </div>
+  </div>
+    
+  <!---->
+</div>
+`;

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -173,16 +173,17 @@ exports[`Storyshots IndividualCard Default 1`] = `
             <span
               class="v-btn__content"
             >
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+              <button
+                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
+                type="button"
               />
             </span>
           </button>
         </div>
       </div>
        
+      <!---->
     </div>
   </div>
 </div>
@@ -237,16 +238,17 @@ exports[`Storyshots IndividualCard Locked 1`] = `
             <span
               class="v-btn__content"
             >
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate mdi mdi-lock theme--light"
+              <button
+                class="v-icon notranslate v-icon--link mdi mdi-lock theme--light"
                 style="font-size: 16px;"
+                type="button"
               />
             </span>
           </button>
         </div>
       </div>
        
+      <!---->
     </div>
   </div>
 </div>
@@ -301,16 +303,17 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
             <span
               class="v-btn__content"
             >
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+              <button
+                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
+                type="button"
               />
             </span>
           </button>
         </div>
       </div>
        
+      <!---->
     </div>
   </div>
 </div>
@@ -386,16 +389,17 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             <span
               class="v-btn__content"
             >
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+              <button
+                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
+                type="button"
               />
             </span>
           </button>
         </div>
       </div>
        
+      <!---->
     </div>
   </div>
 </div>
@@ -469,16 +473,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
           <div
@@ -540,16 +545,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
           <div
@@ -601,16 +607,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
           <div
@@ -672,16 +679,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
           <div
@@ -738,16 +746,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
           <div
@@ -809,16 +818,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
           <div
@@ -880,16 +890,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
           <div
@@ -946,16 +957,17 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+                      <button
+                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
+                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
                
+              <!---->
             </div>
           </div>
         </div>
@@ -1054,71 +1066,17 @@ exports[`Storyshots ProfileCard Default 1`] = `
             <span
               class="v-btn__content"
             >
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
+              <button
+                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
+                type="button"
               />
             </span>
           </button>
         </div>
       </div>
        
-      <div
-        class="v-list-group"
-      >
-        <div
-          aria-expanded="false"
-          class="v-list-group__header v-list-item v-list-item--link theme--light"
-          role="button"
-          tabindex="0"
-        >
-          <div
-            class="v-list-item__title"
-          >
-            Identities (4)
-          </div>
-          <div
-            class="v-list-item__icon v-list-group__header__append-icon"
-          >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-chevron-down theme--light"
-            />
-          </div>
-        </div>
-        <!---->
-      </div>
-       
-      <div
-        class="v-list-group"
-      >
-        <div
-          aria-expanded="false"
-          class="v-list-group__header v-list-item v-list-item--link theme--light"
-          role="button"
-          tabindex="0"
-        >
-          <div
-            class="v-list-item__content"
-          >
-            <div
-              class="v-list-item__title"
-            >
-              Organizations (2)
-            </div>
-          </div>
-          <div
-            class="v-list-item__icon v-list-group__header__append-icon"
-          >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-chevron-down theme--light"
-            />
-          </div>
-        </div>
-        <!---->
-      </div>
+      <!---->
     </div>
   </div>
 </div>

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -173,16 +173,16 @@ exports[`Storyshots IndividualCard Default 1`] = `
             <span
               class="v-btn__content"
             >
-              <button
-                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
-                type="button"
               />
             </span>
           </button>
         </div>
       </div>
-       
+        
       <!---->
     </div>
   </div>
@@ -238,16 +238,16 @@ exports[`Storyshots IndividualCard Locked 1`] = `
             <span
               class="v-btn__content"
             >
-              <button
-                class="v-icon notranslate v-icon--link mdi mdi-lock theme--light"
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-lock theme--light"
                 style="font-size: 16px;"
-                type="button"
               />
             </span>
           </button>
         </div>
       </div>
-       
+        
       <!---->
     </div>
   </div>
@@ -303,16 +303,16 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
             <span
               class="v-btn__content"
             >
-              <button
-                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
-                type="button"
               />
             </span>
           </button>
         </div>
       </div>
-       
+        
       <!---->
     </div>
   </div>
@@ -389,16 +389,16 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             <span
               class="v-btn__content"
             >
-              <button
-                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
-                type="button"
               />
             </span>
           </button>
         </div>
       </div>
-       
+        
       <!---->
     </div>
   </div>
@@ -473,16 +473,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -545,16 +545,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -607,16 +607,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -679,16 +679,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -746,16 +746,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -818,16 +818,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -890,16 +890,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -957,16 +957,16 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      <button
-                        class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                         style="font-size: 16px;"
-                        type="button"
                       />
                     </span>
                   </button>
                 </div>
               </div>
-               
+                
               <!---->
             </div>
           </div>
@@ -1066,14 +1066,70 @@ exports[`Storyshots ProfileCard Default 1`] = `
             <span
               class="v-btn__content"
             >
-              <button
-                class="v-icon notranslate v-icon--link mdi mdi-lock-open-outline theme--light"
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-lock-open-outline theme--light"
                 style="font-size: 16px;"
-                type="button"
               />
             </span>
           </button>
         </div>
+      </div>
+       
+      <div
+        class="v-list-group"
+      >
+        <div
+          aria-expanded="false"
+          class="v-list-group__header v-list-item v-list-item--link theme--light"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="v-list-item__title"
+          >
+            Identities (4)
+          </div>
+          <div
+            class="v-list-item__icon v-list-group__header__append-icon"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate mdi mdi-chevron-down theme--light"
+            />
+          </div>
+        </div>
+        <!---->
+      </div>
+       
+      <div
+        class="v-list-group"
+      >
+        <div
+          aria-expanded="false"
+          class="v-list-group__header v-list-item v-list-item--link theme--light"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="v-list-item__content"
+          >
+            <div
+              class="v-list-item__title"
+            >
+              Organizations (2)
+            </div>
+          </div>
+          <div
+            class="v-list-item__icon v-list-group__header__append-icon"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate mdi mdi-chevron-down theme--light"
+            />
+          </div>
+        </div>
+        <!---->
       </div>
        
       <!---->


### PR DESCRIPTION
This PR adds the functionality of locking or unlocking
individuals by clicking on the lock icon on the `IndividualCard`
component requested in #322 .
Those mutations require the individual's `uuid` as an
argument, so it is added to `IndividualCard` as a prop and passed
from `IndividualsGrid` and `ProfileCard`.

If the mutation fails, a snackbar with the error message is
displayed on the bottom of the screen.