### PR TITLE
[ui] Edit enrollment dates

### DIFF
--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -117,7 +117,7 @@
       <v-subheader>Organizations ({{ enrollments.length }})</v-subheader>
 
       <v-list-item
-        v-for="enrollment in enrollments"
+        v-for="(enrollment, index) in enrollments"
         :key="enrollment.organization.id"
       >
         <v-list-item-content>
@@ -126,10 +126,100 @@
               <span>{{ enrollment.organization.name }}</span>
             </v-col>
             <v-col class="col-3 ma-2 text-center">
-              <span>{{ formatDate(enrollment.start) }}</span>
+              <span v-if="isLocked || compact">
+                {{ formatDate(enrollment.start) }}
+              </span>
+              <v-edit-dialog
+                v-else
+                @close="
+                  $emit('updateEnrollment', {
+                    fromDate: enrollment.start,
+                    toDate: enrollment.end,
+                    newFromDate: new Date(
+                      enrollmentsForm[index].fromDate
+                    ).toISOString(),
+                    organization: enrollment.organization.name,
+                    uuid: uuid
+                  })
+                "
+              >
+                {{ formatDate(enrollment.start) }}
+                <v-icon small right>
+                  mdi-lead-pencil
+                </v-icon>
+                <template v-slot:input>
+                  <v-menu
+                    v-model="enrollmentsForm[index].fromDateMenu"
+                    :close-on-content-click="false"
+                    transition="scale-transition"
+                    offset-y
+                    min-width="290px"
+                  >
+                    <template v-slot:activator="{ on }">
+                      <v-text-field
+                        v-model="enrollmentsForm[index].fromDate"
+                        readonly
+                        v-on="on"
+                      ></v-text-field>
+                    </template>
+                    <v-date-picker
+                      v-model="enrollmentsForm[index].fromDate"
+                      @input="enrollmentsForm[index].fromDateMenu = false"
+                      no-title
+                      scrollable
+                    >
+                    </v-date-picker>
+                  </v-menu>
+                </template>
+              </v-edit-dialog>
             </v-col>
             <v-col class="col-3 ma-2 text-center">
-              <span>{{ formatDate(enrollment.end) }}</span>
+              <span v-if="isLocked || compact">
+                {{ formatDate(enrollment.end) }}
+              </span>
+              <v-edit-dialog
+                v-else
+                @close="
+                  $emit('updateEnrollment', {
+                    fromDate: enrollment.start,
+                    toDate: enrollment.end,
+                    newToDate: new Date(
+                      enrollmentsForm[index].toDate
+                    ).toISOString(),
+                    organization: enrollment.organization.name,
+                    uuid: uuid
+                  })
+                "
+              >
+                {{ formatDate(enrollment.end) }}
+                <v-icon small right>
+                  mdi-lead-pencil
+                </v-icon>
+                <template v-slot:input>
+                  <v-menu
+                    v-model="enrollmentsForm[index].toDateMenu"
+                    :close-on-content-click="false"
+                    transition="scale-transition"
+                    offset-y
+                    min-width="290px"
+                  >
+                    <template v-slot:activator="{ on }">
+                      <v-text-field
+                        v-model="enrollmentsForm[index].toDate"
+                        readonly
+                        v-on="on"
+                      ></v-text-field>
+                    </template>
+                    <v-date-picker
+                      v-model="enrollmentsForm[index].toDate"
+                      @input="enrollmentsForm[index].toDateMenu = false"
+                      no-title
+                      scrollable
+                    >
+                    </v-date-picker>
+                  </v-menu>
+                </template>
+              </v-edit-dialog>
             </v-col>
           </v-row>
         </v-list-item-content>
@@ -196,7 +286,8 @@ export default {
         gender: this.gender,
         country: this.country,
         isBot: this.isBot
-      }
+      },
+      enrollmentsForm: []
     };
   },
   methods: {
@@ -249,6 +340,16 @@ export default {
     sources() {
       return this.identities.map(identity => identity.name);
     }
+  },
+  created() {
+    this.enrollments.forEach(enrollment => {
+      this.enrollmentsForm.push({
+        fromDate: this.formatDate(enrollment.start),
+        fromDateMenu: false,
+        toDate: this.formatDate(enrollment.end),
+        toDateMenu: false
+      });
+    });
   }
 };
 </script>

