### PR TITLE
[ui] Visualize jobs

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -231,6 +231,7 @@ class JobType(graphene.ObjectType):
     status = graphene.String()
     result = graphene.List(JobResultType)
     errors = graphene.List(graphene.String)
+    enqueued_at = graphene.DateTime()
 
 
 class ProfileInputType(graphene.InputObjectType):
@@ -890,6 +891,7 @@ class SortingHatQuery:
 
         status = job.get_status()
         job_type = job.func_name.split('.')[-1]
+        enqueued_at = job.enqueued_at
 
         result = None
         errors = None
@@ -920,7 +922,8 @@ class SortingHatQuery:
                        job_type=job_type,
                        status=status,
                        result=result,
-                       errors=errors)
+                       errors=errors,
+                       enqueued_at=enqueued_at)
 
     @check_auth
     def resolve_jobs(self, info, page=1, page_size=settings.DEFAULT_GRAPHQL_PAGE_SIZE):
@@ -931,12 +934,14 @@ class SortingHatQuery:
             job_id = job.get_id()
             status = job.get_status()
             job_type = job.func_name.split('.')[-1]
+            enqueued_at = job.enqueued_at
 
             result.append(JobType(job_id=job_id,
                                   job_type=job_type,
                                   status=status,
                                   result=[],
-                                  errors=[]))
+                                  errors=[],
+                                  enqueued_at=enqueued_at))
 
         return JobPaginatedType.create_paginated_result(result,
                                                         page,

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2679,6 +2679,7 @@ class MockJob:
         self.func_name = func_name
         self.status = status
         self.result = result
+        self.enqueued_at = datetime_utcnow()
 
     def get_status(self):
         return self.status

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1,7 +1,16 @@
 <template>
   <v-app>
     <v-app-bar app color="primary" dark>
-      <h1 class="headline font-weight-light">Sorting Hat</h1>
+      <router-link to="/" v-slot="{ href, navigate }">
+        <h1
+          :href="href"
+          @click="navigate"
+          class="headline font-weight-light pointer"
+        >
+          Sorting Hat
+        </h1>
+      </router-link>
+
       <v-spacer></v-spacer>
       <v-menu v-if="user && $route.name !== 'Login'" offset-y>
         <template v-slot:activator="{ on }">
@@ -13,6 +22,9 @@
           </v-btn>
         </template>
         <v-list>
+          <v-list-item to="/jobs">
+            <v-list-item-title>Jobs</v-list-item-title>
+          </v-list-item>
           <v-list-item @click="logOut">
             <v-list-item-title>Log out</v-list-item-title>
           </v-list-item>
@@ -55,5 +67,8 @@ export default {
 .fade-enter,
 .fade-leave-active {
   opacity: 0;
+}
+.pointer {
+  cursor: pointer;
 }
 </style>

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -166,6 +166,7 @@ const GET_JOBS = gql`
         status
         jobType
         errors
+        enqueuedAt
       }
       pageInfo {
         page

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -158,6 +158,24 @@ const GET_COUNTRIES = gql`
   }
 `;
 
+const GET_JOBS = gql`
+  query getJobs($page: Int!, $pageSize: Int!) {
+    jobs(page: $page, pageSize: $pageSize) {
+      entities {
+        jobId
+        status
+        jobType
+        errors
+      }
+      pageInfo {
+        page
+        numPages
+        totalResults
+      }
+    }
+  }
+`;
+
 const getIndividualByUuid = (apollo, uuid) => {
   let response = apollo.query({
     query: GET_INDIVIDUAL_BYUUID,
@@ -236,11 +254,23 @@ const getCountries = apollo => {
   return response;
 };
 
+const getJobs = (apollo, page, pageSize) => {
+  let response = apollo.query({
+    query: GET_JOBS,
+    variables: {
+      page: page,
+      pageSize: pageSize
+    }
+  });
+  return response;
+};
+
 export {
   getCountries,
   getIndividuals,
   getIndividualByUuid,
   getProfileByUuid,
   getPaginatedIndividuals,
-  getPaginatedOrganizations
+  getPaginatedOrganizations,
+  getJobs
 };

--- a/ui/src/components/JobsTable.stories.js
+++ b/ui/src/components/JobsTable.stories.js
@@ -26,27 +26,32 @@ export const Default = () => ({
               {
                 jobId: "a60346ea-6fbe-4501-896b-c8433a6b958f",
                 status: "finished",
-                jobType: "recommend_affiliations"
+                jobType: "recommend_affiliations",
+                enqueuedAt: "2021-02-19T12:09:21.651904"
               },
               {
                 jobId: "7fb401f4-6fbe-4501-896b-c8433a6b958f",
                 status: "finished",
-                jobType: "recommend_affiliations"
+                jobType: "recommend_affiliations",
+                enqueuedAt: "2021-02-19T14:12:00.651904"
               },
               {
                 jobId: "c7dac2c6-b0c5-4898-b92a-dc149fa5f175",
                 status: "scheduled",
-                jobType: "affiliate"
+                jobType: "affiliate",
+                enqueuedAt: "2021-02-19T14:22:10.651904"
               },
               {
                 jobId: "8a1aeaff-8f8f-4e3f-912b-04775c83f4c1",
                 status: "failed",
-                jobType: "recommend_affiliations"
+                jobType: "recommend_affiliations",
+                enqueuedAt: "2021-02-20T08:01:56.651904"
               },
               {
                 jobId: "bc904fc6-c8a3-4271-a0eb-223c6524ea71",
                 status: "started",
-                jobType: "affiliate"
+                jobType: "affiliate",
+                enqueuedAt: "2021-02-20T10:45:38.651904"
               }
             ],
             pageInfo: {
@@ -65,16 +70,19 @@ export const Default = () => ({
                 jobId: "929ff864-819e-4c4c-93ac-81883ef48fb3",
                 status: "queued",
                 jobType: "recommend_matches",
+                enqueuedAt: "2021-02-20T10:48:38.651904"
               },
               {
                 jobId: "52d20b58-6bf4-4a42-bcb9-235605c55bff",
                 status: "queued",
-                jobType: "recommend_matches"
+                jobType: "recommend_matches",
+                enqueuedAt: "2021-02-20T12:09:21.651904"
               },
               {
                 jobId: "fac43571-0248-455b-b4fd-650211afb8b1",
                 status: "queued",
-                jobType: "unify"
+                jobType: "unify",
+                enqueuedAt: "2021-02-21T18:50:21.651904"
               }
             ],
             pageInfo: {

--- a/ui/src/components/JobsTable.stories.js
+++ b/ui/src/components/JobsTable.stories.js
@@ -1,0 +1,110 @@
+import { storiesOf } from "@storybook/vue";
+
+import JobsTable from "./JobsTable.vue";
+
+export default {
+  title: "JobsTable",
+  excludeStories: /.*Data$/
+};
+
+const JobsTableTemplate = `<jobs-table :get-jobs="getJobs.bind(this)" />`;
+
+export const Default = () => ({
+  components: { JobsTable },
+  template: JobsTableTemplate,
+  methods: {
+    getJobs(page) {
+      return this.query[page - 1];
+    }
+  },
+  data: () => ({
+    query: [
+      {
+        data: {
+          jobs: {
+            entities: [
+              {
+                jobId: "a60346ea-6fbe-4501-896b-c8433a6b958f",
+                status: "finished",
+                jobType: "recommend_affiliations"
+              },
+              {
+                jobId: "7fb401f4-6fbe-4501-896b-c8433a6b958f",
+                status: "finished",
+                jobType: "recommend_affiliations"
+              },
+              {
+                jobId: "c7dac2c6-b0c5-4898-b92a-dc149fa5f175",
+                status: "scheduled",
+                jobType: "affiliate"
+              },
+              {
+                jobId: "8a1aeaff-8f8f-4e3f-912b-04775c83f4c1",
+                status: "failed",
+                jobType: "recommend_affiliations"
+              },
+              {
+                jobId: "bc904fc6-c8a3-4271-a0eb-223c6524ea71",
+                status: "started",
+                jobType: "affiliate"
+              }
+            ],
+            pageInfo: {
+              page: 1,
+              numPages: 2,
+              totalResults: 8
+            }
+          }
+        }
+      },
+      {
+        data: {
+          jobs: {
+            entities: [
+              {
+                jobId: "929ff864-819e-4c4c-93ac-81883ef48fb3",
+                status: "queued",
+                jobType: "recommend_matches",
+              },
+              {
+                jobId: "52d20b58-6bf4-4a42-bcb9-235605c55bff",
+                status: "queued",
+                jobType: "recommend_matches"
+              },
+              {
+                jobId: "fac43571-0248-455b-b4fd-650211afb8b1",
+                status: "queued",
+                jobType: "unify"
+              }
+            ],
+            pageInfo: {
+              page: 2,
+              numPages: 2,
+              totalResults: 8
+            }
+          }
+        }
+      }
+    ]
+  })
+});
+export const Empty = () => ({
+  components: { JobsTable },
+  template: JobsTableTemplate,
+  methods: {
+    getJobs(page) {
+      return this.query;
+    }
+  },
+  data: () => ({
+    query: {
+      data: {
+        jobs: {
+          entities: [],
+          pageInfo: {
+            page: 1,
+            numPages: 1,
+            totalResults: 0
+          }}}}
+  })
+});

--- a/ui/src/components/JobsTable.vue
+++ b/ui/src/components/JobsTable.vue
@@ -1,0 +1,118 @@
+<template>
+  <v-container>
+    <h4 class="title mt-5 mb-5">
+      <v-icon color="black" left>
+        mdi-tray-full
+      </v-icon>
+      Jobs
+    </h4>
+    <v-simple-table v-if="jobs.length > 0">
+      <template v-slot:default>
+        <thead>
+          <tr>
+            <th class="text-left">
+              Job ID
+            </th>
+            <th class="text-left">
+              Type
+            </th>
+            <th class="text-center">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="job in jobs" :key="job.jobId">
+            <td>
+              <v-tooltip bottom>
+                <template v-slot:activator="{ on }">
+                  <v-chip class="text-center clip" v-on="on" outlined tile>
+                    {{ job.jobId }}
+                  </v-chip>
+                </template>
+                <span>{{ job.jobId }}</span>
+              </v-tooltip>
+            </td>
+            <td class="capitalize">{{ job.jobType.replace("_", " ") }}</td>
+            <td class="text-center">
+              <v-chip
+                class="ma-2"
+                :color="getColor(job.status)"
+                text-color="white"
+              >
+                {{ job.status }}
+              </v-chip>
+            </td>
+          </tr>
+        </tbody>
+      </template>
+    </v-simple-table>
+    <div v-if="jobs.length > 0" class="text-center pt-4">
+      <v-pagination
+        v-model="page"
+        :length="pageCount"
+        :total-visible="5"
+        @input="getPaginatedJobs($event)"
+      ></v-pagination>
+    </div>
+    <p v-else class="text-subtitle-1">There are no jobs in the queue.</p>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: "JobsTable",
+  props: {
+    getJobs: {
+      type: Function,
+      required: true
+    }
+  },
+  data() {
+    return {
+      jobs: [],
+      page: 1,
+      pageSize: 10,
+      pageCount: 1
+    };
+  },
+  created() {
+    this.getPaginatedJobs(1);
+  },
+  methods: {
+    async getPaginatedJobs(page = this.page, pageSize = this.pageSize) {
+      let response = await this.getJobs(page, pageSize);
+      if (response) {
+        this.jobs = response.data.jobs.entities;
+        this.pageCount = response.data.jobs.pageInfo.numPages;
+        this.page = response.data.jobs.pageInfo.page;
+      }
+    },
+    getColor(status) {
+      if (status === "finished") {
+        return "#3fa500";
+      } else if (status === "failed") {
+        return "#f41900";
+      } else if (status === "started") {
+        return "primary";
+      } else {
+        return "rgba(0, 0, 0, 0.42)";
+      }
+    }
+  }
+};
+</script>
+<style lang="scss" scoped>
+.capitalize {
+  text-transform: capitalize;
+}
+.container {
+  max-width: 1160px;
+}
+.clip ::v-deep .v-chip__content {
+  max-width: 8ch;
+  overflow: hidden;
+  text-overflow: clip;
+  font-family: monospace;
+}
+</style>

--- a/ui/src/components/JobsTable.vue
+++ b/ui/src/components/JobsTable.vue
@@ -16,6 +16,9 @@
             <th class="text-left">
               Type
             </th>
+            <th class="text-left">
+              Date
+            </th>
             <th class="text-center">
               Status
             </th>
@@ -34,6 +37,7 @@
               </v-tooltip>
             </td>
             <td class="capitalize">{{ job.jobType.replace("_", " ") }}</td>
+            <td>{{ formatDate(job.enqueuedAt) }}</td>
             <td class="text-center">
               <v-chip
                 class="ma-2"
@@ -98,6 +102,9 @@ export default {
       } else {
         return "rgba(0, 0, 0, 0.42)";
       }
+    },
+    formatDate(dateTime) {
+      return new Date(dateTime).toLocaleString();
     }
   }
 };

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -17,6 +17,11 @@ const routes = [
     path: "/search-help",
     name: "SearchHelp",
     component: () => import("../views/SearchHelp")
+  },
+  {
+    path: "/jobs",
+    name: "Jobs",
+    component: () => import("../views/Jobs")
   }
 ];
 

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -1,0 +1,21 @@
+<template>
+  <v-main>
+    <jobs-table :get-jobs="getJobs" />
+  </v-main>
+</template>
+
+<script>
+import { getJobs } from "../apollo/queries";
+import JobsTable from "../components/JobsTable";
+
+export default {
+  name: "Jobs",
+  components: { JobsTable },
+  methods: {
+    async getJobs(page, pageSize) {
+      const response = await getJobs(this.$apollo, page, pageSize);
+      return response;
+    }
+  }
+};
+</script>

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -585,6 +585,36 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
 </v-container-stub>
 `;
 
+exports[`JobsTable Mock query for getJobs 1`] = `
+<v-container-stub
+  tag="div"
+>
+  <h4
+    class="title mt-5 mb-5"
+  >
+    <v-icon-stub
+      color="black"
+      left=""
+    >
+      
+      mdi-tray-full
+    
+    </v-icon-stub>
+    
+    Jobs
+  
+  </h4>
+   
+  <!---->
+   
+  <p
+    class="text-subtitle-1"
+  >
+    There are no jobs in the queue.
+  </p>
+</v-container-stub>
+`;
+
 exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
 <v-container-stub
   tag="div"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -5781,6 +5781,78 @@ exports[`Storyshots IndividualsTable Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots JobsTable Default 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="container"
+    >
+      <h4
+        class="title mt-5 mb-5"
+      >
+        <i
+          aria-hidden="true"
+          class="v-icon notranslate v-icon--left mdi mdi-tray-full theme--light black--text"
+        />
+        
+    Jobs
+  
+      </h4>
+       
+      <!---->
+       
+      <p
+        class="text-subtitle-1"
+      >
+        There are no jobs in the queue.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots JobsTable Empty 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="container"
+    >
+      <h4
+        class="title mt-5 mb-5"
+      >
+        <i
+          aria-hidden="true"
+          class="v-icon notranslate v-icon--left mdi mdi-tray-full theme--light black--text"
+        />
+        
+    Jobs
+  
+      </h4>
+       
+      <!---->
+       
+      <p
+        class="text-subtitle-1"
+      >
+        There are no jobs in the queue.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots OrganizationEntry Default 1`] = `
 <div
   class="v-application v-application--is-ltr theme--light"
@@ -6004,13 +6076,13 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-922"
+                  for="input-953"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-922"
+                  id="input-953"
                   type="text"
                 />
               </div>
@@ -6476,13 +6548,13 @@ exports[`Storyshots Search Default 1`] = `
             >
               <label
                 class="v-label theme--light"
-                for="input-1011"
+                for="input-1042"
                 style="left: 0px; position: absolute;"
               >
                 Search
               </label>
               <input
-                id="input-1011"
+                id="input-1042"
                 type="text"
               />
             </div>
@@ -7065,13 +7137,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1102"
+                    for="input-1133"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1102"
+                    id="input-1133"
                     type="text"
                   />
                 </div>

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -4,6 +4,7 @@ import Vuetify from "vuetify";
 import IndividualsData from "@/components/IndividualsData";
 import IndividualsTable from "@/components/IndividualsTable";
 import OrganizationsTable from "@/components/OrganizationsTable";
+import JobsTable from "@/components/JobsTable";
 import * as Queries from "@/apollo/queries";
 
 Vue.use(Vuetify);
@@ -148,6 +149,29 @@ const countriesMocked = {
     }
   }
 };
