### PR TITLE
Add organizations from the UI 

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -66,15 +66,11 @@
           />
         </v-col>
         <v-col class="organizations elevation-2">
-          <h4 class="title">
-            <v-icon color="primary" left>
-              mdi-sitemap
-            </v-icon>
-            Organizations
-          </h4>
           <organizations-table
             :fetch-page="getOrganizationsPage"
             :enroll="enroll"
+            :add-organization="addOrganization"
+            :add-domain="addDomain"
             @updateIndividuals="updateTable"
             @updateWorkspace="updateWorkspace"
           />
@@ -97,7 +93,9 @@ import {
   merge,
   unmerge,
   moveIdentity,
-  enroll
+  enroll,
+  addOrganization,
+  addDomain
 } from "./apollo/mutations";
 import IndividualsTable from "./components/IndividualsTable";
 import OrganizationsTable from "./components/OrganizationsTable";
@@ -190,6 +188,14 @@ export default {
     },
     async enroll(uuid, organization) {
       const response = await enroll(this.$apollo, uuid, organization);
+      return response;
+    },
+    async addOrganization(organization) {
+      const response = await addOrganization(this.$apollo, organization);
+      return response;
+    },
+    async addDomain(domain, organization) {
+      const response = await addDomain(this.$apollo, domain, organization);
       return response;
     }
   }

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -142,6 +142,16 @@ const ENROLL = gql`
   }
 `;
 
