### PR TITLE
[ui] Get individuals uuid from 'mk' field

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -43,6 +43,7 @@ const MERGE = gql`
     merge(fromUuids: $fromUuids, toUuid: $toUuid) {
       uuid
       individual {
+        mk
         isLocked
         identities {
           name
@@ -72,6 +73,7 @@ const UNMERGE = gql`
     unmergeIdentities(uuids: $uuids) {
       uuids
       individuals {
+        mk
         profile {
           name
           id
@@ -101,6 +103,7 @@ const MOVE_IDENTITY = gql`
     moveIdentity(fromUuid: $fromUuid, toUuid: $toUuid) {
       uuid
       individual {
+        mk
         isLocked
         identities {
           name

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -82,6 +82,7 @@ const GET_PAGINATED_INDIVIDUALS = gql`
   ) {
     individuals(page: $page, pageSize: $pageSize, filters: $filters) {
       entities {
+        mk
         isLocked
         profile {
           name

--- a/ui/src/components/IndividualsTable.stories.js
+++ b/ui/src/components/IndividualsTable.stories.js
@@ -54,6 +54,7 @@ export const Default = () => ({
           individuals: {
             entities: [
               {
+                mk: "1f1a9e56dedb45f5969413eeb4442d982e33f0f6",
                 isLocked: false,
                 profile: {
                   name: "Tom Marvolo Riddle",
@@ -111,6 +112,7 @@ export const Default = () => ({
                 ]
               },
               {
+                mk: "164e41c60c28698ac30b0d17176d3e720e036918",
                 isLocked: false,
                 profile: {
                   name: "Harry Potter",
@@ -161,6 +163,7 @@ export const Default = () => ({
                 ]
               },
               {
+                mk: "375458370ac0323bfb2e5a153e086551ef628d53",
                 isLocked: true,
                 profile: {
                   name: "Voldemort",
@@ -189,6 +192,7 @@ export const Default = () => ({
                 ]
               },
               {
+                mk: "66bc656d28a1522b650d537c9142be2e5c9e3b55",
                 isLocked: false,
                 profile: {
                   name: "Ron Weasley",
@@ -232,6 +236,7 @@ export const Default = () => ({
                 ]
               },
               {
+                mk: "e4135c5c747dc69262cd4120a5c5ee51d07a9904",
                 isLocked: false,
                 profile: {
                   name: "Hermione Granger",
@@ -289,6 +294,7 @@ export const Default = () => ({
           individuals: {
             entities: [
               {
+                mk: "de85900c79d5dbe782f65ce0e04f269c4cd2f7fb",
                 isLocked: false,
                 profile: {
                   name: "Albus Dumbledore",
@@ -347,6 +353,7 @@ export const Default = () => ({
                 ]
               },
               {
+                mk: "7a727227226daae693c61ddf7040e51c97ac638d",
                 isLocked: false,
                 profile: {
                   name: "Hagrid",

--- a/ui/src/components/WorkSpace.stories.js
+++ b/ui/src/components/WorkSpace.stories.js
@@ -269,6 +269,7 @@ export const DragAndDrop = () => ({
           individuals: {
             entities: [
               {
+                mk: "1f1a9e56dedb45f5969413eeb4442d982e33f0f6",
                 isLocked: false,
                 profile: {
                   name: "Tom Marvolo Riddle",
@@ -326,6 +327,7 @@ export const DragAndDrop = () => ({
                 ]
               },
               {
+                mk: "164e41c60c28698ac30b0d17176d3e720e036918",
                 isLocked: false,
                 profile: {
                   name: "Harry Potter",
@@ -376,6 +378,7 @@ export const DragAndDrop = () => ({
                 ]
               },
               {
+                mk: "375458370ac0323bfb2e5a153e086551ef628d53",
                 isLocked: true,
                 profile: {
                   name: "Voldemort",
@@ -404,6 +407,7 @@ export const DragAndDrop = () => ({
                 ]
               },
               {
+                mk: "66bc656d28a1522b650d537c9142be2e5c9e3b55",
                 isLocked: false,
                 profile: {
                   name: "Ron Weasley",
@@ -447,6 +451,7 @@ export const DragAndDrop = () => ({
                 ]
               },
               {
+                mk: "e4135c5c747dc69262cd4120a5c5ee51d07a9904",
                 isLocked: false,
                 profile: {
                   name: "Hermione Granger",

--- a/ui/src/utils/actions.js
+++ b/ui/src/utils/actions.js
@@ -103,7 +103,7 @@ const formatIndividuals = individuals => {
       enrollments: item.enrollments,
       isLocked: item.isLocked,
       isBot: item.profile.isBot,
-      uuid: item.identities[0].uuid,
+      uuid: item.mk,
       isSelected: false
     };
   });


### PR DESCRIPTION
Gets the individuals' main uuid, used when identities are moved or merged, from the `mk` field instead of from its first identity.