### PR TITLE
Add search function to the Individuals table

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -126,8 +126,13 @@ export default {
     };
   },
   methods: {
-    async getIndividualsPage(page, items) {
-      const response = await getPaginatedIndividuals(this.$apollo, page, items);
+    async getIndividualsPage(page, items, filters) {
+      const response = await getPaginatedIndividuals(
+        this.$apollo,
+        page,
+        items,
+        filters
+      );
       return response;
     },
     async getOrganizationsPage(page, items) {

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -75,8 +75,12 @@ const GET_PROFILE_BYUUID = gql`
 `;
 
 const GET_PAGINATED_INDIVIDUALS = gql`
-  query GetIndividuals($page: Int!, $pageSize: Int!) {
-    individuals(page: $page, pageSize: $pageSize) {
+  query GetIndividuals(
+    $page: Int!
+    $pageSize: Int!
+    $filters: IdentityFilterType
+  ) {
+    individuals(page: $page, pageSize: $pageSize, filters: $filters) {
       entities {
         isLocked
         profile {
@@ -184,12 +188,13 @@ const getIndividuals = {
   }
 };
 
-const getPaginatedIndividuals = (apollo, currentPage, pageSize) => {
+const getPaginatedIndividuals = (apollo, currentPage, pageSize, filters) => {
   let response = apollo.query({
     query: GET_PAGINATED_INDIVIDUALS,
     variables: {
       page: currentPage,
-      pageSize: pageSize
+      pageSize: pageSize,
+      filters: filters
     },
     fetchPolicy: "no-cache"
   });

--- a/ui/src/components/IndividualsTable.stories.js
+++ b/ui/src/components/IndividualsTable.stories.js
@@ -25,8 +25,14 @@ export const Default = () => ({
   components: { IndividualsTable },
   template: IndividualsTableTemplate,
   methods: {
-    queryIndividuals(page) {
-      return this.query[page - 1];
+    queryIndividuals(page, items, filters) {
+      const results =  JSON.parse(JSON.stringify(this.query[page - 1]));
+      results.data.individuals.entities = results.data.individuals.entities
+      .filter(individual => individual.profile.name
+        .toUpperCase()
+        .includes(filters.term.toUpperCase())
+      );
+      return results;
     },
     deleteIndividual() {
       return true;

--- a/ui/src/components/WorkSpace.stories.js
+++ b/ui/src/components/WorkSpace.stories.js
@@ -217,8 +217,14 @@ export const DragAndDrop = () => ({
   components: { WorkSpace, IndividualsTable },
   template: dragAndDropTemplate,
   methods: {
-    queryIndividuals(page) {
-      return this.query[page - 1];
+    queryIndividuals(page, items, filters) {
+      const results =  JSON.parse(JSON.stringify(this.query[page - 1]));
+      results.data.individuals.entities = results.data.individuals.entities
+      .filter(individual => individual.profile.name
+        .toUpperCase()
+        .includes(filters.term.toUpperCase())
+      );
+      return results;
     },
     mergeItems() {
       this.individuals = [this.individuals.shift()];

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -24,6 +24,11 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
     
     </h4>
      
+    <v-hover-stub
+      closedelay="0"
+      opendelay="0"
+    />
+     
     <div>
       <v-tooltip-stub
         bottom="true"
@@ -287,6 +292,11 @@ exports[`IndividualsTable Mock query for merge 1`] = `
       Individuals
     
     </h4>
+     
+    <v-hover-stub
+      closedelay="0"
+      opendelay="0"
+    />
      
     <div>
       <v-tooltip-stub
@@ -552,6 +562,11 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
     
     </h4>
      
+    <v-hover-stub
+      closedelay="0"
+      opendelay="0"
+    />
+     
     <div>
       <v-tooltip-stub
         bottom="true"
@@ -815,6 +830,11 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
       Individuals
     
     </h4>
+     
+    <v-hover-stub
+      closedelay="0"
+      opendelay="0"
+    />
      
     <div>
       <v-tooltip-stub

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -31,6 +31,11 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
     
     </h4>
      
+    <v-hover-stub
+      closedelay="0"
+      opendelay="0"
+    />
+     
     <div>
       <v-tooltip-stub
         bottom="true"
@@ -296,6 +301,11 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
       Individuals
     
     </h4>
+     
+    <v-hover-stub
+      closedelay="0"
+      opendelay="0"
+    />
      
     <div>
       <v-tooltip-stub

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -4342,6 +4342,78 @@ exports[`Storyshots IndividualsTable Default 1`] = `
     
         </h4>
          
+        <div
+          class="v-input search ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field search--hidden"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-text-field__slot"
+              >
+                <label
+                  class="v-label theme--light"
+                  for="input-551"
+                  style="left: 0px; position: absolute;"
+                >
+                  Search
+                </label>
+                <input
+                  id="input-551"
+                  type="text"
+                />
+              </div>
+              <div
+                class="v-input__append-inner"
+              >
+                <div
+                  class="v-input__icon v-input__icon--clear"
+                >
+                  <button
+                    aria-label="clear icon"
+                    class="v-icon notranslate v-icon--disabled v-icon--link mdi mdi-close theme--light"
+                    disabled="disabled"
+                    type="button"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                >
+                  <div
+                    class="v-messages__message"
+                  >
+                    min. 3 characters
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="v-input__append-outer"
+          >
+            <div
+              class="v-input__icon v-input__icon--append-outer"
+            >
+              <button
+                aria-label="append icon"
+                class="v-icon notranslate v-icon--link mdi mdi-magnify theme--light"
+                type="button"
+              />
+            </div>
+          </div>
+        </div>
+         
         <div>
           <span
             class="v-tooltip v-tooltip--bottom"
@@ -5380,6 +5452,78 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
       Individuals
     
           </h4>
+           
+          <div
+            class="v-input search ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field search--hidden"
+          >
+            <div
+              class="v-input__control"
+            >
+              <div
+                class="v-input__slot"
+              >
+                <div
+                  class="v-text-field__slot"
+                >
+                  <label
+                    class="v-label theme--light"
+                    for="input-812"
+                    style="left: 0px; position: absolute;"
+                  >
+                    Search
+                  </label>
+                  <input
+                    id="input-812"
+                    type="text"
+                  />
+                </div>
+                <div
+                  class="v-input__append-inner"
+                >
+                  <div
+                    class="v-input__icon v-input__icon--clear"
+                  >
+                    <button
+                      aria-label="clear icon"
+                      class="v-icon notranslate v-icon--disabled v-icon--link mdi mdi-close theme--light"
+                      disabled="disabled"
+                      type="button"
+                    />
+                  </div>
+                </div>
+              </div>
+              <div
+                class="v-text-field__details"
+              >
+                <div
+                  class="v-messages theme--light"
+                >
+                  <div
+                    class="v-messages__wrapper"
+                  >
+                    <div
+                      class="v-messages__message"
+                    >
+                      min. 3 characters
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="v-input__append-outer"
+            >
+              <div
+                class="v-input__icon v-input__icon--append-outer"
+              >
+                <button
+                  aria-label="append icon"
+                  class="v-icon notranslate v-icon--link mdi mdi-magnify theme--light"
+                  type="button"
+                />
+              </div>
+            </div>
+          </div>
            
           <div>
             <span

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -235,6 +235,73 @@ describe("IndividualsTable", () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
+  test.each([
+    "",
+    "abc",
+    "abcd",
+    "123"
+  ])("Searches by term %p", async (term) => {
+    const querySpy = spyOn(Queries, "getPaginatedIndividuals");
+    const query = jest.fn(() => Promise.resolve(paginatedResponse));
+    const wrapper = shallowMount(IndividualsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          query
+        }
+      },
+      propsData: {
+        fetchPage: Queries.getPaginatedIndividuals,
+        mergeItems: () => {},
+        unmergeItems: () => {},
+        moveItem: () => {},
+        deleteItem: () => {},
+        addIdentity: () => {},
+        updateProfile: () => {},
+        enroll: () => {},
+        getCountries: () => {}
+      }
+    });
+
+    wrapper.setData({ filters: { term: term } });
+
+    const response = await wrapper.vm.queryIndividuals(1);
+
+    expect(querySpy).toHaveBeenCalledWith(1, 10, { term: term });
+  });
+
+  test.each([
+    "a",
+    "ab",
+    "1",
+    "12"
+  ])("Search is disabled if term is %p", async (term) => {
+    const query = jest.fn(() => Promise.resolve(paginatedResponse));
+    const wrapper = shallowMount(IndividualsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          query
+        }
+      },
+      propsData: {
+        fetchPage: query,
+        mergeItems: () => {},
+        unmergeItems: () => {},
+        moveItem: () => {},
+        deleteItem: () => {},
+        addIdentity: () => {},
+        updateProfile: () => {},
+        enroll: () => {},
+        getCountries: () => {}
+      }
+    });
+
+    await wrapper.setData({ filters: { term: term } });
+
+    expect(wrapper.vm.disabledSearch).toBe(true);
+  });
+
   test("Mock query for getCountries", async () => {
     const query = jest.fn(() => Promise.resolve(countriesMocked));
     const wrapper = shallowMount(IndividualsTable, {


### PR DESCRIPTION
This PR adds an input to `IndividualsTable` that allows the user to search individuals by term, and an optional filters argument to the `getPaginatedIndividuals` Apollo query. The query is not performed if the search term is shorter than 3 characters. The input can be cleared to return the full list of individuals.