### PR TITLE
Design sign in/out method for the UI

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,8 @@
     "graphql-tag": "^2.10.3",
     "js-cookie": "^2.2.1",
     "vue": "^2.6.11",
-    "vue-apollo": "^3.0.3", 
+    "vue-apollo": "^3.0.3",
+    "vue-router": "^3.4.9",
     "vuetify": "^2.2.11",
     "vuex": "^3.1.3"
   },

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -1,5 +1,13 @@
 import gql from "graphql-tag";
 
+const TOKEN_AUTH = gql`
+  mutation tokenAuth($username: String!, $password: String!) {
+    tokenAuth(username: $username, password: $password) {
+      token
+    }
+  }
+`;
+
 const LOCK_INDIVIDUAL = gql`
   mutation LockIndividual($uuid: String!) {
     lock(uuid: $uuid) {
@@ -237,6 +245,17 @@ const DELETE_DOMAIN = gql`
   }
 `;
 
+const tokenAuth = (apollo, username, password) => {
+  const response = apollo.mutate({
+    mutation: TOKEN_AUTH,
+    variables: {
+      username: username,
+      password: password
+    }
+  });
+  return response;
+};
+
 const lockIndividual = (apollo, uuid) => {
   let response = apollo.mutate({
     mutation: LOCK_INDIVIDUAL,
@@ -366,6 +385,7 @@ const deleteDomain = (apollo, domain) => {
 };
 
 export {
+  tokenAuth,
   lockIndividual,
   unlockIndividual,
   deleteIdentity,

--- a/ui/src/components/Dashboard.vue
+++ b/ui/src/components/Dashboard.vue
@@ -1,0 +1,227 @@
+<template>
+  <v-content>
+    <work-space
+      :highlight-individual="highlightInWorkspace"
+      :individuals="savedIndividuals"
+      :merge-items="mergeItems"
+      :move-item="moveItem"
+      @clearSpace="savedIndividuals = []"
+      @updateIndividuals="updateTable"
+      @highlight="highlightIndividual($event, 'highlightInTable', true)"
+      @stopHighlight="highlightIndividual($event, 'highlightInTable', false)"
+      @deselect="deselectIndividuals"
+    />
+    <v-row>
+      <v-col class="individuals elevation-2">
+        <individuals-table
+          :fetch-page="getIndividualsPage"
+          :delete-item="deleteItem"
+          :merge-items="mergeItems"
+          :unmerge-items="unmergeItems"
+          :move-item="moveItem"
+          :highlight-individual="highlightInTable"
+          :add-identity="addIdentity"
+          :updateProfile="updateProfile"
+          :enroll="enroll"
+          :get-countries="getCountries"
+          @saveIndividual="addSavedIndividual"
+          @updateWorkspace="updateWorkspace"
+          @highlight="highlightIndividual($event, 'highlightInWorkspace', true)"
+          @stopHighlight="
+            highlightIndividual($event, 'highlightInWorkspace', false)
+          "
+          ref="table"
+        />
+      </v-col>
+      <v-col class="organizations elevation-2">
+        <organizations-table
+          :fetch-page="getOrganizationsPage"
+          :enroll="enroll"
+          :add-organization="addOrganization"
+          :add-domain="addDomain"
+          :delete-domain="deleteDomain"
+          @updateIndividuals="updateTable"
+          @updateWorkspace="updateWorkspace"
+        />
+      </v-col>
+    </v-row>
+    <v-snackbar v-model="snackbar">
+      Individual already in work space
+    </v-snackbar>
+  </v-content>
+</template>
+
+<script>
+import {
+  getCountries,
+  getPaginatedIndividuals,
+  getPaginatedOrganizations
+} from "../apollo/queries";
+import {
+  addIdentity,
+  deleteIdentity,
+  merge,
+  unmerge,
+  moveIdentity,
+  enroll,
+  addOrganization,
+  addDomain,
+  deleteDomain,
+  updateProfile
+} from "../apollo/mutations";
+import IndividualsTable from "../components/IndividualsTable";
+import OrganizationsTable from "../components/OrganizationsTable";
+import WorkSpace from "../components/WorkSpace";
+
+export default {
+  name: "Dashboard",
+  components: {
+    IndividualsTable,
+    OrganizationsTable,
+    WorkSpace
+  },
+  data() {
+    return {
+      highlightInTable: undefined,
+      highlightInWorkspace: undefined,
+      savedIndividuals: [],
+      snackbar: false
+    };
+  },
+  methods: {
+    async getIndividualsPage(page, items, filters) {
+      const response = await getPaginatedIndividuals(
+        this.$apollo,
+        page,
+        items,
+        filters
+      );
+      return response;
+    },
+    async getOrganizationsPage(page, items) {
+      const response = await getPaginatedOrganizations(
+        this.$apollo,
+        page,
+        items
+      );
+      return response;
+    },
+    addSavedIndividual(individual) {
+      const isSaved = this.savedIndividuals.find(savedIndividual => {
+        return individual.uuid === savedIndividual.uuid;
+      });
+      if (isSaved) {
+        this.snackbar = true;
+        return;
+      }
+      this.savedIndividuals.push(individual);
+    },
+    async deleteItem(uuid) {
+      const response = await deleteIdentity(this.$apollo, uuid);
+      return response;
+    },
+    async mergeItems(fromUuids, toUuid) {
+      const response = await merge(this.$apollo, fromUuids, toUuid);
+      return response;
+    },
+    updateTable() {
+      this.$refs.table.queryIndividuals();
+    },
+    updateWorkspace(event) {
+      if (event.remove) {
+        event.remove.forEach(removedItem => {
+          const removedIndex = this.savedIndividuals.findIndex(
+            individual => individual.uuid == removedItem
+          );
+          if (removedIndex !== -1) {
+            this.savedIndividuals.splice(removedIndex, 1);
+          }
+        });
+      }
+      if (event.update) {
+        event.update.forEach(updatedItem => {
+          const updatedIndex = this.savedIndividuals.findIndex(
+            individual => individual.uuid == updatedItem.uuid
+          );
+          if (updatedIndex !== -1) {
+            Object.assign(this.savedIndividuals[updatedIndex], updatedItem);
+          }
+        });
+      }
+    },
+    highlightIndividual(individual, component, highlight) {
+      this[component] = highlight ? individual.uuid : undefined;
+    },
+    async unmergeItems(uuids) {
+      const response = await unmerge(this.$apollo, uuids);
+      return response;
+    },
+    async moveItem(fromUuid, toUuid) {
+      const response = await moveIdentity(this.$apollo, fromUuid, toUuid);
+      return response;
+    },
+    deselectIndividuals() {
+      this.$refs.table.deselectIndividuals();
+    },
+    async enroll(uuid, organization, fromDate, toDate) {
+      const response = await enroll(
+        this.$apollo,
+        uuid,
+        organization,
+        fromDate,
+        toDate
+      );
+      return response;
+    },
+    async addIdentity(email, name, source, username) {
+      const response = await addIdentity(
+        this.$apollo,
+        email,
+        name,
+        source,
+        username
+      );
+      return response;
+    },
+    async updateProfile(data, uuid) {
+      const response = updateProfile(this.$apollo, data, uuid);
+      return response;
+    },
+    async addOrganization(organization) {
+      const response = await addOrganization(this.$apollo, organization);
+      return response;
+    },
+    async addDomain(domain, organization) {
+      const response = await addDomain(this.$apollo, domain, organization);
+      return response;
+    },
+    async deleteDomain(domain) {
+      const response = await deleteDomain(this.$apollo, domain);
+      return response;
+    },
+    async getCountries() {
+      const response = await getCountries(this.$apollo);
+      return response.data.countries.entities;
+    }
+  }
+};
+</script>
+<style scoped>
+.row {
+  justify-content: space-between;
+  margin: 32px;
+}
+.individuals {
+  max-width: 1200px;
+  width: 70%;
+}
+.organizations {
+  width: 25%;
+  max-width: 500px;
+  align-self: flex-start;
+  margin-left: 32px;
+}
+h4 {
+  padding: 12px 26px;
+}
+</style>

--- a/ui/src/components/Login.vue
+++ b/ui/src/components/Login.vue
@@ -1,0 +1,69 @@
+<template>
+  <v-content class="align-center">
+    <v-card class="mx-auto pa-7" max-width="500">
+      <v-card-title class="display-1 mb-2">Welcome</v-card-title>
+      <v-card-subtitle class="mb-3">Please log in to continue</v-card-subtitle>
+      <v-card-text>
+        <v-form ref="form">
+          <v-text-field v-model="username" label="Username" filled />
+          <v-text-field
+            v-model="password"
+            label="Password"
+            :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'"
+            :type="showPassword ? 'text' : 'password'"
+            filled
+            @click:append="showPassword = !showPassword"
+          />
+          <v-alert v-if="errorMessage" text type="error">
+            {{ errorMessage }}
+          </v-alert>
+          <v-btn
+            depressed
+            block
+            color="primary"
+            :disabled="disableSubmit"
+            @click.prevent="submit"
+          >
+            Log in
+          </v-btn>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-content>
+</template>
+
+<script>
+import { mapActions } from "vuex";
+export default {
+  name: "Login",
+  data: () => ({
+    username: "",
+    password: "",
+    showPassword: false,
+    errorMessage: ""
+  }),
+  computed: {
+    disableSubmit() {
+      return this.username.length < 3 || this.password.length < 3;
+    }
+  },
+  methods: {
+    ...mapActions(["login"]),
+    async submit() {
+      try {
+        const authDetails = {
+          apollo: this.$apollo,
+          username: this.username,
+          password: this.password
+        };
+        const response = await this.login(authDetails);
+        if (response) {
+          this.$router.push("/");
+        }
+      } catch (error) {
+        this.errorMessage = error;
+      }
+    }
+  }
+};
+</script>

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -1,8 +1,10 @@
 import Vue from "vue";
 import App from "./App.vue";
+import router from "./router";
 import store from "./store";
 import vuetify from "./plugins/vuetify";
 import VueApollo from "vue-apollo";
+import VueRouter from "vue-router";
 import { ApolloClient } from "apollo-client";
 import { createHttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
@@ -28,11 +30,13 @@ const cache = new InMemoryCache();
 
 const AuthLink = (operation, next) => {
   const token = csrftoken;
+  const authtoken = Cookies.get("sh_authtoken");
   operation.setContext(context => ({
     ...context,
     headers: {
       ...context.headers,
-      "X-CSRFToken": token
+      "X-CSRFToken": token,
+      Authorization: authtoken ? `JWT ${authtoken}` : ""
     }
   }));
   return next(operation);
@@ -47,6 +51,7 @@ const apolloClient = new ApolloClient({
 });
 
 Vue.use(VueApollo);
+Vue.use(VueRouter);
 
 const apolloProvider = new VueApollo({
   defaultClient: apolloClient
@@ -55,6 +60,7 @@ const apolloProvider = new VueApollo({
 Vue.config.productionTip = false;
 
 new Vue({
+  router,
   store,
   vuetify,
   apolloProvider,

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -1,0 +1,40 @@
+import Router from "vue-router";
+import store from "../store";
+import Dashboard from "../components/Dashboard";
+import Login from "../components/Login";
+
+const routes = [
+  {
+    path: "/",
+    name: "Dashboard",
+    component: Dashboard,
+    meta: { requiresAuth: true }
+  },
+  {
+    path: "/login",
+    name: "Login",
+    component: Login
+  }
+];
+
+const router = new Router({
+  mode: "history",
+  routes
+});
+
+router.beforeEach((to, from, next) => {
+  const isAuthenticated = store.getters.isAuthenticated;
+  if (to.matched.some(record => record.meta.requiresAuth)) {
+    if (!isAuthenticated) {
+      next({
+        path: "/login"
+      });
+    } else {
+      next();
+    }
+  } else {
+    next();
+  }
+});
+
+export default router;

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -1076,6 +1076,83 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
 </v-container-stub>
 `;
 
