### PR TITLE
Limit SQLAlchemy versions to <1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyMySQL>=0.7.0
-sqlalchemy>=1.2
+sqlalchemy>=1.2,<1.4
 jinja2==2.11.1
 python-dateutil>=2.6.0
 pandas>=0.22.0,<=0.25.3

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(name="sortinghat",
       ],
       install_requires=[
         'PyMySQL>=0.7.0',
-        'sqlalchemy>=1.2',
+        'sqlalchemy>=1.2,<1.4',
         'jinja2==2.11.1',
         'python-dateutil>=2.6.0',
         'pandas>=0.22.0,<=0.25.3',


### PR DESCRIPTION
SQLAlchemy 1.4.x doesn't work with the current code in SortingHat. This is a hotfix to force pip to install a version lower than 1.4.

Signed-off-by: Santiago Dueñas <sduenas@bitergia.com>