### PR TITLE
[ui] Use GrimoireLab color scheme

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -43,7 +43,8 @@ export default {
   }
 };
 </script>
-<style scoped>
+<style lang="scss">
+@import "styles/index.scss";
 .fade-enter-active,
 .fade-leave-active {
   transition-duration: 0.3s;

--- a/ui/src/components/IndividualEntry.vue
+++ b/ui/src/components/IndividualEntry.vue
@@ -1,5 +1,6 @@
 <template>
   <tr
+    :aria-selected="isSelected"
     :class="{
       expanded: isExpanded,
       selected: isSelected,
@@ -21,7 +22,7 @@
         </v-list-item-avatar>
 
         <v-list-item-content>
-          <v-list-item-title>
+          <v-list-item-title class="font-weight-medium">
             <span v-if="isLocked">{{ name }}</span>
             <v-edit-dialog v-else @save="$emit('edit', { name: form.name })">
               {{ name }}

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -2,7 +2,7 @@
   <v-container>
     <v-row class="actions">
       <h4 class="title">
-        <v-icon color="primary" left>
+        <v-icon color="black" left>
           mdi-account-multiple
         </v-icon>
         Individuals
@@ -37,8 +37,8 @@
         </v-tooltip>
         <v-btn
           depressed
-          color="blue lighten-5"
-          class="primary--text"
+          color="secondary"
+          class="black--text"
           @click.stop="openModal = true"
         >
           Add
@@ -414,16 +414,6 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
-::v-deep .theme--light.v-pagination .v-pagination__item,
-::v-deep .theme--light.v-pagination .v-pagination__navigation {
-  box-shadow: none;
-}
-::v-deep button.v-pagination__item {
-  transition: none;
-}
-::v-deep table {
-  border-collapse: collapse;
-}
 ::v-deep .v-data-table__wrapper {
   overflow-x: hidden;
 }

--- a/ui/src/components/OrganizationEntry.vue
+++ b/ui/src/components/OrganizationEntry.vue
@@ -6,7 +6,7 @@
     @dragenter.prevent="isDropZone($event, true)"
     @dragleave.prevent="isDropZone($event, false)"
   >
-    <td class="text--body-1">{{ name }}</td>
+    <td class="font-weight-medium">{{ name }}</td>
     <td class="text-right text--secondary">
       {{ enrollments }}
       <v-tooltip bottom transition="expand-y-transition" open-delay="200">

--- a/ui/src/components/OrganizationModal.vue
+++ b/ui/src/components/OrganizationModal.vue
@@ -48,7 +48,7 @@
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
-          <v-btn color="blue darken-1" text @click.prevent="closeModal">
+          <v-btn color="primary darken-1" text @click.prevent="closeModal">
             Cancel
           </v-btn>
           <v-btn

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -2,15 +2,15 @@
   <v-container>
     <v-row class="actions">
       <h4 class="title">
-        <v-icon color="primary" left>
+        <v-icon color="black" left>
           mdi-sitemap
         </v-icon>
         Organizations
       </h4>
       <v-btn
         depressed
-        color="blue lighten-5"
-        class="primary--text"
+        color="secondary"
+        class="black--text"
         @click.stop="openModal"
       >
         Add
@@ -65,7 +65,7 @@
     />
 
     <v-dialog v-model="dialog.open" max-width="500px">
-      <v-card>
+      <v-card class="pa-3">
         <v-card-title class="headline">{{ dialog.title }}</v-card-title>
         <v-card-text>{{ dialog.text }}</v-card-text>
         <v-card-actions>
@@ -73,7 +73,7 @@
           <v-btn text @click="dialog.open = false">
             Cancel
           </v-btn>
-          <v-btn color="blue darken-4" text @click.stop="dialog.action">
+          <v-btn color="primary" depressed @click.stop="dialog.action">
             Confirm
           </v-btn>
         </v-card-actions>
@@ -246,14 +246,7 @@ export default {
 };
 </script>
 <style scoped>
-::v-deep .theme--light.v-pagination .v-pagination__item,
-::v-deep .theme--light.v-pagination .v-pagination__navigation {
-  box-shadow: none;
-}
-::v-deep button.v-pagination__item {
-  transition: none;
-}
-
+@import "../styles/index.scss";
 .actions {
   justify-content: space-between;
   padding: 0 26px 24px 26px;

--- a/ui/src/components/ProfileModal.vue
+++ b/ui/src/components/ProfileModal.vue
@@ -149,7 +149,7 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="blue darken-1" text @click.prevent="closeModal">
+        <v-btn color="primary darken-1" text @click.prevent="closeModal">
           Cancel
         </v-btn>
         <v-btn

--- a/ui/src/components/WorkSpace.vue
+++ b/ui/src/components/WorkSpace.vue
@@ -1,16 +1,16 @@
 <template>
   <v-sheet
-    color="grey lighten-5"
+    color="#F5F5F6"
     class="pa-md-4"
-    :class="{ dragging: isDragging }"
+    :class="{ 'is-dragging': isDragging }"
     @drop.native="onDrop($event)"
     @dragover.prevent="onDrag($event)"
     @dragenter.prevent="onDrag($event)"
     @dragleave.prevent="isDragging = false"
   >
     <v-row class="ma-md-0 pt-md-4 pl-md-4 pr-md-4 justify-space-between">
-      <h3 class="text-h6">
-        <v-icon color="primary" left>
+      <h3 class="title">
+        <v-icon color="black" left>
           mdi-pin
         </v-icon>
         Workspace
@@ -257,13 +257,8 @@ export default {
 };
 </script>
 <style scoped>
-.text-h3 {
-  font-size: 1.25rem;
-  line-height: 2rem;
-  font-weight: 500;
-}
-.dragging .drag-zone {
-  outline: 2px dashed #bdbdbd;
+.is-dragging .drag-zone {
+  outline: 2px dashed #003756;
 }
 .col-2 {
   min-width: 300px;

--- a/ui/src/plugins/vuetify.js
+++ b/ui/src/plugins/vuetify.js
@@ -7,6 +7,14 @@ Vue.use(Vuetify);
 const opts = {
   icons: {
     iconfont: "mdi"
+  },
+  theme: {
+    themes: {
+      light: {
+        primary: "#003756",
+        secondary: "#f4bc00"
+      }
+    }
   }
 };
 

--- a/ui/src/styles/index.scss
+++ b/ui/src/styles/index.scss
@@ -1,23 +1,15 @@
-$active-color: #c8e6c9;
-$selected-color: #bbdefb;
-
-.theme--light.v-data-table
-  tbody
-  .dropzone:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper),
-.dropzone {
-  background: lighten($active-color, 10%);
-  border: 2px dashed $active-color;
-}
+$selected-color: #003756;
+$active-color: #f4bc00;
 
 .selected {
-  background-color: lighten($selected-color, 10%);
-  outline: thin solid $selected-color;
+  box-shadow: inset 4px 0 0 $selected-color;
+  background-color: lighten($selected-color, 80%);
 }
 
 .theme--light.v-data-table
   tbody
   tr.selected:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper) {
-  background-color: $selected-color;
+  background-color: desaturate(lighten($selected-color, 75%), 30%) !important;
   transition: background-color 30ms linear;
 }
 
@@ -30,11 +22,46 @@ $selected-color: #bbdefb;
   border-width: 2px 3px;
 }
 
-.highlighted,
+.highlighted:not(.v-card) {
+  box-shadow: inset 0px 0px 0px 2px $selected-color;
+}
+
+.highlighted:not(.v-card).selected {
+  box-shadow: inset 0px 0px 0px 2px $selected-color,
+  inset 0px 0px 0px 2px $selected-color,
+  inset 0px 0px 0px 2px $selected-color,
+  inset 4px 0 0 $selected-color;
+}
+
 .v-sheet.v-card:not(.v-sheet--outlined).highlighted {
   box-shadow: 0px 5px 5px -3px rgba(187, 222, 251, 0.4),
   0px 8px 10px 1px rgba(187, 222, 251, 0.34),
   0px 3px 14px 2px rgba(187, 222, 251, 0.32),
   inset 0px 0px 0px 2px $selected-color;
   transition-duration: 0s;
+}
+
+.theme--light.v-data-table
+  tbody
+  .dropzone:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper),
+.dropzone {
+  background: desaturate(lighten($active-color, 40%), 20%);
+}
+
+.theme--light.v-pagination .v-pagination__item,
+.theme--light.v-pagination .v-pagination__navigation {
+  box-shadow: none;
+}
+
+button.v-pagination__item {
+  transition: none;
+}
+
+.theme--light.v-pagination .v-pagination__item--active {
+  font-weight: 500;
+}
+
+.theme--light.v-icon,
+.v-btn--round .v-btn__content .v-icon {
+  color: rgba(0, 0, 0, 0.62);
 }

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -15,7 +15,7 @@
       @updateWorkspace="updateWorkspace"
     />
     <v-row>
-      <v-col class="individuals elevation-2">
+      <v-col class="individuals elevation-1">
         <individuals-table
           :fetch-page="getIndividualsPage"
           :delete-item="deleteItem"
@@ -40,7 +40,7 @@
           ref="table"
         />
       </v-col>
-      <v-col class="organizations elevation-2">
+      <v-col class="organizations elevation-1">
         <organizations-table
           :fetch-page="getOrganizationsPage"
           :enroll="enroll"


### PR DESCRIPTION
Sets the blue and yellow GrimoireLab colors as primary and secondary colors in the Vuetify theme and changes some styles.

Note: the JWT authentication plugin is having issues at the moment: https://github.com/flavors/django-graphql-jwt/issues/241
If you can't log in, you can remove `meta: { requiresAuth: true }` from `/ui/src/router/index.js` to access the dashboard.