### PR TITLE
[schema] Add query to get the list of jobs

### DIFF
--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -59,6 +59,41 @@ def find_job(job_id):
 
     return jobs[0]
 
+def get_jobs():
+    """Get a list of all jobs
+
+    This function returns a list of all jobs found in the main queue and its
+    registries, sorted by date.
+
+    :returns: a list of Job instances
+    """
+    queue = django_rq.get_queue()
+    started_jobs = [find_job(id)
+                    for id
+                    in queue.started_job_registry.get_job_ids()]
+    deferred_jobs = [find_job(id)
+                    for id
+                    in queue.deferred_job_registry.get_job_ids()]
+    finished_jobs = [find_job(id)
+                    for id
+                    in queue.finished_job_registry.get_job_ids()]
+    failed_jobs = [find_job(id)
+                  for id
+                  in queue.failed_job_registry.get_job_ids()]
+    scheduled_jobs = [find_job(id)
+                     for id
+                     in queue.scheduled_job_registry.get_job_ids()]
+    jobs = (queue.jobs
+           + started_jobs
+           + deferred_jobs
+           + finished_jobs
+           + failed_jobs
+           + scheduled_jobs)
+
+    sorted_jobs = sorted(jobs, key=lambda x: x.enqueued_at)
+
+    return sorted_jobs
+
 
 @django_rq.job
 def recommend_affiliations(ctx, uuids=None):


### PR DESCRIPTION
This PR adds the `jobs` query, which returns a paginated list of all the jobs in the main queue.

The query has the following format:

```
query {
  jobs(pageSize: Int, page: Int) {
    entities {
      jobId
      status
      jobType
      errors
      result
    }
    pageInfo {
      page
      pagesize
      numPages
      hasNext
      hasPrev
      totalResults
    }
  }
}
```