### PR TITLE
[api] Set username as profile name when no name is provided

### DIFF
--- a/sortinghat/core/api.py
+++ b/sortinghat/core/api.py
@@ -170,8 +170,10 @@ def add_identity(ctx, source, name=None, email=None, username=None, uuid=None):
 
     if not uuid:
         individual = add_individual_db(trxl, id_)
+        # In case there is no name, set `username` as profile name
+        profile_name = name if name else username
         individual = update_profile_db(trxl, individual,
-                                       name=name, email=email)
+                                       name=profile_name, email=email)
     else:
         individual = find_individual_by_uuid(uuid)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -459,6 +459,34 @@ class TestAddIdentity(TestCase):
         transactions = Transaction.objects.filter(created_at__gt=trx_date)
         self.assertEqual(len(transactions), 0)
 
+    def test_add_identity_name_none(self):
+        """Check if the username is set to the profile when no name is provided"""
+
+        identity = api.add_identity(self.ctx,
+                                    'scm',
+                                    name=None,
+                                    email='jsmith@example.com',
+                                    username='jsmith')
+        self.assertEqual(identity.uuid, '18f652547d666701fcf1ddb59867bc88bb6e6b86')
+        self.assertEqual(identity.name, None)
+        self.assertEqual(identity.email, 'jsmith@example.com')
+        self.assertEqual(identity.username, 'jsmith')
+        self.assertEqual(identity.source, 'scm')
+
+        individual = Individual.objects.get(mk='18f652547d666701fcf1ddb59867bc88bb6e6b86')
+        self.assertEqual(individual.mk, identity.uuid)
+
+        profile = individual.profile
+        # The profile name must match with the username, as no name was provided
+        self.assertEqual(profile.name, 'jsmith')
+        self.assertEqual(profile.email, 'jsmith@example.com')
+
+        identities = Identity.objects.filter(uuid=identity.uuid)
+        self.assertEqual(len(identities), 1)
+
+        id1 = identities[0]
+        self.assertEqual(id1, identity)
+
     def test_non_existing_uuid(self):
         """Check whether it fails adding identities to one uuid that does not exist"""
 


### PR DESCRIPTION
As requested on issue #390, these changes allow to set the `username` as the profile name in case no `name` value is provided when a new Individual is created.