### PR TITLE
Define visual limits in individuals table 

### DIFF
--- a/ui/.storybook/preview.js
+++ b/ui/.storybook/preview.js
@@ -15,15 +15,26 @@ const VComponents = Object.keys(_Vuetify).reduce((acc, key) => {
 }, {});
 
 Vue.use(Vuetify, {
-  icons: {
-    iconfont: "mdi"
-  },
   components: {
     ...VComponents
   }
 });
 
+const VuetifyConfig = new Vuetify({
+  icons: {
+    iconfont: "mdi"
+  },
+  theme: {
+    themes: {
+      light: {
+        primary: "#003756",
+        secondary: "#f4bc00"
+      }
+    }
+  }
+});
+
 addDecorator(() => ({
-  vuetify: new Vuetify(),
+  vuetify: VuetifyConfig,
   template: "<v-app><story/></v-app>"
 }));

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -1,8 +1,8 @@
 <template>
   <td :class="{ compact: compact }" colspan="4">
     <v-subheader v-if="!compact">Profile</v-subheader>
-    <v-row v-if="!compact" class="ml-12">
-      <p class="ml-2">
+    <v-row v-if="!compact" class="indented mb-2 mt">
+      <div class="ml-4">
         <span class="grey--text text--darken-2">Gender: </span>
         <span v-if="isLocked">{{ gender || " -" }}</span>
         <v-edit-dialog v-else @save="$emit('edit', { gender: form.gender })">
@@ -19,8 +19,8 @@
             ></v-text-field>
           </template>
         </v-edit-dialog>
-      </p>
-      <p class="ml-6">
+      </div>
+      <div class="ml-6">
         <span class="grey--text text--darken-2">Country: </span>
         <span v-if="isLocked">{{ country ? country.name : "-" }}</span>
         <v-edit-dialog
@@ -45,13 +45,17 @@
             />
           </template>
         </v-edit-dialog>
-      </p>
+      </div>
     </v-row>
     <v-subheader>Identities ({{ identitiesCount }})</v-subheader>
     <v-list
       v-for="(source, sourceIndex) in identities"
       :key="source.name"
+      :class="{
+        'row-border': sourceIndex !== identities.length - 1 && !compact
+      }"
       class="indented"
+      dense
     >
       <v-list-item
         v-for="(identity, index) in sortSources(source.identities, 'source')"
@@ -112,24 +116,18 @@
           </v-tooltip>
         </div>
       </v-list-item>
-      <v-divider
-        inset
-        v-if="sourceIndex !== identities.length - 1 && !compact"
-      ></v-divider>
     </v-list>
 
-    <v-divider v-if="!compact" inset class="divider"></v-divider>
-
-    <v-list>
-      <v-subheader>Organizations ({{ enrollments.length }})</v-subheader>
-
+    <v-subheader>Organizations ({{ enrollments.length }})</v-subheader>
+    <v-list class="indented" dense>
       <v-list-item
         v-for="enrollment in enrollments"
         :key="enrollment.organization.id"
+        class="row-border"
       >
         <v-list-item-content>
           <v-row no-gutters class="flex align-center">
-            <v-col class="ma-2 text-center">
+            <v-col>
               <span>{{ enrollment.organization.name }}</span>
             </v-col>
             <v-col class="col-3 ma-2 text-center">
@@ -138,7 +136,7 @@
             <v-col class="col-3 ma-2 text-center">
               <span>{{ formatDate(enrollment.end) }}</span>
             </v-col>
-            <v-col v-if="!compact">
+            <v-col class="text-end col-2" v-if="!compact">
               <v-tooltip
                 bottom
                 transition="expand-y-transition"
@@ -169,8 +167,8 @@
       </v-list-item>
     </v-list>
 
-    <v-card class="dragged-item" color="primary" dark>
-      <v-card-title> Moving 1</v-card-title>
+    <v-card class="dragged-identity" color="primary" dark>
+      <v-card-subtitle> Moving 1 identity</v-card-subtitle>
     </v-card>
   </td>
 </template>
