### PR TITLE
Search organizations by term

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -248,6 +248,7 @@ class CountryFilterType(graphene.InputObjectType):
 
 class OrganizationFilterType(graphene.InputObjectType):
     name = graphene.String(required=False)
+    term = graphene.String(required=False)
 
 
 class IdentityFilterType(graphene.InputObjectType):
@@ -808,6 +809,12 @@ class SortingHatQuery:
 
         if filters and 'name' in filters:
             query = query.filter(name=filters['name'])
+        if filters and 'term' in filters:
+            search_term = filters['term']
+            query = query.filter(Q(name__icontains=search_term) |
+                                 Q(name__in=Subquery(Domain.objects
+                                                    .filter(domain__icontains=search_term)
+                                                    .values_list('organization__name'))))
 
         return OrganizationPaginatedType.create_paginated_result(query,
                                                                  page,

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -121,8 +121,12 @@ const GET_PAGINATED_INDIVIDUALS = gql`
 `;
 
 const GET_PAGINATED_ORGANIZATIONS = gql`
-  query GetOrganizations($page: Int!, $pageSize: Int!) {
-    organizations(page: $page, pageSize: $pageSize) {
+  query GetOrganizations(
+    $page: Int!
+    $pageSize: Int!
+    $filters: OrganizationFilterType
+  ) {
+    organizations(page: $page, pageSize: $pageSize, filters: $filters) {
       entities {
         id
         name
@@ -212,12 +216,13 @@ const getProfileByUuid = (apollo, uuid) => {
   return response;
 };
 
-const getPaginatedOrganizations = (apollo, currentPage, pageSize) => {
+const getPaginatedOrganizations = (apollo, currentPage, pageSize, filters) => {
   let response = apollo.query({
     query: GET_PAGINATED_ORGANIZATIONS,
     variables: {
       page: currentPage,
-      pageSize: pageSize
+      pageSize: pageSize,
+      filters: filters
     },
     fetchPolicy: "no-cache"
   });

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -7,6 +7,10 @@
         </v-icon>
         Organizations
       </h4>
+      <search
+        class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
+        @search="filterSearch"
+      />
       <v-btn
         depressed
         color="secondary"
@@ -100,10 +104,16 @@ import { formatIndividuals } from "../utils/actions";
 import ExpandedOrganization from "./ExpandedOrganization.vue";
 import OrganizationEntry from "./OrganizationEntry.vue";
 import OrganizationModal from "./OrganizationModal.vue";
+import Search from "./Search.vue";
 
 export default {
   name: "OrganizationsTable",
-  components: { OrganizationEntry, ExpandedOrganization, OrganizationModal },
+  components: {
+    OrganizationEntry,
+    ExpandedOrganization,
+    OrganizationModal,
+    Search
+  },
   props: {
     enroll: {
       type: Function,
@@ -161,15 +171,16 @@ export default {
         organization: undefined,
         domains: []
       },
-      selectedOrganization: ""
+      selectedOrganization: "",
+      filters: {}
     };
   },
   created() {
     this.getOrganizations(1);
   },
   methods: {
-    async getOrganizations(page = this.page) {
-      let response = await this.fetchPage(page, this.itemsPerPage);
+    async getOrganizations(page = this.page, filters = this.filters) {
+      let response = await this.fetchPage(page, this.itemsPerPage, filters);
       if (response) {
         this.organizations = response.data.organizations.entities;
         this.pageCount = response.data.organizations.pageInfo.numPages;
@@ -241,15 +252,36 @@ export default {
       event.dataTransfer.setData("organization", item.name);
       const dragImage = document.querySelector(".dragged-organization");
       event.dataTransfer.setDragImage(dragImage, 0, 0);
+    },
+    filterSearch(filters) {
+      this.filters = filters;
+      this.getOrganizations(1);
     }
   }
 };
 </script>
-<style scoped>
+<style lang="scss" scoped>
 @import "../styles/index.scss";
 .actions {
+  align-items: baseline;
   justify-content: space-between;
   padding: 0 26px 24px 26px;
+
+  .search {
+    width: 200px;
+    &:hover {
+      width: 200px;
+    }
+    &--hidden {
+      width: 33px;
+    }
+  }
+  .title {
+    @media (max-width: 1818px) {
+      flex-basis: 100%;
+      margin-bottom: 8px;
+    }
+  }
 }
 
 .dragged-organization {

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -113,11 +113,12 @@ export default {
       );
       return response;
     },
-    async getOrganizationsPage(page, items) {
+    async getOrganizationsPage(page, items, filters) {
       const response = await getPaginatedOrganizations(
         this.$apollo,
         page,
-        items
+        items,
+        filters
       );
       return response;
     },
@@ -267,7 +268,7 @@ export default {
 }
 .organizations {
   max-width: 30%;
-  min-width: 420px;
+  min-width: 450px;
   align-self: flex-start;
   margin-left: 32px;
 

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -1829,6 +1829,10 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
     
     </h4>
      
+    <search-stub
+      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
+    />
+     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -2073,6 +2077,10 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
       Organizations
     
     </h4>
+     
+    <search-stub
+      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
+    />
      
     <v-btn-stub
       activeclass=""
@@ -2319,6 +2327,10 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
     
     </h4>
      
+    <search-stub
+      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
+    />
+     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -2564,6 +2576,10 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
     
     </h4>
      
+    <search-stub
+      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
+    />
+     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -2806,6 +2822,10 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
       Organizations
     
     </h4>
+     
+    <search-stub
+      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
+    />
      
     <v-btn-stub
       activeclass=""

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -609,6 +609,10 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
     
     </h4>
      
+    <search-stub
+      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
+    />
+     
     <v-btn-stub
       activeclass=""
       class="black--text"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -6190,6 +6190,99 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
     
         </h4>
          
+        <div
+          class="v-input search ma-0 ml-auto pa-0 flex-grow-0 ma-0 ml-auto mr-3 pa-0 flex-grow-0 theme--light v-text-field search--hidden"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-text-field__slot"
+              >
+                <label
+                  class="v-label theme--light"
+                  for="input-934"
+                  style="left: 0px; position: absolute;"
+                >
+                  Search
+                </label>
+                <input
+                  id="input-934"
+                  type="text"
+                />
+              </div>
+              <div
+                class="v-input__append-inner"
+              >
+                <div
+                  class="v-input__icon v-input__icon--clear"
+                >
+                  <button
+                    aria-label="clear icon"
+                    class="v-icon notranslate v-icon--disabled v-icon--link mdi mdi-close theme--light"
+                    disabled="disabled"
+                    type="button"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                >
+                  <div
+                    class="v-messages__message"
+                  >
+                    <span>
+                       
+                    </span>
+                     
+                    <a
+                      class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
+                      href="/search-help"
+                      target="_blank"
+                    >
+                      <span
+                        class="v-btn__content"
+                      >
+                        
+        View search syntax
+        
+                        <i
+                          aria-hidden="true"
+                          class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
+                          style="font-size: 12px;"
+                        />
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="v-input__append-outer"
+          >
+            <div
+              class="v-input__icon v-input__icon--append-outer"
+            >
+              <button
+                aria-label="append icon"
+                class="v-icon notranslate v-icon--link mdi mdi-magnify theme--light"
+                type="button"
+              />
+            </div>
+          </div>
+        </div>
+         
         <button
           class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
           type="button"
@@ -6583,13 +6676,13 @@ exports[`Storyshots Search Default 1`] = `
             >
               <label
                 class="v-label theme--light"
-                for="input-1014"
+                for="input-1023"
                 style="left: 0px; position: absolute;"
               >
                 Search
               </label>
               <input
-                id="input-1014"
+                id="input-1023"
                 type="text"
               />
             </div>
@@ -7172,13 +7265,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1105"
+                    for="input-1114"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1105"
+                    id="input-1114"
                     type="text"
                   />
                 </div>

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -109,6 +109,29 @@ const paginatedOrganizations = {
     }
   };
 
