### PR TITLE
[ui] Add CSRF token to the Apollo petitions

### DIFF
--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -13,6 +13,7 @@ DEBUG = True
 ALLOWED_HOSTS = []
 
 CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True
 
 # Application definition
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "core-js": "^3.6.4",
     "graphql": "^15.0.0",
     "graphql-tag": "^2.10.3",
+    "js-cookie": "^2.2.1",
     "vue": "^2.6.11",
     "vue-apollo": "^3.0.3", 
     "vuetify": "^2.2.11",


### PR DESCRIPTION
This commit fixes the error produced when the app do petitions to
the Django server and the CSRF cookie is not set. To solve this,
the code forces a GET to the Django server in order to retrieve
the CSRF token, then the token is added when the Apollo server
is configured.