### PR TITLE
Edit organizations from the UI

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -75,6 +75,7 @@
             :enroll="enroll"
             :add-organization="addOrganization"
             :add-domain="addDomain"
+            :delete-domain="deleteDomain"
             @updateIndividuals="updateTable"
             @updateWorkspace="updateWorkspace"
           />
@@ -102,6 +103,7 @@ import {
   enroll,
   addOrganization,
   addDomain,
+  deleteDomain,
   updateProfile
 } from "./apollo/mutations";
 import IndividualsTable from "./components/IndividualsTable";
@@ -223,6 +225,10 @@ export default {
     },
     async addDomain(domain, organization) {
       const response = await addDomain(this.$apollo, domain, organization);
+      return response;
+    },
+    async deleteDomain(domain) {
+      const response = await deleteDomain(this.$apollo, domain);
       return response;
     },
     async getCountries() {

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -227,6 +227,16 @@ const UPDATE_PROFILE = gql`
   }
 `;
 
+const DELETE_DOMAIN = gql`
+  mutation deleteDomain($domain: String!) {
+    deleteDomain(domain: $domain) {
+      domain {
+        domain
+      }
+    }
+  }
+`;
+
 const lockIndividual = (apollo, uuid) => {
   let response = apollo.mutate({
     mutation: LOCK_INDIVIDUAL,
@@ -347,6 +357,14 @@ const addDomain = (apollo, domain, organization) => {
   return response;
 };
 
+const deleteDomain = (apollo, domain) => {
+  let response = apollo.mutate({
+    mutation: DELETE_DOMAIN,
+    variables: { domain: domain }
+  });
+  return response;
+};
+
 export {
   lockIndividual,
   unlockIndividual,
@@ -357,6 +375,7 @@ export {
   enroll,
   addOrganization,
   addDomain,
+  deleteDomain,
   addIdentity,
   updateProfile
 };

--- a/ui/src/components/OrganizationEntry.vue
+++ b/ui/src/components/OrganizationEntry.vue
@@ -8,7 +8,12 @@
   >
     <td class="text--body-1">{{ name }}</td>
     <td class="text-right text--secondary">{{ enrollments }}</td>
-    <td class="text-right" width="40">
+    <td class="text-right" width="109">
+      <v-btn icon @click.stop="$emit('edit')">
+        <v-icon small>
+          mdi-lead-pencil
+        </v-icon>
+      </v-btn>
       <v-btn icon @click.stop="$emit('expand')">
         <v-icon>
           {{ isExpanded ? "mdi-chevron-up" : "mdi-chevron-down" }}

--- a/ui/src/components/OrganizationModal.stories.js
+++ b/ui/src/components/OrganizationModal.stories.js
@@ -16,6 +16,7 @@ const OrganizationModalTemplate = `
       :is-open.sync="isOpen"
       :add-domain="addDomain"
       :add-organization="addDomain"
+      :delete-domain="addDomain"                           l
     />
   </div>
 `;

--- a/ui/src/components/OrganizationModal.vue
+++ b/ui/src/components/OrganizationModal.vue
@@ -37,13 +37,7 @@
             </v-col>
           </v-row>
           <v-row>
-            <v-btn
-              text
-              small
-              left
-              color="primary"
-              @click="addInput"
-            >
+            <v-btn text small left color="primary" @click="addInput">
               <v-icon small color="primary">mdi-plus-circle-outline</v-icon>
               Add domain
             </v-btn>

--- a/ui/src/components/OrganizationsTable.stories.js
+++ b/ui/src/components/OrganizationsTable.stories.js
@@ -13,6 +13,7 @@ const OrganizationsTableTemplate = `
     :enroll="enroll"
     :add-organization="addOrganization.bind(this)"
     :add-domain="addDomain"
+    :delete-domain="deleteDomain"
   />
 `;
 
@@ -43,6 +44,13 @@ export const Default = () => ({
         domain: domain
       });
       return true;
+    },
+    deleteDomain(domain) {
+      this.query[0].data.organizations.entities.find(entity => {
+        const index = entity.domains.findIndex(item => item.domain === domain);
+        entity.domains.splice(index, 1);
+      }
+      );
     }
   },
   data: () => ({

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -11,7 +11,7 @@
         depressed
         color="blue lighten-5"
         class="primary--text"
-        @click.stop="openModal = true"
+        @click.stop="openModal"
       >
         Add
       </v-btn>
@@ -34,6 +34,7 @@
           v-on:dblclick.native="expand(!isExpanded)"
           @expand="expand(!isExpanded)"
           @enroll="confirmEnroll"
+          @edit="openModal(item)"
         />
       </template>
       <template v-slot:expanded-item="{ item }">
@@ -51,9 +52,12 @@
     </div>
 
     <organization-modal
-      :is-open.sync="openModal"
+      :is-open.sync="modal.open"
       :add-organization="addOrganization"
       :add-domain="addDomain"
+      :delete-domain="deleteDomain"
+      :organization="modal.organization"
+      :domains="modal.domains"
       @updateOrganizations="getOrganizations(page)"
     />
 
@@ -109,6 +113,10 @@ export default {
     addDomain: {
       type: Function,
       required: true
+    },
+    deleteDomain: {
+      type: Function,
+      required: true
     }
   },
   data() {
@@ -132,7 +140,11 @@ export default {
         open: false,
         text: ""
       },
-      openModal: false
+      modal: {
+        open: false,
+        organization: undefined,
+        domains: []
+      }
     };
   },
   created() {
@@ -173,6 +185,17 @@ export default {
       } catch (error) {
         Object.assign(this.snackbar, { open: true, text: error });
       }
+    },
+    openModal(organization) {
+      const domains =
+        organization.domains && organization.domains.length > 0
+          ? organization.domains.map(domain => domain.domain)
+          : [""];
+      Object.assign(this.modal, {
+        open: true,
+        organization: organization ? organization.name : "",
+        domains: domains
+      });
     }
   }
 };

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -1203,6 +1203,8 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
         return fn.apply(this, arguments);
       }"
     addorganization="() => {}"
+    deletedomain="() => {}"
+    domains=""
   />
    
   <v-dialog-stub
@@ -1415,6 +1417,222 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
     addorganization="function mockConstructor() {
         return fn.apply(this, arguments);
       }"
