### PR TITLE
[ui] Fix removed cards reappearing in workspace

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -59,6 +59,8 @@ const MERGE = gql`
           organization {
             name
           }
+          start
+          end
         }
       }
     }

--- a/ui/src/components/Dashboard.vue
+++ b/ui/src/components/Dashboard.vue
@@ -6,7 +6,7 @@
       :individuals="savedIndividuals"
       :merge-items="mergeItems"
       :move-item="moveItem"
-      @clearSpace="savedIndividuals = []"
+      @clearSpace="clearWorkspace"
       @updateIndividuals="updateTable"
       @highlight="highlightIndividual($event, 'highlightInTable', true)"
       @stopHighlight="highlightIndividual($event, 'highlightInTable', false)"
@@ -240,6 +240,9 @@ export default {
         toDate
       );
       return response;
+    },
+    clearWorkspace() {
+      this.savedIndividuals = [];
     }
   }
 };

--- a/ui/src/components/WorkSpace.vue
+++ b/ui/src/components/WorkSpace.vue
@@ -232,6 +232,7 @@ export default {
       this.savedIndividuals = this.savedIndividuals.filter(
         savedIndividual => savedIndividual.uuid !== individual.uuid
       );
+      this.$emit("updateWorkspace", { remove: [individual.uuid] });
       this.$emit("stopHighlight", individual);
     },
     move(event) {


### PR DESCRIPTION
Fixes #414. When individual cards were removed from the workspace, the list of individuals in the workspace that was saved in the dashboard was not updated. This made them reappear when an identity was split from an individual and its card was moved to the workspace.