+exports[`Login Mock mutation for tokenAuth 1`] = `
+<v-content-stub
+  class="align-center"
+  tag="main"
+>
+  <v-card-stub
+    class="mx-auto pa-7"
+    loaderheight="4"
+    maxwidth="500"
+    tag="div"
+  >
+    <v-card-title-stub
+      class="display-1 mb-2"
+    >
+      Welcome
+    </v-card-title-stub>
+     
+    <v-card-subtitle-stub
+      class="mb-3"
+    >
+      Please log in to continue
+    </v-card-subtitle-stub>
+     
+    <v-card-text-stub>
+      <v-form-stub>
+        <v-text-field-stub
+          backgroundcolor=""
+          clearicon="$clear"
+          errorcount="1"
+          errormessages=""
+          filled="true"
+          label="Username"
+          loaderheight="2"
+          messages=""
+          rules=""
+          successmessages=""
+          type="text"
+          value=""
+        />
+         
+        <v-text-field-stub
+          appendicon="mdi-eye-off"
+          backgroundcolor=""
+          clearicon="$clear"
+          errorcount="1"
+          errormessages=""
+          filled="true"
+          label="Password"
+          loaderheight="2"
+          messages=""
+          rules=""
+          successmessages=""
+          type="password"
+          value=""
+        />
+         
+        <!---->
+         
+        <v-btn-stub
+          activeclass=""
+          block="true"
+          color="primary"
+          depressed="true"
+          disabled="true"
+          tag="button"
+          type="button"
+        >
+          
+          Log in
+        
+        </v-btn-stub>
+      </v-form-stub>
+    </v-card-text-stub>
+  </v-card-stub>
+</v-content-stub>
+`;
+
 exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
 <v-container-stub
   tag="div"

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -2,6 +2,7 @@ import { shallowMount, mount } from "@vue/test-utils";
 import Vue from "vue";
 import Vuetify from "vuetify";
 import IndividualsTable from "@/components/IndividualsTable";