@@ -245,7 +243,7 @@ export default {
       });
     },
     startDrag(identity, event) {
-      const dragImage = document.querySelector(".dragged-item");
+      const dragImage = document.querySelector(".dragged-identity");
       event.dataTransfer.setDragImage(dragImage, 0, 0);
       event.dataTransfer.effectAllowed = "move";
       event.dataTransfer.setData("type", "move");
@@ -274,19 +272,9 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import "../styles/index.scss";
-td {
-  padding-left: 75px;
-  border-bottom: thin solid rgba(0, 0, 0, 0.12);
-}
-
 .indented {
-  margin: 0 40px;
-}
-
-.v-application--is-ltr .v-divider--inset:not(.v-divider--vertical).divider {
-  width: calc(100% - 30px);
-  max-width: calc(100% - 30px);
-  margin-left: 30px;
+  margin-left: 40px;
+  background-color: transparent;
 }
 
 .draggable {
@@ -297,7 +285,7 @@ td {
   }
 }
 
-.dragged-item {
+.dragged-identity {
   max-width: 300px;
   position: absolute;
   top: -300px;
@@ -323,6 +311,11 @@ td {
   ::v-deep .indented {
     padding: 0;
     margin: 0;
+    text-align: center;
+  }
+
+  .row-border:not(:last-child) {
+    border: 0;
   }
 }
 

--- a/ui/src/components/ExpandedOrganization.vue
+++ b/ui/src/components/ExpandedOrganization.vue
@@ -1,5 +1,5 @@
 <template>
-  <td>
+  <td colspan="3">
     <v-list dense>
       <v-subheader>Domains ({{ domains.length }})</v-subheader>
       <v-list-item v-for="(item, index) in domains" :key="index">

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -137,7 +137,9 @@
 
     <v-card class="dragged-item" color="primary" dark>
       <v-card-subtitle>
-        Moving {{ this.selectedIndividuals.length }}
+        Moving
+        {{ this.selectedIndividuals.length }}
+        {{ this.selectedIndividuals.length > 1 ? "individuals" : "individual" }}
       </v-card-subtitle>
     </v-card>
 

--- a/ui/src/styles/index.scss
+++ b/ui/src/styles/index.scss
@@ -1,15 +1,64 @@
 $selected-color: #003756;
 $active-color: #f4bc00;
+$border-color: rgba(0, 0, 0, 0.12);
 
-.selected {
+// Expanded table item
+.expanded:not(.selected) {
+  box-shadow: inset 1px 0 0 $border-color,
+  inset -2px 0px 1px -1px $border-color;
+}
+
+.expanded.selected {
+  box-shadow: inset 4px 0 0 $selected-color,
+  inset -1px 0px 1px -1px rgba(0, 0, 0, 0.45);
+}
+
+.row-border:not(:last-child) {
+  border-bottom: thin solid $border-color;
+}
+
+.theme--light.v-data-table > .v-data-table__wrapper > table > tbody >
+  tr.expanded > td:not(.v-data-table__mobile-row) {
+  border-bottom: 0;
+}
+
+.theme--light.v-data-table > .v-data-table__wrapper > table > tbody > tr:hover + td {
+  background-color: #eeeeee;
+}
+
+.theme--light.v-data-table .v-list--dense {
+  background-color: transparent;
+}
+
+.v-data-table__wrapper tr + td {
+  font-size: 0.875rem;
+  padding: 0 75px 4px 75px;
+  border: thin solid $border-color;
+  border-top: 0;
+}
+
+.v-data-table__wrapper tr:not(.expanded) + td {
+  padding-left: 2rem;
+}
+
+.theme--light.v-data-table tbody tr:first-child.expanded td {
+  border-top: thin solid $border-color;
+}
+
+// Selected table item
+.selected,
+.expanded.selected + td {
   box-shadow: inset 4px 0 0 $selected-color;
   background-color: lighten($selected-color, 80%);
+  border-left: 0;
 }
 
 .theme--light.v-data-table
   tbody
-  tr.selected:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper) {
-  background-color: desaturate(lighten($selected-color, 75%), 30%) !important;
+  tr.selected:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper),
+.theme--light.v-data-table > .v-data-table__wrapper > table > tbody > tr.selected:hover + td,
+.selected + td .v-list-item.theme--light.draggable:hover {
+  background-color: desaturate(lighten($selected-color, 75%), 30%);
   transition: background-color 30ms linear;
 }
 
@@ -17,11 +66,11 @@ $active-color: #f4bc00;
   tbody
   .dragging:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper),
 .dragging {
-  background-color: lighten($selected-color, 10%);
-  border: solid $selected-color;
-  border-width: 2px 3px;
+  background-color: desaturate(lighten($selected-color, 75%), 30%);
+  box-shadow: inset 4px 0 0 $selected-color;
 }
 
+// Highlighted item
 .highlighted:not(.v-card) {
   box-shadow: inset 0px 0px 0px 2px $selected-color;
 }
@@ -41,6 +90,8 @@ $active-color: #f4bc00;
   transition-duration: 0s;
 }
 
+
+// Drop zones
 .theme--light.v-data-table
   tbody
   .dropzone:hover:not(.v-data-table__expanded__content):not(.v-data-table__empty-wrapper),
@@ -48,6 +99,8 @@ $active-color: #f4bc00;
   background: desaturate(lighten($active-color, 40%), 20%);
 }
 
