### PR TITLE
[ui] Split identities on ExpandedIndividual

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -49,6 +49,7 @@
             :fetch-page="getIndividualsPage"
             :delete-item="deleteItem"
             :merge-items="mergeItems"
+            :unmerge-items="unmergeItems"
             :highlight-individual="highlightInTable"
             @saveIndividual="addSavedIndividual"
             @highlight="
@@ -77,7 +78,7 @@ import {
   getPaginatedIndividuals,
   getPaginatedOrganizations
 } from "./apollo/queries";
-import { deleteIdentity, merge } from "./apollo/mutations";
+import { deleteIdentity, merge, unmerge } from "./apollo/mutations";
 import IndividualsTable from "./components/IndividualsTable";
 import OrganizationsTable from "./components/OrganizationsTable";
 import WorkSpace from "./components/WorkSpace";
@@ -133,6 +134,10 @@ export default {
     },
     highlightIndividual(individual, component, highlight) {
       this[component] = highlight ? individual.uuid : undefined;
+    },
+    async unmergeItems(uuids) {
+      const response = await unmerge(this.$apollo, uuids);
+      return response;
     }
   }
 };

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -53,6 +53,35 @@ const MERGE = gql`
   }
 `;
 
+const UNMERGE = gql`
+  mutation unmerge($uuids: [String!]) {
+    unmergeIdentities(uuids: $uuids) {
+      uuids
+      individuals {
+        profile {
+          name
+          id
+          isBot
+        }
+        identities {
+          name
+          source
+          email
+          uuid
+          username
+        }
+        enrollments {
+          start
+          end
+          organization {
+            name
+          }
+        }
+      }
+    }
+  }
+`;
+
 const lockIndividual = (apollo, uuid) => {
   let response = apollo.mutate({
     mutation: LOCK_INDIVIDUAL,
@@ -94,4 +123,14 @@ const merge = (apollo, fromUuids, toUuid) => {
   return response;
 };
 
-export { lockIndividual, unlockIndividual, deleteIdentity, merge };
+const unmerge = (apollo, uuids) => {
+  let response = apollo.mutate({
+    mutation: UNMERGE,
+    variables: {
+      uuids: uuids,
+    }
+  });
+  return response;
+};
+
+export { lockIndividual, unlockIndividual, deleteIdentity, merge, unmerge };

--- a/ui/src/components/ExpandedIndividual.stories.js
+++ b/ui/src/components/ExpandedIndividual.stories.js
@@ -7,12 +7,13 @@ export default {
   excludeStories: /.*Data$/
 };
 
-const expandedIndividualTemplate = '<expanded-individual :enrollments="enrollments" :identities="identities" :compact="compact" />';
+const expandedIndividualTemplate = '<expanded-individual :enrollments="enrollments" :identities="identities" :compact="compact" :uuid="uuid" />';
 
 export const Default = () => ({
   components: { ExpandedIndividual },
   template: expandedIndividualTemplate,
   data: () => ({
+    uuid: "06e6903c91180835b6ee91dd56782c6ca72bc562",
     compact: false,
     name: "Tom Marvolo Riddle",
     identities: [
@@ -84,6 +85,7 @@ export const Compact = () => ({
   components: { ExpandedIndividual },
   template: expandedIndividualTemplate,
   data: () => ({
+    uuid: "006afa",
     compact: true,
     name: "Tom Marvolo Riddle",
     identities: [
@@ -155,6 +157,7 @@ export const NoOrganizations = () => ({
   components: { ExpandedIndividual },
   template: expandedIndividualTemplate,
   data: () => ({
+    uuid: "164e41c60c28698ac30b0d17176d3e720e036918",
     compact: false,
     identities: [
       {

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -27,6 +27,29 @@
             :source="identity.source || source.name"
           />
         </v-list-item-content>
+
+        <v-list-item-action v-if="!compact">
+          <v-tooltip
+            bottom
+            transition="expand-y-transition"
+            open-delay="200"
+          >
+            <template v-slot:activator="{ on }">
+              <v-btn
+                icon
+                :disabled="identity.uuid === uuid"
+                v-on="on"
+                @click="$emit('unmerge', [identity.uuid, uuid])"
+              >
+                <v-icon>
+                  mdi-call-split
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Split identity</span>
+          </v-tooltip>
+        </v-list-item-action>
+
       </v-list-item>
       <v-divider
         inset
@@ -65,7 +88,7 @@
 import Identity from "./Identity.vue";
 
 export default {
-  name: "profilecard",
+  name: "ExpandedIndividual",
   components: {
     Identity
   },
@@ -82,6 +105,10 @@ export default {
       type: Boolean,
       required: false,
       default: false
+    },
+    uuid: {
+      type: String,
+      required: true
     }
   },
   methods: {
@@ -127,7 +154,7 @@ td {
 }
 
 .indented {
-  margin-left: 40px;
+  margin: 0 40px;
 }
 
 .v-application--is-ltr .v-divider--inset:not(.v-divider--vertical).divider {
@@ -155,7 +182,7 @@ td {
 
   ::v-deep .indented {
     padding: 0;
-    margin-left: 0;
+    margin: 0;
   }
 }
 </style>

--- a/ui/src/components/IndividualCard.vue
+++ b/ui/src/components/IndividualCard.vue
@@ -50,6 +50,7 @@
             compact
             :enrollments="enrollments"
             :identities="identities"
+            :uuid="uuid"
           />
         </v-menu>
         <v-btn text icon @click.stop="$emit('remove')" @mousedown.stop>

--- a/ui/src/components/IndividualsTable.stories.js
+++ b/ui/src/components/IndividualsTable.stories.js
@@ -12,6 +12,7 @@ const IndividualsTableTemplate = `
     :fetch-page="queryIndividuals.bind(this)"
     :delete-item="deleteIndividual"
     :merge-items="deleteIndividual"
+    :unmerge-items="deleteIndividual"
   />
 `;
 

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -72,8 +72,10 @@
       </template>
       <template v-slot:expanded-item="{ item }">
         <expanded-individual
+          :uuid="item.uuid"
           :enrollments="item.enrollments"
           :identities="item.identities"
+          @unmerge="unmerge($event)"
         />
       </template>
     </v-data-table>
@@ -132,6 +134,10 @@ export default {
       required: true
     },
     mergeItems: {
+      type: Function,
+      required: true
+    },
+    unmergeItems: {
       type: Function,
       required: true
     },
@@ -277,6 +283,14 @@ export default {
     },
     mergeSelected(individuals) {
       mergeIndividuals(individuals, this.merge, this.dialog);
+    },
+    async unmerge(uuids) {
+      const response = await this.unmergeItems(uuids);
+      if (response && response.data) {
+        const unmergedItems = this.formatIndividuals(response.data.unmergeIdentities.individuals);
+        this.$emit('saveIndividual', unmergedItems[0])
+        this.queryIndividuals(this.page);
+      }
     }
   }
 };

--- a/ui/src/components/WorkSpace.stories.js
+++ b/ui/src/components/WorkSpace.stories.js
@@ -24,6 +24,7 @@ const dragAndDropTemplate = `
     :fetch-page="queryIndividuals.bind(this)"
     :delete-item="deleteItem"
     :merge-items="deleteItem"
+    :unmerge-items="deleteItem"
     :highlight-individual="highlightInTable"
     @highlight="highlightIndividual($event, 'highlightInWorkspace', true)"
     @stopHighlight="highlightIndividual($event, 'highlightInWorkspace', false)"

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -487,3 +487,247 @@ exports[`IndividualsTable Mock query for merge 1`] = `
   </v-card-stub>
 </v-container-stub>
 `;
+
+exports[`IndividualsTable Mock query for unmerge 1`] = `
+<v-container-stub
+  tag="div"
+>
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <h4
+      class="title"
+    >
+      <v-icon-stub
+        color="primary"
+        left=""
+      >
+        
+        mdi-account-multiple
+      
+      </v-icon-stub>
+      
+      Individuals
+    
+    </h4>
+     
+    <div>
+      <v-tooltip-stub
+        bottom="true"
+        closedelay="0"
+        contentclass=""
+        fixed="true"
+        maxwidth="auto"
+        nudgebottom="0"
+        nudgeleft="0"
+        nudgeright="0"
+        nudgetop="0"
+        nudgewidth="0"
+        opendelay="200"
+        openonhover="true"
+        tag="span"
+        transition="expand-y-transition"
+      >
+         
+        <span>
+          Merge selected
+        </span>
+      </v-tooltip-stub>
+       
+      <v-tooltip-stub
+        bottom="true"
+        closedelay="0"
+        contentclass=""
+        fixed="true"
+        maxwidth="auto"
+        nudgebottom="0"
+        nudgeleft="0"
+        nudgeright="0"
+        nudgetop="0"
+        nudgewidth="0"
+        opendelay="200"
+        openonhover="true"
+        tag="span"
+        transition="expand-y-transition"
+      >
+         
+        <span>
+          Delete selected
+        </span>
+      </v-tooltip-stub>
+    </div>
+  </v-row-stub>
+   
+  <v-data-table-stub
+    customfilter="function defaultFilter(value, search, item) {
+          return value != null && search != null && typeof value !== 'boolean' && value.toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
+        }"
+    customgroup="function groupItems(items, groupBy, groupDesc) {
+          var key = groupBy[0];
+          var groups = [];
+          var current = null;
+
+          for (var i = 0; i < items.length; i++) {
+            var item = items[i];
+            var val = getObjectValueByPath(item, key);
+
+            if (current !== val) {
+              current = val;
+              groups.push({
+                name: val,
+                items: []
+              });
+            }
+
+            groups[groups.length - 1].items.push(item);
+          }
+
+          return groups;
+        }"
+    customsort="function sortItems(items, sortBy, sortDesc, locale, customSorters) {
+          if (sortBy === null || !sortBy.length) return items;
+          var stringCollator = new Intl.Collator(locale, {
+            sensitivity: 'accent',
+            usage: 'sort'
+          });
+          return items.sort(function (a, b) {
+            var _a, _b;
+
+            for (var i = 0; i < sortBy.length; i++) {
+              var sortKey = sortBy[i];
+              var sortA = getObjectValueByPath(a, sortKey);
+              var sortB = getObjectValueByPath(b, sortKey);
+
+              if (sortDesc[i]) {
+                _a = __read([sortB, sortA], 2), sortA = _a[0], sortB = _a[1];
+              }
+
+              if (customSorters && customSorters[sortKey]) {
+                var customResult = customSorters[sortKey](sortA, sortB);
+                if (!customResult) continue;
+                return customResult;
+              } // Check if both cannot be evaluated
+
+
+              if (sortA === null && sortB === null) {
+                continue;
+              }
+
+              _b = __read([sortA, sortB].map(function (s) {
+                return (s || '').toString().toLocaleLowerCase();
+              }), 2), sortA = _b[0], sortB = _b[1];
+
+              if (sortA !== sortB) {
+                if (!isNaN(sortA) && !isNaN(sortB)) return Number(sortA) - Number(sortB);
+                return stringCollator.compare(sortA, sortB);
+              }
+            }
+
+            return 0;
+          });
+        }"
+    expanded=""
+    expandicon="$expand"
+    groupby=""
+    groupdesc=""
+    headers="[object Object],[object Object],[object Object],[object Object]"
+    hidedefaultfooter="true"
+    hidedefaultheader="true"
+    itemkey="uuid"
+    items=""
+    itemsperpage="10"
+    loadingtext="$vuetify.dataIterator.loadingText"
+    locale="en-US"
+    mobilebreakpoint="600"
+    nodatatext="$vuetify.noDataText"
+    noresultstext="$vuetify.dataIterator.noResultsText"
+    options="[object Object]"
+    page="0"
+    selectablekey="isSelectable"
+    serveritemslength="-1"
+    sortby=""
+    sortdesc=""
+    value=""
+  />
+   
+  <div
+    class="text-center pt-2"
+  >
+    <v-pagination-stub
+      length="0"
+      nexticon="$next"
+      previcon="$prev"
+      totalvisible="7"
+      value="0"
+    />
+  </div>
+   
+  <v-dialog-stub
+    closedelay="0"
+    contentclass=""
+    maxwidth="400"
+    opendelay="0"
+    origin="center center"
+    retainfocus="true"
+    transition="dialog-transition"
+    width="auto"
+  >
+    <v-card-stub
+      loaderheight="4"
+      tag="div"
+    >
+      <v-card-title-stub
+        class="headline"
+      >
+        
+      </v-card-title-stub>
+       
+      <v-card-text-stub>
+        
+      </v-card-text-stub>
+       
+      <v-card-actions-stub>
+        <v-spacer-stub />
+         
+        <v-btn-stub
+          activeclass=""
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Cancel
+        
+        </v-btn-stub>
+         
+        <v-btn-stub
+          activeclass=""
+          color="blue darken-4"
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Confirm
+        
+        </v-btn-stub>
+      </v-card-actions-stub>
+    </v-card-stub>
+  </v-dialog-stub>
+   
+  <v-card-stub
+    class="dragged-item"
+    color="primary"
+    dark="true"
+    loaderheight="4"
+    tag="div"
+  >
+    <v-card-title-stub>
+      
+      Moving 0
+    
+    </v-card-title-stub>
+  </v-card-stub>
+</v-container-stub>
+`;

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -91,6 +91,8 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
               </div>
             </div>
           </div>
+           
+          <!---->
         </div>
          
         <!---->
@@ -167,6 +169,8 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
               </div>
             </div>
           </div>
+           
+          <!---->
         </div>
         <div
           class="v-list-item theme--light"
@@ -236,6 +240,8 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
               </div>
             </div>
           </div>
+           
+          <!---->
         </div>
          
         <!---->
@@ -312,6 +318,8 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
               </div>
             </div>
           </div>
+           
+          <!---->
         </div>
          
         <!---->
@@ -507,6 +515,29 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
+           
+          <div
+            class="v-list-item__action"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+          </div>
         </div>
          
         <hr
@@ -594,6 +625,30 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
+           
+          <div
+            class="v-list-item__action"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                disabled="disabled"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+          </div>
         </div>
         <div
           class="v-list-item theme--light"
@@ -664,6 +719,29 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                 </span>
               </div>
             </div>
+          </div>
+           
+          <div
+            class="v-list-item__action"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
           </div>
         </div>
          
@@ -751,6 +829,29 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                 </span>
               </div>
             </div>
+          </div>
+           
+          <div
+            class="v-list-item__action"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
           </div>
         </div>
          
@@ -950,6 +1051,30 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                 </span>
               </div>
             </div>
+          </div>
+           
+          <div
+            class="v-list-item__action"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                disabled="disabled"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
           </div>
         </div>
          

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -24,6 +24,53 @@ const mergeResponse = {
   }
 };
 
+const unmergeResponse = {
+  "data": {
+    "unmergeIdentities": {
+      "uuids": [
+        "3db176be6859adac3a454c5377af81b1b7e3f8d8",
+        "10982379421b80e13266db011d6e5131dd519016"
+      ],
+      "individuals": [
+        {
+          "profile": {
+            "name": "Test 11",
+            "id": "260",
+            "isBot": false
+          },
+          "identities": [
+            {
+              "name": "Test 11",
+              "source": "git",
+              "email": "test11@example.net",
+              "uuid": "3db176be6859adac3a454c5377af81b1b7e3f8d8",
+              "username": "tes39"
+            }
+          ],
+          "enrollments": []
+        },
+        {
+          "profile": {
+            "name": "Test 4",
+            "id": "255",
+            "isBot": false
+          },
+          "identities": [
+            {
+              "name": "Test 4",
+              "source": "test",
+              "email": "test4@example.net",
+              "uuid": "10982379421b80e13266db011d6e5131dd519016",
+              "username": "test4"
+            }
+          ],
+          "enrollments": []
+        }
+      ]
+    }
+  }
+};
+
 describe("IndividualsTable", () => {
   test("Mock query for deleteIdentity", async () => {
     const mutate = jest.fn(() => Promise.resolve(deleteResponse));
@@ -37,6 +84,7 @@ describe("IndividualsTable", () => {
       propsData: {
         deleteItem: mutate,
         mergeItems: () => {},
+        unmergeItems: () => {},
         fetchPage: () => {}
       }
     });
@@ -57,11 +105,37 @@ describe("IndividualsTable", () => {
       },
       propsData: {
         mergeItems: mutate,
+        unmergeItems: () => {},
         deleteItem: () => {},
         fetchPage: () => {}
       }
     });
     const response = await Mutations.deleteIdentity(wrapper.vm.$apollo, "5f06473815dc415c9861680de8101813d9eb18e8");
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock query for unmerge", async () => {
+    const mutate = jest.fn(() => Promise.resolve(unmergeResponse));
+    const wrapper = shallowMount(IndividualsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      },
+      propsData: {
+        unmergeItems: mutate,
+        mergeItems: () => {},
+        deleteItem: () => {},
+        fetchPage: () => {}
+      }
+    });
+    const response = await Mutations.unmerge(wrapper.vm.$apollo, [
+      "3db176be6859adac3a454c5377af81b1b7e3f8d8",
+      "10982379421b80e13266db011d6e5131dd519016"
+    ]);
 
     expect(mutate).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -203,6 +203,7 @@ describe("IndividualsTable", () => {
       propsData: {
         fetchPage: query,
         mergeItems: () => {},
+        unmergeItems: () => {},
         deleteItem: () => {}
       }
     });


### PR DESCRIPTION
An individual's identity can be unmerged by clicking a button on the `ExpandedIndividual` identities list. The split individual is then placed on the workspace.
A new Apollo mutation is implemented to split the identities.