+const filteredOrganizations = {
+  data: {
+    organizations: {
+      entities: [
+        {
+          id: "1",
+          name: "Bitergia",
+          enrollments: [{ id: "274", __typename: "EnrollmentType"}],
+          domains: [],
+          __typename: "OrganizationType"
+        }],
+        pageInfo: {
+          page: 1,
+          pageSize: 10,
+          numPages: 1,
+          totalResults: 1,
+          __typename: "PaginationType"
+        },
+        __typename: "OrganizationPaginatedType"
+    }
+  }
+};
+
 const countriesMocked = {
   data: {
     countries: {
@@ -322,5 +345,35 @@ describe("OrganizationsTable", () => {
 
     expect(query).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock search by term", async () => {
+    const querySpy = spyOn(Queries, "getPaginatedOrganizations");
+    const query = jest.fn(() => Promise.resolve(paginatedResponse));
+    const wrapper = shallowMount(OrganizationsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          query
+        }
+      },
+      propsData: {
+        fetchPage: Queries.getPaginatedOrganizations,
+        enroll: () => {},
+        addDomain: () => {},
+        addOrganization: () => {},
+        deleteDomain: () => {},
+        deleteOrganization: () => {}
+      },
+      data() {
+        return {
+          filters: { term: "Bitergia" }
+        }
+      }
+    });
+
+    const response = await wrapper.vm.getOrganizations();
+
+    expect(querySpy).toHaveBeenCalledWith(1, 10, { term: "Bitergia" });
   });
 });


### PR DESCRIPTION
The schema and UI are updated to allow filtering organizations by term:
- A `term` filter is added to the `organizations` query in `schema.py`, which returns a list of organizations whose name or domains contain the given term.
- Search filters are added to the `getPaginatedOrganizations` Apollo GraphQL query. The functions that call that query are updated accordingly.
- The `Search` component is imported in `OrganizationsTable`.