+const ADD_ORGANIZATION = gql`
+  mutation addOrganization($name: String!) {
+    addOrganization(name: $name) {
+      organization {
+        name
+      }
+    }
+  }
+`;
+
 const lockIndividual = (apollo, uuid) => {
   let response = apollo.mutate({
     mutation: LOCK_INDIVIDUAL,
@@ -215,6 +225,16 @@ const enroll = (apollo, uuid, organization) => {
   return response;
 };
 
+const addOrganization = (apollo, name) => {
+  let response = apollo.mutate({
+    mutation: ADD_ORGANIZATION,
+    variables: {
+      name: name
+    }
+  });
+  return response;
+};
+
 export {
   lockIndividual,
   unlockIndividual,
@@ -222,5 +242,6 @@ export {
   merge,
   unmerge,
   moveIdentity,
-  enroll
+  enroll,
+  addOrganization
 };

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -152,6 +152,19 @@ const ADD_ORGANIZATION = gql`
   }
 `;
 
+const ADD_DOMAIN = gql`
+  mutation addDomain($domain: String!, $organization: String!) {
+    addDomain(domain: $domain, organization: $organization) {
+      domain {
+        domain
+        organization {
+          name
+        }
+      }
+    }
+  }
+`;
+
 const lockIndividual = (apollo, uuid) => {
   let response = apollo.mutate({
     mutation: LOCK_INDIVIDUAL,
@@ -235,6 +248,17 @@ const addOrganization = (apollo, name) => {
   return response;
 };
 
+const addDomain = (apollo, domain, organization) => {
+  let response = apollo.mutate({
+    mutation: ADD_DOMAIN,
+    variables: {
+      domain: domain,
+      organization: organization
+    }
+  });
+  return response;
+};
+
 export {
   lockIndividual,
   unlockIndividual,
@@ -243,5 +267,6 @@ export {
   unmerge,
   moveIdentity,
   enroll,
-  addOrganization
+  addOrganization,
+  addDomain
 };

--- a/ui/src/components/OrganizationModal.stories.js
+++ b/ui/src/components/OrganizationModal.stories.js
@@ -1,0 +1,47 @@
+import { storiesOf } from "@storybook/vue";
+
+import OrganizationModal from "./OrganizationModal.vue";
+
+export default {
+  title: "OrganizationModal",
+  excludeStories: /.*Data$/
+};
+
+const OrganizationModalTemplate = `
+  <div class="ma-auto">
+    <v-btn color="primary" dark @click.stop="isOpen = true">
+      Open Dialog
+    </v-btn>
+    <organization-modal
+      :is-open.sync="isOpen"
+      :add-domain="addDomain"
+      :add-organization="addDomain"
+    />
+  </div>
+`;
+
+export const Default = () => ({
+  components: { OrganizationModal },
+  template: OrganizationModalTemplate,
+  data: () => ({
+    isOpen: false
+  }),
+  methods: {
+    addDomain() {
+      return true;
+    }
+  }
+});
+
+export const ErrorOnSave = () => ({
+  components: { OrganizationModal },
+  template: OrganizationModalTemplate,
+  data: () => ({
+    isOpen: false
+  }),
+  methods: {
+    addDomain() {
+      throw new Error("Example error");
+    }
+  }
+});

--- a/ui/src/components/OrganizationModal.vue
+++ b/ui/src/components/OrganizationModal.vue
@@ -1,0 +1,153 @@
+<template>
+  <v-dialog v-model="isOpen" persistent max-width="450px">
+    <v-card class="pa-6">
+      <v-card-title>
+        <span class="headline">Add organization</span>
+      </v-card-title>
+      <form>
+        <v-card-text>
+          <v-row>
+            <v-col cols="12">
+              <v-text-field label="Name" v-model="form.name" filled required />
+            </v-col>
+          </v-row>
+          <v-row class="pl-4">
+            <span class="title font-weight-regular pl-16">Domains</span>
+          </v-row>
+          <v-list>
+            <v-list-item v-for="(domain, index) in form.domains" :key="index">
+              <v-list-item-content>
+                <v-list-item-title v-text="domain" />
+              </v-list-item-content>
+              <v-list-item-action>
+                <v-btn icon @click="removeDomain(index)">
+                  <v-icon small color="primary">mdi-delete</v-icon>
+                </v-btn>
+              </v-list-item-action>
+            </v-list-item>
+          </v-list>
+          <v-row class="flex-row align-center">
+            <v-col cols="9">
+              <v-text-field
+                v-model="activeDomain"
+                label="Domain"
+                filled
+                @keyup.enter="saveDomain"
+              />
+            </v-col>
+            <v-col cols="2">
+              <v-btn
+                block
+                text
+                color="primary"
+                :disabled="activeDomain.length === 0"
+                @click="saveDomain"
+              >
+                Add
+              </v-btn>
+            </v-col>
+          </v-row>
+          <v-alert v-if="errorMessage" text type="error">
+            {{ errorMessage }}
+          </v-alert>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="blue darken-1" text @click.prevent="onCancel">
+            Cancel
+          </v-btn>
+          <v-btn
+            depressed
+            color="primary"
+            :disabled="form.name.length === 0"
+            @click.prevent="onSave"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </form>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+export default {
+  name: "OrganizationModal",
+  props: {
+    addDomain: {
+      type: Function,
+      required: true
+    },
+    addOrganization: {
+      type: Function,
+      required: true
+    },
+    isOpen: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  data() {
+    return {
+      form: {
+        name: "",
+        domains: []
+      },
+      activeDomain: "",
+      errorMessage: ""
+    };
+  },
+  methods: {
+    saveDomain() {
+      this.form.domains.push(this.activeDomain);
+      this.activeDomain = "";
+    },
+    removeDomain(index) {
+      this.form.domains.splice(index, 1);
+    },
+    async onSave() {
+      try {
+        const response = await this.addOrganization(this.form.name);
+        if (response) {
+          if (this.form.domains.length === 0) {
+            this.errorMessage = "";
+            Object.assign(this.form, { name: "", domains: [] });
+            this.$emit("update:isOpen", false);
+            this.$emit("updateOrganizations");
+            return;
+          }
+          const domainsResponse = await Promise.all(
+            this.form.domains.map(domain =>
+              this.addOrganizationDomain(domain, this.form.name)
+            )
+          );
+          if (domainsResponse) {
+            Object.assign(this.form, { name: "", domains: [] });
+            this.errorMessage = "";
+            this.$emit("update:isOpen", false);
+            this.$emit("updateOrganizations");
+          }
+        }
+      } catch (error) {
+        this.errorMessage = error;
+      }
+    },
+    onCancel() {
+      Object.assign(this.form, { name: "", domains: [] });
+      this.errorMessage = "";
+      this.$emit("update:isOpen", false);
+    },
+    async addOrganizationDomain(domain, organization) {
+      try {
+        const response = await this.addDomain(domain, organization);
+        if (response) {
+          return response;
+        }
+      } catch (error) {
+        this.errorMessage = error;
+      }
+    }
+  }
+};
+</script>

--- a/ui/src/components/OrganizationModal.vue
+++ b/ui/src/components/OrganizationModal.vue
@@ -19,36 +19,26 @@
           <v-row class="pl-4">
             <span class="title font-weight-regular pl-16">Domains</span>
           </v-row>
-          <v-list>
-            <v-list-item v-for="(domain, index) in form.domains" :key="index">
-              <v-list-item-content>
-                <v-list-item-title v-text="domain" />
-              </v-list-item-content>
-              <v-list-item-action>
-                <v-btn icon @click="removeDomain(index)">
-                  <v-icon small color="primary">mdi-delete</v-icon>
-                </v-btn>
-              </v-list-item-action>
-            </v-list-item>
-          </v-list>
-          <v-row class="flex-row align-center">
-            <v-col cols="9">
+          <v-row v-for="(domain, index) in form.domains" :key="index">
+            <v-col cols="10">
               <v-text-field
-                v-model="activeDomain"
+                v-model="form.domains[index]"
                 label="Domain"
                 filled
-                @keyup.enter="saveDomain"
               />
             </v-col>
-            <v-col cols="2">
+            <v-col cols="2" class="pt-6">
               <v-btn
-                block
-                text
+                v-if="index === form.domains.length - 1"
+                icon
                 color="primary"
-                :disabled="activeDomain.length === 0"
-                @click="saveDomain"
+                :disabled="domain.length === 0"
+                @click="addInput"
               >
-                Add
+                <v-icon color="primary">mdi-plus-circle-outline</v-icon>
+              </v-btn>
+              <v-btn v-else icon color="primary" @click="removeDomain(index)">
+                <v-icon color="primary">mdi-delete</v-icon>
               </v-btn>
             </v-col>
           </v-row>
@@ -97,9 +87,8 @@ export default {
     return {
       form: {
         name: "",
-        domains: []
+        domains: [""]
       },
-      activeDomain: "",
       errorMessage: "",
       savedData: {
         name: undefined,
@@ -108,10 +97,6 @@ export default {
     };
   },
   methods: {
-    saveDomain() {
-      this.form.domains.push(this.activeDomain);
-      this.activeDomain = "";
-    },
     removeDomain(index) {
       this.form.domains.splice(index, 1);
     },
@@ -137,13 +122,14 @@ export default {
       }
     },
     closeModal() {
-      Object.assign(this.form, { name: "", domains: [] });
+      Object.assign(this.form, { name: "", domains: [""] });
+      Object.assign(this.savedData, { name: undefined, domains: [] });
       this.errorMessage = "";
       this.$emit("update:isOpen", false);
     },
     async handleDomains() {
       const newDomains = this.form.domains.filter(
-        domain => !this.savedData.domains.includes(domain)
+        domain => domain.length > 0 && !this.savedData.domains.includes(domain)
       );
       try {
         const response = await Promise.all(
@@ -165,6 +151,9 @@ export default {
         this.savedData.domains.push(domain);
         return response;
       }
+    },
+    addInput() {
+      this.form.domains.push("");
     }
   }
 };

--- a/ui/src/components/OrganizationsTable.stories.js
+++ b/ui/src/components/OrganizationsTable.stories.js
@@ -7,7 +7,14 @@ export default {
   excludeStories: /.*Data$/
 };
 
-const OrganizationsTableTemplate = '<organizations-table :fetch-page="getOrganizations.bind(this)" :enroll="enroll" />';
+const OrganizationsTableTemplate = `
+  <organizations-table
+    :fetch-page="getOrganizations.bind(this)"
+    :enroll="enroll"
+    :add-organization="addOrganization.bind(this)"
+    :add-domain="addDomain"
+  />
+`;
 
 export const Default = () => ({
   components: { OrganizationsTable },
@@ -17,6 +24,24 @@ export const Default = () => ({
       return this.query[page - 1];
     },
     enroll() {
+      return true;
+    },
+    addOrganization(organization) {
+      this.query[0].data.organizations.entities.push({
+        id: organization,
+        name: organization,
+        enrollments: [],
+        domains: []
+      });
+      return true;
+    },
+    addDomain(domain, organization) {
+      const index = this.query[0].data.organizations.entities.findIndex(
+        entity => entity.name === organization
+      );
+      this.query[0].data.organizations.entities[index].domains.push({
+        domain: domain
+      });
       return true;
     }
   },

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -1,5 +1,21 @@
 <template>
   <v-container>
+    <v-row class="actions">
+      <h4 class="title">
+        <v-icon color="primary" left>
+          mdi-sitemap
+        </v-icon>
+        Organizations
+      </h4>
+      <v-btn
+        depressed
+        color="blue lighten-5"
+        class="primary--text"
+        @click.stop="openModal = true"
+      >
+        Add
+      </v-btn>
+    </v-row>
     <v-data-table
       hide-default-header
       hide-default-footer
@@ -34,6 +50,13 @@
       ></v-pagination>
     </div>
 
+    <organization-modal
+      :is-open.sync="openModal"
+      :add-organization="addOrganization"
+      :add-domain="addDomain"
+      @updateOrganizations="getOrganizations(page)"
+    />
+
     <v-dialog v-model="dialog.open" max-width="400">
       <v-card>
         <v-card-title class="headline">{{ dialog.title }}</v-card-title>
@@ -60,10 +83,11 @@
 import { formatIndividuals } from "../utils/actions";
 import ExpandedOrganization from "./ExpandedOrganization.vue";
 import OrganizationEntry from "./OrganizationEntry.vue";
+import OrganizationModal from "./OrganizationModal.vue";
 
 export default {
   name: "OrganizationsTable",
-  components: { OrganizationEntry, ExpandedOrganization },
+  components: { OrganizationEntry, ExpandedOrganization, OrganizationModal },
   props: {
     enroll: {
       type: Function,
@@ -77,6 +101,14 @@ export default {
       type: Number,
       required: false,
       default: 10
+    },
+    addOrganization: {
+      type: Function,
+      required: true
+    },
+    addDomain: {
+      type: Function,
+      required: true
     }
   },
   data() {
@@ -99,7 +131,8 @@ export default {
       snackbar: {
         open: false,
         text: ""
-      }
+      },
+      openModal: false
     };
   },
   created() {
@@ -151,5 +184,10 @@ export default {
 }
 ::v-deep button.v-pagination__item {
   transition: none;
+}
+
+.actions {
+  justify-content: space-between;
+  padding: 0 26px 24px 26px;
 }
 </style>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -976,10 +976,44 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
 </v-container-stub>
 `;
 
-exports[`OrganizationsTable Mock mutation for enroll 1`] = `
+exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
 <v-container-stub
   tag="div"
 >
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <h4
+      class="title"
+    >
+      <v-icon-stub
+        color="primary"
+        left=""
+      >
+        
+        mdi-sitemap
+      
+      </v-icon-stub>
+      
+      Organizations
+    
+    </h4>
+     
+    <v-btn-stub
+      activeclass=""
+      class="primary--text"
+      color="blue lighten-5"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
   <v-data-table-stub
     customfilter="function defaultFilter(value, search, item) {
           return value != null && search != null && typeof value !== 'boolean' && value.toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
@@ -1052,7 +1086,7 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
     expandicon="$expand"
     groupby=""
     groupdesc=""
-    headers="[object Object],[object Object]"
+    headers="[object Object],[object Object],[object Object]"
     hidedefaultfooter="true"
     hidedefaultheader="true"
     itemkey="id"
@@ -1083,6 +1117,435 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
       value="0"
     />
   </div>
+   
+  <organization-modal-stub
+    adddomain="function mockConstructor() {
+        return fn.apply(this, arguments);
+      }"
+    addorganization="() => {}"
+  />
+   
+  <v-dialog-stub
+    closedelay="0"
+    contentclass=""
+    maxwidth="400"
+    opendelay="0"
+    origin="center center"
+    retainfocus="true"
+    transition="dialog-transition"
+    width="auto"
+  >
+    <v-card-stub
+      loaderheight="4"
+      tag="div"
+    >
+      <v-card-title-stub
+        class="headline"
+      >
+        
+      </v-card-title-stub>
+       
+      <v-card-text-stub>
+        
+      </v-card-text-stub>
+       
+      <v-card-actions-stub>
+        <v-spacer-stub />
+         
+        <v-btn-stub
+          activeclass=""
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Cancel
+        
+        </v-btn-stub>
+         
+        <v-btn-stub
+          activeclass=""
+          color="blue darken-4"
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Confirm
+        
+        </v-btn-stub>
+      </v-card-actions-stub>
+    </v-card-stub>
+  </v-dialog-stub>
+   
+  <v-snackbar-stub
+    timeout="6000"
+  >
+    
+    
+  
+  </v-snackbar-stub>
+</v-container-stub>
+`;
+
+exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
+<v-container-stub
+  tag="div"
+>
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <h4
+      class="title"
+    >
+      <v-icon-stub
+        color="primary"
+        left=""
+      >
+        
+        mdi-sitemap
+      
+      </v-icon-stub>
+      
+      Organizations
+    
+    </h4>
+     
+    <v-btn-stub
+      activeclass=""
+      class="primary--text"
+      color="blue lighten-5"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-data-table-stub
+    customfilter="function defaultFilter(value, search, item) {
+          return value != null && search != null && typeof value !== 'boolean' && value.toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
+        }"
+    customgroup="function groupItems(items, groupBy, groupDesc) {
+          var key = groupBy[0];
+          var groups = [];
+          var current = null;
+
+          for (var i = 0; i < items.length; i++) {
+            var item = items[i];
+            var val = getObjectValueByPath(item, key);
+
+            if (current !== val) {
+              current = val;
+              groups.push({
+                name: val,
+                items: []
+              });
+            }
+
+            groups[groups.length - 1].items.push(item);
+          }
+
+          return groups;
+        }"
+    customsort="function sortItems(items, sortBy, sortDesc, locale, customSorters) {
+          if (sortBy === null || !sortBy.length) return items;
+          var stringCollator = new Intl.Collator(locale, {
+            sensitivity: 'accent',
+            usage: 'sort'
+          });
+          return items.sort(function (a, b) {
+            var _a, _b;
+
+            for (var i = 0; i < sortBy.length; i++) {
+              var sortKey = sortBy[i];
+              var sortA = getObjectValueByPath(a, sortKey);
+              var sortB = getObjectValueByPath(b, sortKey);
+
+              if (sortDesc[i]) {
+                _a = __read([sortB, sortA], 2), sortA = _a[0], sortB = _a[1];
+              }
+
+              if (customSorters && customSorters[sortKey]) {
+                var customResult = customSorters[sortKey](sortA, sortB);
+                if (!customResult) continue;
+                return customResult;
+              } // Check if both cannot be evaluated
+
+
+              if (sortA === null && sortB === null) {
+                continue;
+              }
+
+              _b = __read([sortA, sortB].map(function (s) {
+                return (s || '').toString().toLocaleLowerCase();
+              }), 2), sortA = _b[0], sortB = _b[1];
+
+              if (sortA !== sortB) {
+                if (!isNaN(sortA) && !isNaN(sortB)) return Number(sortA) - Number(sortB);
+                return stringCollator.compare(sortA, sortB);
+              }
+            }
+
+            return 0;
+          });
+        }"
+    expanded=""
+    expandicon="$expand"
+    groupby=""
+    groupdesc=""
+    headers="[object Object],[object Object],[object Object]"
+    hidedefaultfooter="true"
+    hidedefaultheader="true"
+    itemkey="id"
+    items=""
+    itemsperpage="10"
+    loadingtext="$vuetify.dataIterator.loadingText"
+    locale="en-US"
+    mobilebreakpoint="600"
+    nodatatext="$vuetify.noDataText"
+    noresultstext="$vuetify.dataIterator.noResultsText"
+    options="[object Object]"
+    page="0"
+    selectablekey="isSelectable"
+    serveritemslength="-1"
+    sortby=""
+    sortdesc=""
+    value=""
+  />
+   
+  <div
+    class="text-center pt-2"
+  >
+    <v-pagination-stub
+      length="0"
+      nexticon="$next"
+      previcon="$prev"
+      totalvisible="5"
+      value="0"
+    />
+  </div>
+   
+  <organization-modal-stub
+    adddomain="() => {}"
+    addorganization="function mockConstructor() {
+        return fn.apply(this, arguments);
+      }"
+  />
+   
+  <v-dialog-stub
+    closedelay="0"
+    contentclass=""
+    maxwidth="400"
+    opendelay="0"
+    origin="center center"
+    retainfocus="true"
+    transition="dialog-transition"
+    width="auto"
+  >
+    <v-card-stub
+      loaderheight="4"
+      tag="div"
+    >
+      <v-card-title-stub
+        class="headline"
+      >
+        
+      </v-card-title-stub>
+       
+      <v-card-text-stub>
+        
+      </v-card-text-stub>
+       
+      <v-card-actions-stub>
+        <v-spacer-stub />
+         
+        <v-btn-stub
+          activeclass=""
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Cancel
+        
+        </v-btn-stub>
+         
+        <v-btn-stub
+          activeclass=""
+          color="blue darken-4"
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Confirm
+        
+        </v-btn-stub>
+      </v-card-actions-stub>
+    </v-card-stub>
+  </v-dialog-stub>
+   
+  <v-snackbar-stub
+    timeout="6000"
+  >
+    
+    
+  
+  </v-snackbar-stub>
+</v-container-stub>
+`;
+
+exports[`OrganizationsTable Mock mutation for enroll 1`] = `
+<v-container-stub
+  tag="div"
+>
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <h4
+      class="title"
+    >
+      <v-icon-stub
+        color="primary"
+        left=""
+      >
+        
+        mdi-sitemap
+      
+      </v-icon-stub>
+      
+      Organizations
+    
+    </h4>
+     
+    <v-btn-stub
+      activeclass=""
+      class="primary--text"
+      color="blue lighten-5"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-data-table-stub
+    customfilter="function defaultFilter(value, search, item) {
+          return value != null && search != null && typeof value !== 'boolean' && value.toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
+        }"
+    customgroup="function groupItems(items, groupBy, groupDesc) {
+          var key = groupBy[0];
+          var groups = [];
+          var current = null;
+
+          for (var i = 0; i < items.length; i++) {
+            var item = items[i];
+            var val = getObjectValueByPath(item, key);
+
+            if (current !== val) {
+              current = val;
+              groups.push({
+                name: val,
+                items: []
+              });
+            }
+
+            groups[groups.length - 1].items.push(item);
+          }
+
+          return groups;
+        }"
+    customsort="function sortItems(items, sortBy, sortDesc, locale, customSorters) {
+          if (sortBy === null || !sortBy.length) return items;
+          var stringCollator = new Intl.Collator(locale, {
+            sensitivity: 'accent',
+            usage: 'sort'
+          });
+          return items.sort(function (a, b) {
+            var _a, _b;
+
+            for (var i = 0; i < sortBy.length; i++) {
+              var sortKey = sortBy[i];
+              var sortA = getObjectValueByPath(a, sortKey);
+              var sortB = getObjectValueByPath(b, sortKey);
+
+              if (sortDesc[i]) {
+                _a = __read([sortB, sortA], 2), sortA = _a[0], sortB = _a[1];
+              }
+
+              if (customSorters && customSorters[sortKey]) {
+                var customResult = customSorters[sortKey](sortA, sortB);
+                if (!customResult) continue;
+                return customResult;
+              } // Check if both cannot be evaluated
+
+
+              if (sortA === null && sortB === null) {
+                continue;
+              }
+
+              _b = __read([sortA, sortB].map(function (s) {
+                return (s || '').toString().toLocaleLowerCase();
+              }), 2), sortA = _b[0], sortB = _b[1];
+
+              if (sortA !== sortB) {
+                if (!isNaN(sortA) && !isNaN(sortB)) return Number(sortA) - Number(sortB);
+                return stringCollator.compare(sortA, sortB);
+              }
+            }
+
+            return 0;
+          });
+        }"
+    expanded=""
+    expandicon="$expand"
+    groupby=""
+    groupdesc=""
+    headers="[object Object],[object Object],[object Object]"
+    hidedefaultfooter="true"
+    hidedefaultheader="true"
+    itemkey="id"
+    items=""
+    itemsperpage="10"
+    loadingtext="$vuetify.dataIterator.loadingText"
+    locale="en-US"
+    mobilebreakpoint="600"
+    nodatatext="$vuetify.noDataText"
+    noresultstext="$vuetify.dataIterator.noResultsText"
+    options="[object Object]"
+    page="0"
+    selectablekey="isSelectable"
+    serveritemslength="-1"
+    sortby=""
+    sortdesc=""
+    value=""
+  />
+   
+  <div
+    class="text-center pt-2"
+  >
+    <v-pagination-stub
+      length="0"
+      nexticon="$next"
+      previcon="$prev"
+      totalvisible="5"
+      value="0"
+    />
+  </div>
+   
+  <organization-modal-stub
+    adddomain="() => {}"
+    addorganization="() => {}"
+  />
    
   <v-dialog-stub
     closedelay="0"

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -255,6 +255,40 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
 <v-container-stub
   tag="div"
 >
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <h4
+      class="title"
+    >
+      <v-icon-stub
+        color="primary"
+        left=""
+      >
+        
+        mdi-sitemap
+      
+      </v-icon-stub>
+      
+      Organizations
+    
+    </h4>
+     
+    <v-btn-stub
+      activeclass=""
+      class="primary--text"
+      color="blue lighten-5"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
   <v-data-table-stub
     customfilter="function defaultFilter(value, search, item) {
           return value != null && search != null && typeof value !== 'boolean' && value.toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
@@ -358,6 +392,11 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
       value="0"
     />
   </div>
+   
+  <organization-modal-stub
+    adddomain="() => {}"
+    addorganization="() => {}"
+  />
    
   <v-dialog-stub
     closedelay="0"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -4253,6 +4253,78 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots OrganizationModal Default 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="ma-auto"
+    >
+      <button
+        class="v-btn v-btn--contained theme--dark v-size--default primary"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          
+      Open Dialog
+    
+        </span>
+      </button>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots OrganizationModal Error On Save 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="ma-auto"
+    >
+      <button
+        class="v-btn v-btn--contained theme--dark v-size--default primary"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          
+      Open Dialog
+    
+        </span>
+      </button>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots OrganizationsTable Default 1`] = `
 <div
   class="v-application v-application--is-ltr theme--light"
@@ -4265,6 +4337,35 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
     <div
       class="container"
     >
+      <div
+        class="row actions"
+      >
+        <h4
+          class="title"
+        >
+          <i
+            aria-hidden="true"
+            class="v-icon notranslate v-icon--left mdi mdi-sitemap theme--light primary--text"
+          />
+          
+      Organizations
+    
+        </h4>
+         
+        <button
+          class="primary--text v-btn v-btn--depressed theme--light v-size--default blue lighten-5"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            
+      Add
+    
+          </span>
+        </button>
+      </div>
+       
       <div
         class="v-data-table theme--light"
       >
@@ -4327,6 +4428,13 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
             </button>
           </li>
         </ul>
+      </div>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
       </div>
        
       <div

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -137,6 +137,19 @@ const addOrganizationResponse = {
   }
 };
 
+const addDomainResponse = {
+  data: {
+    addDomain: {
+      domain: {
+        domain: "domain.com",
+        organization: {
+          name: "Organization"
+        }
+      }
+    }
+  }
+};
+
 describe("IndividualsTable", () => {
   test("Mock query for deleteIdentity", async () => {
     const mutate = jest.fn(() => Promise.resolve(deleteResponse));
@@ -281,6 +294,29 @@ describe("OrganizationsTable", () => {
 
     const response = await Mutations.addOrganization(
       wrapper.vm.$apollo, "Name");
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock mutation for addDomain", async () => {
+    const mutate = jest.fn(() => Promise.resolve(addDomainResponse));
+    const wrapper = shallowMount(OrganizationsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      },
+      propsData: {
+        enroll: mutate,
+        fetchPage: () => {}
+      }
+    });
+
+    const response = await Mutations.addDomain(
+      wrapper.vm.$apollo, "domain.com", "Organization"
+    );
 
     expect(mutate).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -125,6 +125,18 @@ const enrollResponse = {
   }
 };
 
+const addOrganizationResponse = {
+  data: {
+    addOrganization: {
+      organization: {
+        name: "Name",
+        __typename: "OrganizationType"
+      },
+      __typename: "AddOrganization"
+    }
+  }
+};
+
 describe("IndividualsTable", () => {
   test("Mock query for deleteIdentity", async () => {
     const mutate = jest.fn(() => Promise.resolve(deleteResponse));
@@ -250,5 +262,27 @@ describe("OrganizationsTable", () => {
 
     expect(mutate).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();
-  })
-})
+  });
+
+  test("Mock mutation for addOrganization", async () => {
+    const mutate = jest.fn(() => Promise.resolve(addOrganizationResponse));
+    const wrapper = shallowMount(OrganizationsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      },
+      propsData: {
+        enroll: mutate,
+        fetchPage: () => {}
+      }
+    });
+
+    const response = await Mutations.addOrganization(
+      wrapper.vm.$apollo, "Name");
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -263,7 +263,9 @@ describe("OrganizationsTable", () => {
       },
       propsData: {
         enroll: mutate,
-        fetchPage: () => {}
+        fetchPage: () => {},
+        addDomain: () => {},
+        addOrganization: () => {}
       }
     });
 
@@ -288,7 +290,9 @@ describe("OrganizationsTable", () => {
       },
       propsData: {
         enroll: mutate,
-        fetchPage: () => {}
+        fetchPage: () => {},
+        addOrganization: mutate,
+        addDomain: () => {}
       }
     });
 
@@ -309,8 +313,10 @@ describe("OrganizationsTable", () => {
         }
       },
       propsData: {
-        enroll: mutate,
-        fetchPage: () => {}
+        enroll: () => {},
+        fetchPage: () => {},
+        addDomain: mutate,
+        addOrganization: () => {}
       }
     });
 

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -227,7 +227,9 @@ describe("OrganizationsTable", () => {
       },
       propsData: {
         fetchPage: query,
-        enroll: () => {}
+        enroll: () => {},
+        addDomain: () => {},
+        addOrganization: () => {}
       }
     });
     const response = await Queries.getPaginatedOrganizations(wrapper.vm.$apollo, 1, 1);


### PR DESCRIPTION
Implements the `OrganizationModal` component, which displays a form that allows an organization and its domains to be created. The component is embedded inside `OrganizationsTable` and opens when the "add" button is clicked, as requested in  #383 . Two new GraphQL mutations -`addOrganization` and `addDomain`- are added to save the changes in the database.