### PR TITLE
[ui] Allow all organizations in ProfileModal to be removed

### DIFF
--- a/ui/src/components/ProfileModal.vue
+++ b/ui/src/components/ProfileModal.vue
@@ -130,19 +130,16 @@
             </v-menu>
           </v-col>
           <v-col cols="1" class="pt-6">
-            <v-btn
-              v-if="index === enrollmentsForm.length - 1"
-              icon
-              color="primary"
-              :disabled="enrollment.length === 0"
-              @click="addInput"
-            >
-              <v-icon color="primary">mdi-plus-circle-outline</v-icon>
-            </v-btn>
-            <v-btn v-else icon color="primary" @click="removeEnrollment(index)">
+            <v-btn icon color="primary" @click="removeEnrollment(index)">
               <v-icon color="primary">mdi-delete</v-icon>
             </v-btn>
           </v-col>
+        </v-row>
+        <v-row>
+          <v-btn text small color="primary" @click="addInput">
+            <v-icon left small color="primary">mdi-plus-circle-outline</v-icon>
+            Add organization
+          </v-btn>
         </v-row>
       </v-card-text>
 

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -2281,10 +2281,34 @@ exports[`ProfileModal Mock mutation for addIdentity 1`] = `
             <v-icon-stub
               color="primary"
             >
-              mdi-plus-circle-outline
+              mdi-delete
             </v-icon-stub>
           </v-btn-stub>
         </v-col-stub>
+      </v-row-stub>
+       
+      <v-row-stub
+        tag="div"
+      >
+        <v-btn-stub
+          activeclass=""
+          color="primary"
+          small="true"
+          tag="button"
+          text="true"
+          type="button"
+        >
+          <v-icon-stub
+            color="primary"
+            left=""
+            small=""
+          >
+            mdi-plus-circle-outline
+          </v-icon-stub>
+          
+          Add organization
+        
+        </v-btn-stub>
       </v-row-stub>
     </v-card-text-stub>
      
@@ -2693,10 +2717,34 @@ exports[`ProfileModal Mock mutation for updateProfile 1`] = `
             <v-icon-stub
               color="primary"
             >
-              mdi-plus-circle-outline
+              mdi-delete
             </v-icon-stub>
           </v-btn-stub>
         </v-col-stub>
+      </v-row-stub>
+       
+      <v-row-stub
+        tag="div"
+      >
+        <v-btn-stub
+          activeclass=""
+          color="primary"
+          small="true"
+          tag="button"
+          text="true"
+          type="button"
+        >
+          <v-icon-stub
+            color="primary"
+            left=""
+            small=""
+          >
+            mdi-plus-circle-outline
+          </v-icon-stub>
+          
+          Add organization
+        
+        </v-btn-stub>
       </v-row-stub>
     </v-card-text-stub>
      


### PR DESCRIPTION
All enrollments in `ProfileModal` can be deleted by clicking the trashcan button next to them, like the domains in `OrganizationModal`. The add organization button is placed below them.