### PR TITLE
[ui] Drag and drop organizations to enroll individuals

### DIFF
--- a/ui/src/components/Dashboard.vue
+++ b/ui/src/components/Dashboard.vue
@@ -1,6 +1,7 @@
 <template>
   <v-main>
     <work-space
+      :enroll="enroll"
       :highlight-individual="highlightInWorkspace"
       :individuals="savedIndividuals"
       :merge-items="mergeItems"
@@ -10,6 +11,8 @@
       @highlight="highlightIndividual($event, 'highlightInTable', true)"
       @stopHighlight="highlightIndividual($event, 'highlightInTable', false)"
       @deselect="deselectIndividuals"
+      @updateOrganizations="updateOrganizations"
+      @updateWorkspace="updateWorkspace"
     />
     <v-row>
       <v-col class="individuals elevation-2">
@@ -28,6 +31,7 @@
           :unlock-individual="unlockIndividual"
           :withdraw="withdraw"
           @saveIndividual="addSavedIndividual"
+          @updateOrganizations="updateOrganizations"
           @updateWorkspace="updateWorkspace"
           @highlight="highlightIndividual($event, 'highlightInWorkspace', true)"
           @stopHighlight="
@@ -46,6 +50,7 @@
           :delete-organization="deleteOrganization"
           @updateIndividuals="updateTable"
           @updateWorkspace="updateWorkspace"
+          ref="organizations"
         />
       </v-col>
     </v-row>
@@ -131,6 +136,9 @@ export default {
     async mergeItems(fromUuids, toUuid) {
       const response = await merge(this.$apollo, fromUuids, toUuid);
       return response;
+    },
+    updateOrganizations() {
+      this.$refs.organizations.getOrganizations();
     },
     updateTable() {
       this.$refs.table.queryIndividuals();

--- a/ui/src/components/IndividualCard.vue
+++ b/ui/src/components/IndividualCard.vue
@@ -138,6 +138,8 @@ export default {
       const type = event.dataTransfer.getData("type");
       if (type === "move") {
         this.moveIndividual(event);
+      } else if (type === "enrollFromOrganization") {
+        this.enrollIndividual(event);
       } else {
         this.mergeIndividuals(event);
       }
@@ -156,6 +158,10 @@ export default {
       );
       const uuids = droppedIndividuals.map(individual => individual.uuid);
       this.$emit("merge", [this.uuid, ...uuids]);
+    },
+    enrollIndividual(event) {
+      const organization = event.dataTransfer.getData("organization");
+      this.$emit("enroll", organization);
     }
   }
 };

