### PR TITLE
[schema] Support filtering individuals by last updated date

### DIFF
--- a/sortinghat/core/errors.py
+++ b/sortinghat/core/errors.py
@@ -29,6 +29,7 @@ CODE_CLOSED_TRANSACTION_ERROR = 12
 CODE_LOCKED_IDENTITY_ERROR = 13
 CODE_DUPLICATE_RANGE_ERROR = 14
 CODE_EQUAL_INDIVIDUAL_ERROR = 15
+CODE_FILTER_ERROR = 16
 CODE_RECOMMENDATION_ERROR = 100
 CODE_TOKEN_EXPIRED = 126
 CODE_PERMISSION_DENIED = 127
@@ -79,6 +80,13 @@ class InvalidValueError(BaseError):
 
     code = CODE_VALUE_ERROR
     message = "%(msg)s"
+
+
+class InvalidFilterError(BaseError):
+    """Exception raised when a filter is invalid"""
+
+    code = CODE_FILTER_ERROR
+    message = "Error in %(filter_name)s filter: %(msg)s"
 
 
 class EqualIndividualError(BaseError):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -27,6 +27,7 @@ from sortinghat.core.errors import (BaseError,
                                     AlreadyExistsError,
                                     NotFoundError,
                                     InvalidValueError,
+                                    InvalidFilterError,
                                     EqualIndividualError,
                                     ClosedTransactionError,
                                     LockedIdentityError,
@@ -143,6 +144,24 @@ class TestInvalidValueError(TestCase):
         """
         kwargs = {}
         self.assertRaises(KeyError, InvalidValueError, **kwargs)
+
+
+class TestInvalidFilterError(TestCase):
+    """Unit tests for InvalidFilterError"""
+
+    def test_message(self):
+        """Make sure that prints the right error"""
+
+        e = InvalidFilterError(filter_name='example', msg="invalid filter")
+        self.assertEqual("Error in example filter: invalid filter", str(e))
+
+    def test_no_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {}
+        self.assertRaises(KeyError, InvalidFilterError, **kwargs)
 
 
 class TestEqualIndividualError(TestCase):


### PR DESCRIPTION
Now, individuals can be queried filtering by their last updated date.

The accepted filter formats are controlled by regular expressions matching two patterns:
* A comparison operator (>, >=, <, <=) and a date (e.g. `>=YYYY-MM-DDTHH:MM:SSZ`).
* A range operator (..) between two dates (e.g. `YYYY-MM-DDTHH:MM:SSZ..YYYY-MM-DDTHH:MM:SSZ`)

The accepted date format is ISO 8601, `YYYY-MM-DDTHH:MM:SSZ`, also accepting microseconds and time zone offset (`YYYY-MM-DDTHH:MM:SS.ms+HH:HH`).

Note: This PR is linked to issue #394 .