+    deletedomain="() => {}"
+    domains=""
+  />
+   
+  <v-dialog-stub
+    closedelay="0"
+    contentclass=""
+    maxwidth="400"
+    opendelay="0"
+    origin="center center"
+    retainfocus="true"
+    transition="dialog-transition"
+    width="auto"
+  >
+    <v-card-stub
+      loaderheight="4"
+      tag="div"
+    >
+      <v-card-title-stub
+        class="headline"
+      >
+        
+      </v-card-title-stub>
+       
+      <v-card-text-stub>
+        
+      </v-card-text-stub>
+       
+      <v-card-actions-stub>
+        <v-spacer-stub />
+         
+        <v-btn-stub
+          activeclass=""
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Cancel
+        
+        </v-btn-stub>
+         
+        <v-btn-stub
+          activeclass=""
+          color="blue darken-4"
+          tag="button"
+          text="true"
+          type="button"
+        >
+          
+          Confirm
+        
+        </v-btn-stub>
+      </v-card-actions-stub>
+    </v-card-stub>
+  </v-dialog-stub>
+   
+  <v-snackbar-stub
+    timeout="6000"
+  >
+    
+    
+  
+  </v-snackbar-stub>
+</v-container-stub>
+`;
+
+exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
+<v-container-stub
+  tag="div"
+>
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <h4
+      class="title"
+    >
+      <v-icon-stub
+        color="primary"
+        left=""
+      >
+        
+        mdi-sitemap
+      
+      </v-icon-stub>
+      
+      Organizations
+    
+    </h4>
+     
+    <v-btn-stub
+      activeclass=""
+      class="primary--text"
+      color="blue lighten-5"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-data-table-stub
+    customfilter="function defaultFilter(value, search, item) {
+          return value != null && search != null && typeof value !== 'boolean' && value.toString().toLocaleLowerCase().indexOf(search.toLocaleLowerCase()) !== -1;
+        }"
+    customgroup="function groupItems(items, groupBy, groupDesc) {
+          var key = groupBy[0];
+          var groups = [];
+          var current = null;
+
+          for (var i = 0; i < items.length; i++) {
+            var item = items[i];
+            var val = getObjectValueByPath(item, key);
+
+            if (current !== val) {
+              current = val;
+              groups.push({
+                name: val,
+                items: []
+              });
+            }
+
+            groups[groups.length - 1].items.push(item);
+          }
+
+          return groups;
+        }"
+    customsort="function sortItems(items, sortBy, sortDesc, locale, customSorters) {
+          if (sortBy === null || !sortBy.length) return items;
+          var stringCollator = new Intl.Collator(locale, {
+            sensitivity: 'accent',
+            usage: 'sort'
+          });
+          return items.sort(function (a, b) {
+            var _a, _b;
+
+            for (var i = 0; i < sortBy.length; i++) {
+              var sortKey = sortBy[i];
+              var sortA = getObjectValueByPath(a, sortKey);
+              var sortB = getObjectValueByPath(b, sortKey);
+
+              if (sortDesc[i]) {
+                _a = __read([sortB, sortA], 2), sortA = _a[0], sortB = _a[1];
+              }
+
+              if (customSorters && customSorters[sortKey]) {
+                var customResult = customSorters[sortKey](sortA, sortB);
+                if (!customResult) continue;
+                return customResult;
+              } // Check if both cannot be evaluated
+
+
+              if (sortA === null && sortB === null) {
+                continue;
+              }
+
+              _b = __read([sortA, sortB].map(function (s) {
+                return (s || '').toString().toLocaleLowerCase();
+              }), 2), sortA = _b[0], sortB = _b[1];
+
+              if (sortA !== sortB) {
+                if (!isNaN(sortA) && !isNaN(sortB)) return Number(sortA) - Number(sortB);
+                return stringCollator.compare(sortA, sortB);
+              }
+            }
+
+            return 0;
+          });
+        }"
+    expanded=""
+    expandicon="$expand"
+    groupby=""
+    groupdesc=""
+    headers="[object Object],[object Object],[object Object]"
+    hidedefaultfooter="true"
+    hidedefaultheader="true"
+    itemkey="id"
+    items=""
+    itemsperpage="10"
+    loadingtext="$vuetify.dataIterator.loadingText"
+    locale="en-US"
+    mobilebreakpoint="600"
+    nodatatext="$vuetify.noDataText"
+    noresultstext="$vuetify.dataIterator.noResultsText"
+    options="[object Object]"
+    page="0"
+    selectablekey="isSelectable"
+    serveritemslength="-1"
+    sortby=""
+    sortdesc=""
+    value=""
+  />
+   
+  <div
+    class="text-center pt-2"
+  >
+    <v-pagination-stub
+      length="0"
+      nexticon="$next"
+      previcon="$prev"
+      totalvisible="5"
+      value="0"
+    />
+  </div>
+   
+  <organization-modal-stub
+    adddomain="() => {}"
+    addorganization="() => {}"
+    deletedomain="function mockConstructor() {
+        return fn.apply(this, arguments);
+      }"
+    domains=""
   />
    
   <v-dialog-stub
@@ -1625,6 +1843,8 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
   <organization-modal-stub
     adddomain="() => {}"
     addorganization="() => {}"
+    deletedomain="() => {}"
+    domains=""
   />
    
   <v-dialog-stub

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -682,6 +682,8 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
   <organization-modal-stub
     adddomain="() => {}"
     addorganization="() => {}"
+    deletedomain="() => {}"
+    domains=""
   />
    
   <v-dialog-stub

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -4537,8 +4537,23 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
                
               <td
                 class="text-right"
-                width="40"
+                width="109"
               >
+                <button
+                  class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                  type="button"
+                >
+                  <span
+                    class="v-btn__content"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate mdi mdi-lead-pencil theme--light"
+                      style="font-size: 16px;"
+                    />
+                  </span>
+                </button>
+                 
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
                   type="button"
@@ -4589,6 +4604,7 @@ exports[`Storyshots OrganizationModal Default 1`] = `
        
       <div
         class="v-dialog__container"