--- a/ui/src/components/IndividualEntry.vue
+++ b/ui/src/components/IndividualEntry.vue
@@ -242,6 +242,8 @@ export default {
       const type = event.dataTransfer.getData("type");
       if (type === "move") {
         this.moveIndividual(event);
+      } else if (type === "enrollFromOrganization") {
+        this.enrollIndividual(event);
       } else {
         this.mergeIndividuals(event);
       }
@@ -258,6 +260,10 @@ export default {
     moveIndividual(event) {
       const uuid = event.dataTransfer.getData("uuid");
       this.$emit("move", { fromUuid: uuid, toUuid: this.uuid });
+    },
+    enrollIndividual(event) {
+      const organization = event.dataTransfer.getData("organization");
+      this.$emit("enroll", organization);
     }
   },
   watch: {

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -81,6 +81,7 @@
           @highlight="$emit('highlight', item)"
           @stopHighlight="$emit('stopHighlight', item)"
           @lock="handleLock(item.uuid, $event)"
+          @enroll="confirmEnroll(item.uuid, $event)"
         />
       </template>
       <template v-slot:expanded-item="{ item }">
@@ -109,7 +110,7 @@
       ></v-pagination>
     </div>
 
-    <v-dialog v-model="dialog.open" max-width="400">
+    <v-dialog v-model="dialog.open" max-width="500px">
       <v-card>
         <v-card-title class="headline">{{ dialog.title }}</v-card-title>
         <v-card-text>{{ dialog.text }}</v-card-text>
@@ -135,9 +136,9 @@
     />
 
     <v-card class="dragged-item" color="primary" dark>
-      <v-card-title>
+      <v-card-subtitle>
         Moving {{ this.selectedIndividuals.length }}
-      </v-card-title>
+      </v-card-subtitle>
     </v-card>
 
     <v-snackbar v-model="snackbar.open">
@@ -152,6 +153,7 @@ import {
   moveIdentity,
   formatIndividuals
 } from "../utils/actions";
+import { enrollMixin } from "../mixins/enroll";
 import IndividualEntry from "./IndividualEntry.vue";
 import ExpandedIndividual from "./ExpandedIndividual.vue";
 import ProfileModal from "./ProfileModal.vue";
@@ -165,6 +167,7 @@ export default {
     ProfileModal,
     Search
   },
+  mixins: [enrollMixin],
   props: {
     fetchPage: {
       type: Function,

--- a/ui/src/components/OrganizationEntry.vue
+++ b/ui/src/components/OrganizationEntry.vue
@@ -54,7 +54,7 @@ export default {
     onDrop(event) {
       this.dropZone = false;
       const type = event.dataTransfer.getData("type");
-      if (type === "enroll") {
+      if (type === "enrollFromOrganization") {
         return;
       }
       const droppedIndividuals = JSON.parse(

--- a/ui/src/components/OrganizationEntry.vue
+++ b/ui/src/components/OrganizationEntry.vue
@@ -1,10 +1,10 @@
 <template>
   <tr
-    :class="{ dropzone: isDragging }"
+    :class="{ dropzone: dropZone }"
     @drop.stop="onDrop($event)"
-    @dragover.prevent="isDragging = true"
-    @dragenter.prevent="isDragging = true"
-    @dragleave.prevent="isDragging = false"
+    @dragover.prevent="isDropZone($event, true)"
+    @dragenter.prevent="isDropZone($event, true)"
+    @dragleave.prevent="isDropZone($event, false)"
   >
     <td class="text--body-1">{{ name }}</td>
     <td class="text-right text--secondary">{{ enrollments }}</td>
@@ -47,12 +47,16 @@ export default {
   },
   data() {
     return {
-      isDragging: false
+      dropZone: false
     };
   },
   methods: {
     onDrop(event) {
-      this.isDragging = false;
+      this.dropZone = false;
+      const type = event.dataTransfer.getData("type");
+      if (type === "enroll") {
+        return;
+      }
       const droppedIndividuals = JSON.parse(
         event.dataTransfer.getData("individuals")
       );
@@ -60,10 +64,29 @@ export default {
         uuids: droppedIndividuals.map(individual => individual.uuid),
         organization: this.name
       });
+    },
+    isDropZone(event, isDragging) {
+      const type = event.dataTransfer.getData("type");
+      // Can't use 'getData' while dragging on Chrome
+      const types = event.dataTransfer.types;
+
+      // Prevents an organization from being drag&dropped into another one
+      if (
+        isDragging &&
+        type !== "enrollFromOrganization" &&
+        !types.includes("organization")
+      ) {
+        this.dropZone = true;
+      } else {
+        this.dropZone = false;
+      }
     }
   }
 };
 </script>
 <style lang="scss" scoped>
 @import "../styles/index.scss";
+tr {
+  cursor: pointer;
+}
 </style>

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -237,7 +237,7 @@ export default {
     startDrag(item, event) {
       this.selectedOrganization = item.name;
       event.dataTransfer.dropEffect = "move";
-      event.dataTransfer.setData("type", "enroll");
+      event.dataTransfer.setData("type", "enrollFromOrganization");
       event.dataTransfer.setData("organization", item.name);
       const dragImage = document.querySelector(".dragged-organization");
       event.dataTransfer.setDragImage(dragImage, 0, 0);

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -31,7 +31,9 @@
           :enrollments="item.enrollments.length"
           :domains="item.domains"
           :is-expanded="isExpanded"
+          draggable
           v-on:dblclick.native="expand(!isExpanded)"
+          @dragstart.native="startDrag(item, $event)"
           @expand="expand(!isExpanded)"
           @enroll="confirmEnroll"
           @edit="openModal(item)"
@@ -62,7 +64,7 @@
       @updateOrganizations="getOrganizations(page)"
     />
 
-    <v-dialog v-model="dialog.open" max-width="400">
+    <v-dialog v-model="dialog.open" max-width="500px">
       <v-card>
         <v-card-title class="headline">{{ dialog.title }}</v-card-title>
         <v-card-text>{{ dialog.text }}</v-card-text>
@@ -81,6 +83,15 @@
     <v-snackbar v-model="snackbar.open">
       {{ snackbar.text }}
     </v-snackbar>
+
+    <v-card class="dragged-organization" color="primary" dark>
+      <v-card-title>
+        {{ selectedOrganization }}
+      </v-card-title>
+      <v-card-subtitle>
+        Drag and drop on an individual to affiliate
+      </v-card-subtitle>
+    </v-card>
   </v-container>
 </template>
 
@@ -149,14 +160,15 @@ export default {
         open: false,
         organization: undefined,
         domains: []
-      }
+      },
+      selectedOrganization: ""
     };
   },
   created() {
     this.getOrganizations(1);
   },
   methods: {
-    async getOrganizations(page) {
+    async getOrganizations(page = this.page) {
       let response = await this.fetchPage(page, this.itemsPerPage);
       if (response) {
         this.organizations = response.data.organizations.entities;
@@ -221,6 +233,14 @@ export default {
       } catch (error) {
         Object.assign(this.snackbar, { open: true, text: error });
       }
+    },
+    startDrag(item, event) {
+      this.selectedOrganization = item.name;
+      event.dataTransfer.dropEffect = "move";
+      event.dataTransfer.setData("type", "enroll");
+      event.dataTransfer.setData("organization", item.name);
+      const dragImage = document.querySelector(".dragged-organization");
+      event.dataTransfer.setDragImage(dragImage, 0, 0);
     }
   }
 };
@@ -237,5 +257,11 @@ export default {
 .actions {
   justify-content: space-between;
   padding: 0 26px 24px 26px;
+}
+
+.dragged-organization {
+  max-width: 400px;
+  position: absolute;
+  top: -400px;
 }
 </style>

--- a/ui/src/components/WorkSpace.stories.js
+++ b/ui/src/components/WorkSpace.stories.js
@@ -9,7 +9,7 @@ export default {
 };
 
 const workSpaceTemplate =
-  '<work-space :individuals="individuals" :merge-items="mergeItems" :move-item="moveItem"/>';
+  '<work-space :individuals="individuals" :merge-items="mergeItems" :move-item="moveItem" :enroll="() => {}"/>';
 
 const dragAndDropTemplate = `
   <div>
@@ -18,6 +18,7 @@ const dragAndDropTemplate = `
     :merge-items="mergeItems"
     :move-item="moveItem"
     :highlight-individual="highlightInWorkspace"
+    :enroll="deleteItem"
     @highlight="highlightIndividual($event, 'highlightInTable', true)"
     @stopHighlight="highlightIndividual($event, 'highlightInTable', false)"
     @deselect="deselectIndividuals"
@@ -207,6 +208,7 @@ export const Empty = () => ({
     individuals: []
   }),
   methods: {
+
     mergeItems() {
       this.individuals.pop();
     },

--- a/ui/src/components/WorkSpace.vue
+++ b/ui/src/components/WorkSpace.vue
@@ -62,6 +62,7 @@
           :identities="individual.identities"
           :enrollments="individual.enrollments"
           :is-highlighted="individual.uuid === highlightIndividual"
+          @enroll="confirmEnroll(individual.uuid, $event)"
           @merge="mergeSelected($event)"
           @mouseenter="$emit('highlight', individual)"
           @mouseleave="$emit('stopHighlight', individual)"
@@ -103,12 +104,14 @@ import {
   moveIdentity,
   groupIdentities
 } from "../utils/actions";
+import { enrollMixin } from "../mixins/enroll";
 import IndividualCard from "./IndividualCard.vue";
 export default {
   name: "WorkSpace",
   components: {
     IndividualCard
   },
+  mixins: [enrollMixin],
   props: {
     highlightIndividual: {
       type: String,
@@ -123,6 +126,10 @@ export default {
       required: true
     },
     moveItem: {
+      type: Function,
+      required: true
+    },
+    enroll: {
       type: Function,
       required: true
     }
@@ -154,7 +161,8 @@ export default {
       this.$emit("clearSpace");
     },
     onDrop(evt) {
-      if (event.dataTransfer.getData("type") === "move") {
+      const type = evt.dataTransfer.getData("type");
+      if (type === "move" || type === "enrollFromOrganization") {
         return;
       }
       const droppedIndividuals = JSON.parse(
@@ -248,7 +256,13 @@ export default {
       }
     },
     onDrag(event) {
-      if (event.dataTransfer.getData("type") === "move") {
+      const type = event.dataTransfer.getData("type");
+      const types = event.dataTransfer.types;
+      if (
+        type === "move" ||
+        type === "enrollFromOrganization" ||
+        types.includes("organization")
+      ) {
         return;
       }
       this.isDragging = true;

--- a/ui/src/mixins/enroll.js
+++ b/ui/src/mixins/enroll.js
@@ -1,0 +1,34 @@
+import { formatIndividuals } from "../utils/actions";
+
+const enrollMixin = {
+  methods: {
+    confirmEnroll(uuid, organization) {
+      Object.assign(this.dialog, {
+        open: true,
+        title: `Affiliate individual to ${organization}?`,
+        text: "",
+        action: () => this.enrollIndividual(uuid, organization)
+      });
+    },
+    async enrollIndividual(uuid, organization) {
+      this.dialog.open = false;
+      try {
+        const response = await this.enroll(uuid, organization);
+        if (response) {
+          this.$emit("updateWorkspace", {
+            update: formatIndividuals([response.data.enroll.individual])
+          });
+          this.$emit("updateOrganizations");
+          this.$emit("updateIndividuals");
+          if (this.queryIndividuals) {
+            this.queryIndividuals();
+          }
+        }
+      } catch (error) {
+        Object.assign(this.snackbar, { open: true, text: error });
+      }
+    }
+  }
+};
+
+export { enrollMixin };

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -202,7 +202,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -266,11 +266,11 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
     loaderheight="4"
     tag="div"
   >
-    <v-card-title-stub>
+    <v-card-subtitle-stub>
       
       Moving 0
     
-    </v-card-title-stub>
+    </v-card-subtitle-stub>
   </v-card-stub>
    
   <v-snackbar-stub
@@ -488,7 +488,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -552,11 +552,11 @@ exports[`IndividualsTable Mock query for merge 1`] = `
     loaderheight="4"
     tag="div"
   >
-    <v-card-title-stub>
+    <v-card-subtitle-stub>
       
       Moving 0
     
-    </v-card-title-stub>
+    </v-card-subtitle-stub>
   </v-card-stub>
    
   <v-snackbar-stub
@@ -774,7 +774,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -838,11 +838,11 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
     loaderheight="4"
     tag="div"
   >
-    <v-card-title-stub>
+    <v-card-subtitle-stub>
       
       Moving 0
     
-    </v-card-title-stub>
+    </v-card-subtitle-stub>
   </v-card-stub>
    
   <v-snackbar-stub
@@ -1060,7 +1060,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -1124,11 +1124,11 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
     loaderheight="4"
     tag="div"
   >
-    <v-card-title-stub>
+    <v-card-subtitle-stub>
       
       Moving 0
     
-    </v-card-title-stub>
+    </v-card-subtitle-stub>
   </v-card-stub>
    
   <v-snackbar-stub
@@ -1346,7 +1346,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -1410,11 +1410,11 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
     loaderheight="4"
     tag="div"
   >
-    <v-card-title-stub>
+    <v-card-subtitle-stub>
       
       Moving 0
     
-    </v-card-title-stub>
+    </v-card-subtitle-stub>
   </v-card-stub>
    
   <v-snackbar-stub
@@ -1668,7 +1668,7 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -1728,6 +1728,26 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
     
   
   </v-snackbar-stub>
+   
+  <v-card-stub
+    class="dragged-organization"
+    color="primary"
+    dark="true"
+    loaderheight="4"
+    tag="div"
+  >
+    <v-card-title-stub>
+      
+      
+    
+    </v-card-title-stub>
+     
+    <v-card-subtitle-stub>
+      
+      Drag and drop on an individual to affiliate
+    
+    </v-card-subtitle-stub>
+  </v-card-stub>
 </v-container-stub>
 `;
 
@@ -1892,7 +1912,7 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -1952,6 +1972,26 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
     
   
   </v-snackbar-stub>
+   
+  <v-card-stub
+    class="dragged-organization"
+    color="primary"
+    dark="true"
+    loaderheight="4"
+    tag="div"
+  >
+    <v-card-title-stub>
+      
+      
+    
+    </v-card-title-stub>
+     
+    <v-card-subtitle-stub>
+      
+      Drag and drop on an individual to affiliate
+    
+    </v-card-subtitle-stub>
+  </v-card-stub>
 </v-container-stub>
 `;
 
@@ -2116,7 +2156,7 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -2176,6 +2216,26 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
     
   
   </v-snackbar-stub>
+   
+  <v-card-stub
+    class="dragged-organization"
+    color="primary"
+    dark="true"
+    loaderheight="4"
+    tag="div"
+  >
+    <v-card-title-stub>
+      
+      
+    
+    </v-card-title-stub>
+     
+    <v-card-subtitle-stub>
+      
+      Drag and drop on an individual to affiliate
+    
+    </v-card-subtitle-stub>
+  </v-card-stub>
 </v-container-stub>
 `;
 
@@ -2338,7 +2398,7 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -2398,6 +2458,26 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
     
   
   </v-snackbar-stub>
+   
+  <v-card-stub
+    class="dragged-organization"
+    color="primary"
+    dark="true"
+    loaderheight="4"
+    tag="div"
+  >
+    <v-card-title-stub>
+      
+      
+    
+    </v-card-title-stub>
+     
+    <v-card-subtitle-stub>
+      
+      Drag and drop on an individual to affiliate
+    
+    </v-card-subtitle-stub>
+  </v-card-stub>
 </v-container-stub>
 `;
 
@@ -2560,7 +2640,7 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -2620,6 +2700,26 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
     
   
   </v-snackbar-stub>
+   
+  <v-card-stub
+    class="dragged-organization"
+    color="primary"
+    dark="true"
+    loaderheight="4"
+    tag="div"
+  >
+    <v-card-title-stub>
+      
+      
+    
+    </v-card-title-stub>
+     
+    <v-card-subtitle-stub>
+      
+      Drag and drop on an individual to affiliate
+    
+    </v-card-subtitle-stub>
+  </v-card-stub>
 </v-container-stub>
 `;
 

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -209,7 +209,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -275,11 +275,11 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
     loaderheight="4"
     tag="div"
   >
-    <v-card-title-stub>
+    <v-card-subtitle-stub>
       
       Moving 0
     
-    </v-card-title-stub>
+    </v-card-subtitle-stub>
   </v-card-stub>
    
   <v-snackbar-stub
@@ -497,7 +497,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -561,11 +561,11 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
     loaderheight="4"
     tag="div"
   >
-    <v-card-title-stub>
+    <v-card-subtitle-stub>
       
       Moving 0
     
-    </v-card-title-stub>
+    </v-card-subtitle-stub>
   </v-card-stub>
    
   <v-snackbar-stub
@@ -740,7 +740,7 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
   <v-dialog-stub
     closedelay="0"
     contentclass=""
-    maxwidth="400"
+    maxwidth="500px"
     opendelay="0"
     origin="center center"
     retainfocus="true"
@@ -800,5 +800,25 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
     
   
   </v-snackbar-stub>
+   
+  <v-card-stub
+    class="dragged-organization"
+    color="primary"
+    dark="true"
+    loaderheight="4"
+    tag="div"
+  >
+    <v-card-title-stub>
+      
+      
+    
+    </v-card-title-stub>
+     
+    <v-card-subtitle-stub>
+      
+      Drag and drop on an individual to affiliate
+    
+    </v-card-subtitle-stub>
+  </v-card-stub>
 </v-container-stub>
 `;

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -5209,7 +5209,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
         class="dragged-item v-card v-sheet theme--dark primary"
       >
         <div
-          class="v-card__title"
+          class="v-card__subtitle"
         >
           
       Moving 0
@@ -5562,6 +5562,26 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
           />
         </div>
       </div>
+       
+      <div
+        class="dragged-organization v-card v-sheet theme--dark primary"
+      >
+        <div
+          class="v-card__title"
+        >
+          
+      
+    
+        </div>
+         
+        <div
+          class="v-card__subtitle"
+        >
+          
+      Drag and drop on an individual to affiliate
+    
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -5797,13 +5817,13 @@ exports[`Storyshots Search Default 1`] = `
             >
               <label
                 class="v-label theme--light"
-                for="input-863"
+                for="input-864"
                 style="left: 0px; position: absolute;"
               >
                 Search
               </label>
               <input
-                id="input-863"
+                id="input-864"
                 type="text"
               />
             </div>
@@ -6311,13 +6331,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-944"
+                    for="input-945"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-944"
+                    id="input-945"
                     type="text"
                   />
                 </div>
@@ -6511,7 +6531,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           class="dragged-item v-card v-sheet theme--dark primary"
         >
           <div
-            class="v-card__title"
+            class="v-card__subtitle"
           >
             
       Moving 0


### PR DESCRIPTION
An organization can be dragged and dropped into an `IndividualCard` or an `IndividualEntry`. They recover the organization's name and pass it to their parent component, `IndividualsTable` or `Workspace`. The parent then uses the functions in `enrollMixin` to enroll the individual.