+
+// Table pagination
 .theme--light.v-pagination .v-pagination__item,
 .theme--light.v-pagination .v-pagination__navigation {
   box-shadow: none;
@@ -64,4 +117,9 @@ button.v-pagination__item {
 .theme--light.v-icon,
 .v-btn--round .v-btn__content .v-icon {
   color: rgba(0, 0, 0, 0.62);
+}
+
+.v-subheader {
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.87);
 }

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -12,7 +12,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -75,8 +75,8 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
        
       <v-btn-stub
         activeclass=""
-        class="primary--text"
-        color="blue lighten-5"
+        class="black--text"
+        color="secondary"
         depressed="true"
         tag="button"
         type="button"
@@ -268,7 +268,9 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
   >
     <v-card-subtitle-stub>
       
-      Moving 0
+      Moving
+      0
+      individual
     
     </v-card-subtitle-stub>
   </v-card-stub>
@@ -298,7 +300,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -361,8 +363,8 @@ exports[`IndividualsTable Mock query for merge 1`] = `
        
       <v-btn-stub
         activeclass=""
-        class="primary--text"
-        color="blue lighten-5"
+        class="black--text"
+        color="secondary"
         depressed="true"
         tag="button"
         type="button"
@@ -554,7 +556,9 @@ exports[`IndividualsTable Mock query for merge 1`] = `
   >
     <v-card-subtitle-stub>
       
-      Moving 0
+      Moving
+      0
+      individual
     
     </v-card-subtitle-stub>
   </v-card-stub>
@@ -584,7 +588,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -647,8 +651,8 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
        
       <v-btn-stub
         activeclass=""
-        class="primary--text"
-        color="blue lighten-5"
+        class="black--text"
+        color="secondary"
         depressed="true"
         tag="button"
         type="button"
@@ -840,7 +844,9 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
   >
     <v-card-subtitle-stub>
       
-      Moving 0
+      Moving
+      0
+      individual
     
     </v-card-subtitle-stub>
   </v-card-stub>
@@ -870,7 +876,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -933,8 +939,8 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
        
       <v-btn-stub
         activeclass=""
-        class="primary--text"
-        color="blue lighten-5"
+        class="black--text"
+        color="secondary"
         depressed="true"
         tag="button"
         type="button"
@@ -1126,7 +1132,9 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
   >
     <v-card-subtitle-stub>
       
-      Moving 0
+      Moving
+      0
+      individual
     
     </v-card-subtitle-stub>
   </v-card-stub>
@@ -1156,7 +1164,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -1219,8 +1227,8 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
        
       <v-btn-stub
         activeclass=""
-        class="primary--text"
-        color="blue lighten-5"
+        class="black--text"
+        color="secondary"
         depressed="true"
         tag="button"
         type="button"
@@ -1412,7 +1420,9 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
   >
     <v-card-subtitle-stub>
       
-      Moving 0
+      Moving
+      0
+      individual
     
     </v-card-subtitle-stub>
   </v-card-stub>
@@ -1519,7 +1529,7 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -1533,8 +1543,8 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
      
     <v-btn-stub
       activeclass=""
-      class="primary--text"
-      color="blue lighten-5"
+      class="black--text"
+      color="secondary"
       depressed="true"
       tag="button"
       type="button"
@@ -1676,6 +1686,7 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
     width="auto"
   >
     <v-card-stub
+      class="pa-3"
       loaderheight="4"
       tag="div"
     >
@@ -1705,9 +1716,9 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
          
         <v-btn-stub
           activeclass=""
-          color="blue darken-4"
+          color="primary"
+          depressed="true"
           tag="button"
-          text="true"
           type="button"
         >
           
@@ -1763,7 +1774,7 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -1777,8 +1788,8 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
      
     <v-btn-stub
       activeclass=""
-      class="primary--text"
-      color="blue lighten-5"
+      class="black--text"
+      color="secondary"
       depressed="true"
       tag="button"
       type="button"
@@ -1920,6 +1931,7 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
     width="auto"
   >
     <v-card-stub
+      class="pa-3"
       loaderheight="4"
       tag="div"
     >
@@ -1949,9 +1961,9 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
          
         <v-btn-stub
           activeclass=""
-          color="blue darken-4"
+          color="primary"
+          depressed="true"
           tag="button"
-          text="true"
           type="button"
         >
           
@@ -2007,7 +2019,7 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -2021,8 +2033,8 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
      
     <v-btn-stub
       activeclass=""
-      class="primary--text"
-      color="blue lighten-5"
+      class="black--text"
+      color="secondary"
       depressed="true"
       tag="button"
       type="button"
@@ -2164,6 +2176,7 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
     width="auto"
   >
     <v-card-stub
+      class="pa-3"
       loaderheight="4"
       tag="div"
     >
@@ -2193,9 +2206,9 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
          
         <v-btn-stub
           activeclass=""
-          color="blue darken-4"
+          color="primary"
+          depressed="true"
           tag="button"
-          text="true"
           type="button"
         >
           
@@ -2251,7 +2264,7 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -2265,8 +2278,8 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
      
     <v-btn-stub
       activeclass=""
-      class="primary--text"
-      color="blue lighten-5"
+      class="black--text"
+      color="secondary"
       depressed="true"
       tag="button"
       type="button"
@@ -2406,6 +2419,7 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
     width="auto"
   >
     <v-card-stub
+      class="pa-3"
       loaderheight="4"
       tag="div"
     >
@@ -2435,9 +2449,9 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
          
         <v-btn-stub
           activeclass=""
-          color="blue darken-4"
+          color="primary"
+          depressed="true"
           tag="button"
-          text="true"
           type="button"
         >
           
@@ -2493,7 +2507,7 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -2507,8 +2521,8 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
      
     <v-btn-stub
       activeclass=""
-      class="primary--text"
-      color="blue lighten-5"
+      class="black--text"
+      color="secondary"
       depressed="true"
       tag="button"
       type="button"
@@ -2648,6 +2662,7 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
     width="auto"
   >
     <v-card-stub
+      class="pa-3"
       loaderheight="4"
       tag="div"
     >
@@ -2677,9 +2692,9 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
          
         <v-btn-stub
           activeclass=""
-          color="blue darken-4"
+          color="primary"
+          depressed="true"
           tag="button"
-          text="true"
           type="button"
         >
           
@@ -3140,7 +3155,7 @@ exports[`ProfileModal Mock mutation for addIdentity 1`] = `
        
       <v-btn-stub
         activeclass=""
-        color="blue darken-1"
+        color="primary darken-1"
         tag="button"
         text="true"
         type="button"
@@ -3584,7 +3599,7 @@ exports[`ProfileModal Mock mutation for updateProfile 1`] = `
        
       <v-btn-stub
         activeclass=""
-        color="blue darken-1"
+        color="primary darken-1"
         tag="button"
         text="true"
         type="button"

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -19,7 +19,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -82,8 +82,8 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
        
       <v-btn-stub
         activeclass=""
-        class="primary--text"
-        color="blue lighten-5"
+        class="black--text"
+        color="secondary"
         depressed="true"
         tag="button"
         type="button"
@@ -277,7 +277,9 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
   >
     <v-card-subtitle-stub>
       
-      Moving 0
+      Moving
+      0
+      individual
     
     </v-card-subtitle-stub>
   </v-card-stub>
@@ -307,7 +309,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -370,8 +372,8 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
        
       <v-btn-stub
         activeclass=""
-        class="primary--text"
-        color="blue lighten-5"
+        class="black--text"
+        color="secondary"
         depressed="true"
         tag="button"
         type="button"
@@ -563,7 +565,9 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
   >
     <v-card-subtitle-stub>
       
-      Moving 0
+      Moving
+      0
+      individual
     
     </v-card-subtitle-stub>
   </v-card-stub>
@@ -593,7 +597,7 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
       class="title"
     >
       <v-icon-stub
-        color="primary"
+        color="black"
         left=""
       >
         
@@ -607,8 +611,8 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
      
     <v-btn-stub
       activeclass=""
-      class="primary--text"
-      color="blue lighten-5"
+      class="black--text"
+      color="secondary"
       depressed="true"
       tag="button"
       type="button"
@@ -748,6 +752,7 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
     width="auto"
   >
     <v-card-stub
+      class="pa-3"
       loaderheight="4"
       tag="div"
     >
@@ -777,9 +782,9 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
          
         <v-btn-stub
           activeclass=""
-          color="blue darken-4"
+          color="primary"
+          depressed="true"
           tag="button"
-          text="true"
           type="button"
         >
           

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -24,7 +24,7 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
       </div>
        
       <div
-        class="v-list indented v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       >
         <div
@@ -171,11 +171,9 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
            
           <!---->
         </div>
-         
-        <!---->
       </div>
       <div
-        class="v-list indented v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       >
         <div
@@ -250,11 +248,9 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
            
           <!---->
         </div>
-         
-        <!---->
       </div>
       <div
-        class="v-list indented v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       >
         <div
@@ -329,24 +325,20 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
            
           <!---->
         </div>
-         
-        <!---->
       </div>
        
-      <!---->
+      <div
+        class="v-subheader theme--light"
+      >
+        Organizations (2)
+      </div>
        
       <div
-        class="v-list v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       >
         <div
-          class="v-subheader theme--light"
-        >
-          Organizations (2)
-        </div>
-         
-        <div
-          class="v-list-item theme--light"
+          class="row-border v-list-item theme--light"
           role="listitem"
           tabindex="-1"
         >
@@ -357,7 +349,7 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
               class="row flex align-center no-gutters"
             >
               <div
-                class="ma-2 text-center col"
+                class="col"
               >
                 <span>
                   Slytherin
@@ -385,7 +377,7 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
           </div>
         </div>
         <div
-          class="v-list-item theme--light"
+          class="row-border v-list-item theme--light"
           role="listitem"
           tabindex="-1"
         >
@@ -396,7 +388,7 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
               class="row flex align-center no-gutters"
             >
               <div
-                class="ma-2 text-center col"
+                class="col"
               >
                 <span>
                   Hogwarts School of Witchcraft and Wizardry
@@ -426,12 +418,12 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
       </div>
        
       <div
-        class="dragged-item v-card v-sheet theme--dark primary"
+        class="dragged-identity v-card v-sheet theme--dark primary"
       >
         <div
-          class="v-card__title"
+          class="v-card__subtitle"
         >
-           Moving 1
+           Moving 1 identity
         </div>
       </div>
     </td>
@@ -459,10 +451,10 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
       </div>
        
       <div
-        class="row ml-12"
+        class="row indented mb-2 mt"
       >
-        <p
-          class="ml-2"
+        <div
+          class="ml-4"
         >
           <span
             class="grey--text text--darken-2"
@@ -491,9 +483,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
             </div>
             <!---->
           </div>
-        </p>
+        </div>
          
-        <p
+        <div
           class="ml-6"
         >
           <span
@@ -526,7 +518,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
             </div>
             <!---->
           </div>
-        </p>
+        </div>
       </div>
        
       <div
@@ -536,7 +528,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
       </div>
        
       <div
-        class="v-list indented v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense row-border"
         role="list"
       >
         <div
@@ -756,15 +748,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
             </span>
           </div>
         </div>
-         
-        <hr
-          aria-orientation="horizontal"
-          class="v-divider v-divider--inset theme--light"
-          role="separator"
-        />
       </div>
       <div
-        class="v-list indented v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense row-border"
         role="list"
       >
         <div
@@ -880,15 +866,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
             </span>
           </div>
         </div>
-         
-        <hr
-          aria-orientation="horizontal"
-          class="v-divider v-divider--inset theme--light"
-          role="separator"
-        />
       </div>
       <div
-        class="v-list indented v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       >
         <div
@@ -1004,28 +984,20 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
             </span>
           </div>
         </div>
-         
-        <!---->
       </div>
        
-      <hr
-        aria-orientation="horizontal"
-        class="divider v-divider v-divider--inset theme--light"
-        role="separator"
-      />
+      <div
+        class="v-subheader theme--light"
+      >
+        Organizations (2)
+      </div>
        
       <div
-        class="v-list v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       >
         <div
-          class="v-subheader theme--light"
-        >
-          Organizations (2)
-        </div>
-         
-        <div
-          class="v-list-item theme--light"
+          class="row-border v-list-item theme--light"
           role="listitem"
           tabindex="-1"
         >
@@ -1036,7 +1008,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               class="row flex align-center no-gutters"
             >
               <div
-                class="ma-2 text-center col"
+                class="col"
               >
                 <span>
                   Slytherin
@@ -1060,7 +1032,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
                
               <div
-                class="col"
+                class="text-end col-2 col"
               >
                 <span
                   class="v-tooltip v-tooltip--bottom"
@@ -1085,7 +1057,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           </div>
         </div>
         <div
-          class="v-list-item theme--light"
+          class="row-border v-list-item theme--light"
           role="listitem"
           tabindex="-1"
         >
@@ -1096,7 +1068,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               class="row flex align-center no-gutters"
             >
               <div
-                class="ma-2 text-center col"
+                class="col"
               >
                 <span>
                   Hogwarts School of Witchcraft and Wizardry
@@ -1120,7 +1092,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
                
               <div
-                class="col"
+                class="text-end col-2 col"
               >
                 <span
                   class="v-tooltip v-tooltip--bottom"
@@ -1147,12 +1119,12 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
       </div>
        
       <div
-        class="dragged-item v-card v-sheet theme--dark primary"
+        class="dragged-identity v-card v-sheet theme--dark primary"
       >
         <div
-          class="v-card__title"
+          class="v-card__subtitle"
         >
-           Moving 1
+           Moving 1 identity
         </div>
       </div>
     </td>
@@ -1180,10 +1152,10 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
       </div>
        
       <div
-        class="row ml-12"
+        class="row indented mb-2 mt"
       >
-        <p
-          class="ml-2"
+        <div
+          class="ml-4"
         >
           <span
             class="grey--text text--darken-2"
@@ -1212,9 +1184,9 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
             </div>
             <!---->
           </div>
-        </p>
+        </div>
          
-        <p
+        <div
           class="ml-6"
         >
           <span
@@ -1247,7 +1219,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
             </div>
             <!---->
           </div>
-        </p>
+        </div>
       </div>
        
       <div
@@ -1257,7 +1229,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
       </div>
        
       <div
-        class="v-list indented v-sheet theme--light"
+        class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       >
         <div
@@ -1374,35 +1346,26 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
             </span>
           </div>
         </div>
-         
-        <!---->
       </div>
        
-      <hr
-        aria-orientation="horizontal"
-        class="divider v-divider v-divider--inset theme--light"
-        role="separator"
+      <div
+        class="v-subheader theme--light"
+      >
+        Organizations (0)
+      </div>
+       
+      <div
+        class="v-list indented v-sheet theme--light v-list--dense"
+        role="list"
       />
        
       <div
-        class="v-list v-sheet theme--light"
-        role="list"
+        class="dragged-identity v-card v-sheet theme--dark primary"
       >
         <div
-          class="v-subheader theme--light"
+          class="v-card__subtitle"
         >
-          Organizations (0)
-        </div>
-         
-      </div>
-       
-      <div
-        class="dragged-item v-card v-sheet theme--dark primary"
-      >
-        <div
-          class="v-card__title"
-        >
-           Moving 1
+           Moving 1 identity
         </div>
       </div>
     </td>
@@ -1419,7 +1382,9 @@ exports[`Storyshots ExpandedOrganization Default 1`] = `
   <div
     class="v-application--wrap"
   >
-    <td>
+    <td
+      colspan="3"
+    >
       <div
         class="v-list v-sheet theme--light v-list--dense"
         role="list"
@@ -1475,7 +1440,9 @@ exports[`Storyshots ExpandedOrganization Empty 1`] = `
   <div
     class="v-application--wrap"
   >
-    <td>
+    <td
+      colspan="3"
+    >
       <div
         class="v-list v-sheet theme--light v-list--dense"
         role="list"
@@ -2413,7 +2380,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <div
                         class="v-menu v-small-dialog theme--light"
@@ -2629,7 +2596,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <span>
                         Tom Marvolo Riddle
@@ -2811,7 +2778,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <div
                         class="v-menu v-small-dialog theme--light"
@@ -3027,7 +2994,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <div
                         class="v-menu v-small-dialog theme--light"
@@ -3243,7 +3210,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <span>
                         Tom Marvolo Riddle
@@ -3425,7 +3392,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <div
                         class="v-menu v-small-dialog theme--light"
@@ -3641,7 +3608,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <div
                         class="v-menu v-small-dialog theme--light"
@@ -3857,7 +3824,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <div
                         class="v-menu v-small-dialog theme--light"
@@ -4073,7 +4040,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                     class="v-list-item__content"
                   >
                     <div
-                      class="v-list-item__title"
+                      class="v-list-item__title font-weight-medium"
                     >
                       <div
                         class="v-menu v-small-dialog theme--light"
@@ -5147,7 +5114,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
         >
           <i
             aria-hidden="true"
-            class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light primary--text"
+            class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light black--text"
           />
           
       Individuals
@@ -5168,13 +5135,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-655"
+                  for="input-651"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-655"
+                  id="input-651"
                   type="text"
                 />
               </div>
@@ -5289,7 +5256,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           </span>
            
           <button
-            class="primary--text v-btn v-btn--depressed theme--light v-size--default blue lighten-5"
+            class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
             type="button"
           >
             <span
@@ -5398,7 +5365,9 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           class="v-card__subtitle"
         >
           
-      Moving 0
+      Moving
+      0
+      individual
     
         </div>
       </div>
@@ -5459,7 +5428,7 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
               class=""
             >
               <td
-                class="text--body-1"
+                class="font-weight-medium"
               >
                 Hogwarts School of Witchcraft and Wizardry
               </td>
@@ -5632,7 +5601,7 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
         >
           <i
             aria-hidden="true"
-            class="v-icon notranslate v-icon--left mdi mdi-sitemap theme--light primary--text"
+            class="v-icon notranslate v-icon--left mdi mdi-sitemap theme--light black--text"
           />
           
       Organizations
@@ -5640,7 +5609,7 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
         </h4>
          
         <button
-          class="primary--text v-btn v-btn--depressed theme--light v-size--default blue lighten-5"
+          class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
           type="button"
         >
           <span
@@ -6030,13 +5999,13 @@ exports[`Storyshots Search Default 1`] = `
             >
               <label
                 class="v-label theme--light"
-                for="input-917"
+                for="input-913"
                 style="left: 0px; position: absolute;"
               >
                 Search
               </label>
               <input
-                id="input-917"
+                id="input-913"
                 type="text"
               />
             </div>
@@ -6123,17 +6092,18 @@ exports[`Storyshots WorkSpace Default 1`] = `
     class="v-application--wrap"
   >
     <div
-      class="pa-md-4 v-sheet theme--light grey lighten-5"
+      class="pa-md-4 v-sheet theme--light"
+      style="background-color: rgb(245, 245, 246); border-color: #f5f5f6;"
     >
       <div
         class="row ma-md-0 pt-md-4 pl-md-4 pr-md-4 justify-space-between"
       >
         <h3
-          class="text-h6"
+          class="title"
         >
           <i
             aria-hidden="true"
-            class="v-icon notranslate v-icon--left mdi mdi-pin theme--light primary--text"
+            class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
           />
           
       Workspace
@@ -6470,17 +6440,18 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
   >
     <div>
       <div
-        class="pa-md-4 v-sheet theme--light grey lighten-5"
+        class="pa-md-4 v-sheet theme--light"
+        style="background-color: rgb(245, 245, 246); border-color: #f5f5f6;"
       >
         <div
           class="row ma-md-0 pt-md-4 pl-md-4 pr-md-4 justify-space-between"
         >
           <h3
-            class="text-h6"
+            class="title"
           >
             <i
               aria-hidden="true"
-              class="v-icon notranslate v-icon--left mdi mdi-pin theme--light primary--text"
+              class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
             />
             
       Workspace
@@ -6580,7 +6551,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           >
             <i
               aria-hidden="true"
-              class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light primary--text"
+              class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light black--text"
             />
             
       Individuals
@@ -6601,13 +6572,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1006"
+                    for="input-1002"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1006"
+                    id="input-1002"
                     type="text"
                   />
                 </div>
@@ -6722,7 +6693,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </span>
              
             <button
-              class="primary--text v-btn v-btn--depressed theme--light v-size--default blue lighten-5"
+              class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
               type="button"
             >
               <span
@@ -6831,7 +6802,9 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             class="v-card__subtitle"
           >
             
-      Moving 0
+      Moving
+      0
+      individual
     
           </div>
         </div>
@@ -6874,17 +6847,18 @@ exports[`Storyshots WorkSpace Empty 1`] = `
     class="v-application--wrap"
   >
     <div
-      class="pa-md-4 v-sheet theme--light grey lighten-5"
+      class="pa-md-4 v-sheet theme--light"
+      style="background-color: rgb(245, 245, 246); border-color: #f5f5f6;"
     >
       <div
         class="row ma-md-0 pt-md-4 pl-md-4 pr-md-4 justify-space-between"
       >
         <h3
-          class="text-h6"
+          class="title"
         >
           <i
             aria-hidden="true"
-            class="v-icon notranslate v-icon--left mdi mdi-pin theme--light primary--text"
+            class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
           />
           
       Workspace


### PR DESCRIPTION
This PR attempts to improve the visual limits of expanded individuals to make the information more readable as requested in #423. It includes the color theme from #424.

![limits](https://user-images.githubusercontent.com/26812577/103898967-faced280-50f5-11eb-8cf2-37d1bb36c95c.gif)