+
+const jobsMocked = {
+  data: {
+    jobs: {
+      entities: [
+        {
+          jobId: "41f813e5-6701-41d2-bfac-ac13e04d4858",
+          status: "queued",
+          jobType: "unify",
+          errors: [],
+          result: []
+        }
+      ],
+      pageInfo: {
+        page: 2,
+        numPages: 2,
+        totalResults: 11,
+        hasNext: false,
+        hasPrev: true
+      }
+    }
+  }
+}
 
 describe("IndividualsData", () => {
   test("mock query for getIndividuals", async () => {
@@ -375,5 +399,29 @@ describe("OrganizationsTable", () => {
     const response = await wrapper.vm.getOrganizations();
 
     expect(querySpy).toHaveBeenCalledWith(1, 10, { term: "Bitergia" });
+  });
+});
+
+describe("JobsTable", () => {
+  test("Mock query for getJobs", async () => {
+    const query = jest.fn(() => Promise.resolve(jobsMocked));
+    const wrapper = shallowMount(JobsTable, {
+      Vue,
+      mocks: {
+        $apollo: {
+          query
+        }
+      },
+      propsData: {
+        getJobs: query,
+      }
+    });
+    const response = await Queries.getJobs(wrapper.vm.$apollo, 2, 10);
+
+    expect(query).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+    expect(wrapper.vm.jobs.length).toBe(1);
+    expect(wrapper.vm.page).toBe(2);
+    expect(wrapper.vm.pageCount).toBe(2);
   });
 });


### PR DESCRIPTION
Adds the `JobsTable` component, which displays a list of jobs, their type and their status, retrieved with the `getJobs` Apollo GraphQL query. The list can be accessed through the `/jobs` route. A link can be found on the app bar menu.