+        l=""
         role="dialog"
       >
         <!---->
@@ -4625,6 +4641,7 @@ exports[`Storyshots OrganizationModal Error On Save 1`] = `
        
       <div
         class="v-dialog__container"
+        l=""
         role="dialog"
       >
         <!---->

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -188,6 +188,18 @@ const updateProfileResponse = {
   }
 };
 
+const deleteDomainResponse = {
+  data: {
+    deleteDomain: {
+      domain: {
+        domain: "Name",
+        __typename: "DomainType"
+      },
+      __typename: "DeleteDomain"
+    }
+  }
+};
+
 describe("IndividualsTable", () => {
   test("Mock query for deleteIdentity", async () => {
     const mutate = jest.fn(() => Promise.resolve(deleteResponse));
@@ -319,7 +331,8 @@ describe("OrganizationsTable", () => {
         enroll: mutate,
         fetchPage: () => {},
         addDomain: () => {},
-        addOrganization: () => {}
+        addOrganization: () => {},
+        deleteDomain: () => {}
       }
     });
 
@@ -346,7 +359,8 @@ describe("OrganizationsTable", () => {
         enroll: mutate,
         fetchPage: () => {},
         addOrganization: mutate,
-        addDomain: () => {}
+        addDomain: () => {},
+        deleteDomain: () => {}
       }
     });
 
@@ -370,6 +384,33 @@ describe("OrganizationsTable", () => {
         enroll: () => {},
         fetchPage: () => {},
         addDomain: mutate,
+        deleteDomain: () => {},
+        addOrganization: () => {}
+      }
+    });
+
+    const response = await Mutations.addDomain(
+      wrapper.vm.$apollo, "domain.com", "Organization"
+    );
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock mutation for deleteDomain", async () => {
+    const mutate = jest.fn(() => Promise.resolve(addDomainResponse));
+    const wrapper = shallowMount(OrganizationsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      },
+      propsData: {
+        enroll: () => {},
+        fetchPage: () => {},
+        addDomain: () => {},
+        deleteDomain: mutate,
         addOrganization: () => {}
       }
     });

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -277,7 +277,8 @@ describe("OrganizationsTable", () => {
         fetchPage: query,
         enroll: () => {},
         addDomain: () => {},
-        addOrganization: () => {}
+        addOrganization: () => {},
+        deleteDomain: () => {}
       }
     });
     const response = await Queries.getPaginatedOrganizations(wrapper.vm.$apollo, 1, 1);


### PR DESCRIPTION
Adds an edit icon to `OrganizationEntry`, which opens the `OrganizationModal` component. `OrganizationTable` passes the organization information and a new `deleteDomain` Apollo mutation to the modal so that the domains can be edited.