--- a/ui/src/components/IndividualsTable.stories.js
+++ b/ui/src/components/IndividualsTable.stories.js
@@ -20,6 +20,7 @@ const IndividualsTableTemplate = `
     :get-countries="getCountries.bind(this)"
     :lock-individual="deleteIndividual"
     :unlock-individual="deleteIndividual"
+    :update-enrollment="deleteIndividual"
   />
 `;
 

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -111,6 +111,7 @@
           :get-countries="getCountries"
           @edit="updateProfileInfo($event, item.uuid)"
           @unmerge="unmerge($event)"
+          @updateEnrollment="updateEnrollmentDate"
         />
       </template>
     </v-data-table>
@@ -231,6 +232,10 @@ export default {
     unlockIndividual: {
       type: Function,
       required: true
+    },
+    updateEnrollment: {
+      type: Function,
+      required: false
     }
   },
   data() {
@@ -401,6 +406,16 @@ export default {
         } catch (error) {
           Object.assign(this.snackbar, { open: true, text: error });
         }
+      }
+    },
+    async updateEnrollmentDate(data) {
+      try {
+        const response = this.updateEnrollment(data);
+        if (response) {
+          this.queryIndividuals();
+        }
+      } catch (error) {
+        Object.assign(this.snackbar, { open: true, text: error });
       }
     }
   },

--- a/ui/src/components/WorkSpace.stories.js
+++ b/ui/src/components/WorkSpace.stories.js
@@ -35,6 +35,7 @@ const dragAndDropTemplate = `
     :get-countries="getCountries.bind(this)"
     :lock-individual="deleteItem"
     :unlock-individual="deleteItem"
+    :update-enrollment="deleteItem"
     @highlight="highlightIndividual($event, 'highlightInWorkspace', true)"
     @stopHighlight="highlightIndividual($event, 'highlightInWorkspace', false)"
     ref="table"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -1027,17 +1027,53 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               <div
                 class="col-3 ma-2 text-center col"
               >
-                <span>
-                  1938-09-01
-                </span>
+                <div
+                  class="v-menu v-small-dialog theme--light"
+                >
+                  <div
+                    class="v-small-dialog__activator"
+                  >
+                    <span
+                      class="v-small-dialog__activator__content"
+                    >
+                      
+              1938-09-01
+              
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </div>
+                  <!---->
+                </div>
               </div>
                
               <div
                 class="col-3 ma-2 text-center col"
               >
-                <span>
-                  1998-05-02
-                </span>
+                <div
+                  class="v-menu v-small-dialog theme--light"
+                >
+                  <div
+                    class="v-small-dialog__activator"
+                  >
+                    <span
+                      class="v-small-dialog__activator__content"
+                    >
+                      
+              1998-05-02
+              
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </div>
+                  <!---->
+                </div>
               </div>
             </div>
           </div>
@@ -1064,17 +1100,53 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               <div
                 class="col-3 ma-2 text-center col"
               >
-                <span>
-                  1938-09-01
-                </span>
+                <div
+                  class="v-menu v-small-dialog theme--light"
+                >
+                  <div
+                    class="v-small-dialog__activator"
+                  >
+                    <span
+                      class="v-small-dialog__activator__content"
+                    >
+                      
+              1938-09-01
+              
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </div>
+                  <!---->
+                </div>
               </div>
                
               <div
                 class="col-3 ma-2 text-center col"
               >
-                <span>
-                  1945-06-02
-                </span>
+                <div
+                  class="v-menu v-small-dialog theme--light"
+                >
+                  <div
+                    class="v-small-dialog__activator"
+                  >
+                    <span
+                      class="v-small-dialog__activator__content"
+                    >
+                      
+              1945-06-02
+              
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </div>
+                  <!---->
+                </div>
               </div>
             </div>
           </div>
@@ -4959,13 +5031,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-644"
+                  for="input-656"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-644"
+                  id="input-656"
                   type="text"
                 />
               </div>
@@ -6072,13 +6144,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-952"
+                    for="input-964"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-952"
+                    id="input-964"
                     type="text"
                   />
                 </div>


### PR DESCRIPTION
The start and end dates of an enrollment can be edited by clicking on them on `ExpandedIndividual`, which opens a date picker. The old and new enrollment data is emitted to `IndividualsTable` to handle it.

This PR is a draft, a new mutation to update the enrollments needs to be added.