+import Login from "@/components/Login";
 import OrganizationsTable from "@/components/OrganizationsTable";
 import ProfileModal from "@/components/ProfileModal";
 import * as Mutations from "@/apollo/mutations";
@@ -196,6 +197,14 @@ const deleteDomainResponse = {
         __typename: "DomainType"
       },
       __typename: "DeleteDomain"
+    }
+  }
+};
+
+const tokenResponse = {
+  data: {
+    tokenAuth: {
+      token: "eyJ0eXAiOiJKV1QiL"
     }
   }
 };
@@ -477,6 +486,29 @@ describe("ProfileModal", () => {
         isBot: true
       },
       "002bad315c34120cdfa2b1e26b3ca88ce36bc183"
+    );
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});
+
+describe("Login", () => {
+  test("Mock mutation for tokenAuth", async () => {
+    const mutate = jest.fn(() => Promise.resolve(tokenResponse));
+    const wrapper = shallowMount(Login, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      }
+    });
+    
+    const response = await Mutations.tokenAuth(
+      wrapper.vm.$apollo,
+      "username",
+      "password"
     );
 
     expect(mutate).toBeCalled();

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -13417,6 +13417,11 @@ vue-property-decorator@8.3.0:
   dependencies:
     vue-class-component "^7.1.0"
 
+vue-router@^3.4.9:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/vue-router/-/vue-router-3.4.9.tgz#c016f42030ae2932f14e4748b39a1d9a0e250e66"
+  integrity sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA==
+
 vue-style-loader@^4.1.0, vue-style-loader@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/vue-style-loader/-/vue-style-loader-4.1.2.tgz#dedf349806f25ceb4e64f3ad7c0a44fba735fcf8"


### PR DESCRIPTION
This PR implements a basic sign in/out functionality. It adds the `vue-router` dependency, which is the official Vue tool to manage routes, to to create the main `/` and `/login` routes and check if a user is authenticated before navigating to them.
The main view is moved to its own `Dashboard` component. A new `Login` component where a user can enter and submit credentials is displayed at the `/login` route. The user token is retrieved with the `tokenAuth` Apollo mutation and saved to a cookie and to the store, and it is used in the authorization header of the remaining Apollo queries and mutations.
The nav bar displays the user name when logged in. The user can click the username to log out, which removes the authentication cookies and redirects to the login view.