### PR TITLE
Search bot individuals

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -257,6 +257,7 @@ class IdentityFilterType(graphene.InputObjectType):
     uuid = graphene.String(required=False)
     term = graphene.String(required=False)
     is_locked = graphene.Boolean(required=False)
+    is_bot = graphene.Boolean(required=False)
     last_updated = graphene.String(
         required=False,
         description='Filter with a comparison operator (>, >=, <, <=) and a date OR with a range operator (..) between\
@@ -857,6 +858,10 @@ class SortingHatQuery:
                                                  .values_list('individual__mk')))
         if filters and 'is_locked' in filters:
             query = query.filter(is_locked=filters['is_locked'])
+        if filters and 'is_bot' in filters:
+            query = query.filter(mk__in=Subquery(Profile.objects
+                                                 .filter(is_bot=filters['is_bot'])
+                                                 .values_list('individual__mk')))
         if filters and 'last_updated' in filters:
             # Accepted date format is ISO 8601, YYYY-MM-DDTHH:MM:SS
             try:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -352,6 +352,16 @@ SH_INDIVIDUALS_BOT_FILTER = """{
     }
   }
 }"""
+SH_INDIVIDUALS_BOT_FILTER_FALSE = """{
+  individuals(filters: {isBot: false}) {
+    entities {
+      mk
+      profile {
+        isBot
+      }
+    }
+  }
+}"""
 SH_INDIVIDUALS_LAST_UPDATED_FILTER = """{
   individuals(filters: {lastUpdated: "%s"}) {
     entities {
@@ -2037,6 +2047,18 @@ class TestQueryIndividuals(django.test.TestCase):
         indv = individuals[0]
         self.assertEqual(indv['mk'], 'a9b403e150dd4af8953a52a4bb841051e4b705d9')
         self.assertEqual(indv['profile']['isBot'], True)
+
+        # Test isBot: false
+        client = graphene.test.Client(schema)
+        executed = client.execute(SH_INDIVIDUALS_BOT_FILTER_FALSE,
+                                  context_value=self.context_value)
+
+        individuals = executed['data']['individuals']['entities']
+        self.assertEqual(len(individuals), 1)
+
+        indv = individuals[0]
+        self.assertEqual(indv['mk'], 'c6d2504fde0e34b78a185c4b709e5442d045451c')
+        self.assertEqual(indv['profile']['isBot'], False)
 
 
     def test_filter_non_exist_registry(self):

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -48,9 +48,11 @@ export default {
   methods: {
     search() {
       this.parseFilters();
+      if (this.errorMessage) return;
       this.$emit("search", this.filters);
     },
     parseFilters() {
+      const booleanFilters = ["isLocked", "isBot"];
       const terms = [];
       this.filters = {};
       this.errorMessage = undefined;
@@ -62,10 +64,8 @@ export default {
           const [filter, text] = value.split(":");
           if (filter === "lastUpdated") {
             this.parseLastUpdated(text);
-          } else if (text === "true") {
-            this.filters[filter] = true;
-          } else if (text === "false") {
-            this.filters[filter] = false;
+          } else if (booleanFilters.find(bfilter => bfilter === filter)) {
+            this.parseBooleanFilter(filter, text);
           } else {
             this.filters[filter] = text;
           }
@@ -101,6 +101,15 @@ export default {
           .join("");
       } catch (error) {
         this.errorMessage = "Invalid date";
+      }
+    },
+    parseBooleanFilter(filter, value) {
+      if (value === "true") {
+        this.filters[filter] = true;
+      } else if (value === "false") {
+        this.filters[filter] = false;
+      } else {
+        this.errorMessage = "Accepted values are true and false";
       }
     },
     clear() {

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -62,6 +62,10 @@ export default {
           const [filter, text] = value.split(":");
           if (filter === "lastUpdated") {
             this.parseLastUpdated(text);
+          } else if (text === "true") {
+            this.filters[filter] = true;
+          } else if (text === "false") {
+            this.filters[filter] = false;
           } else {
             this.filters[filter] = text;
           }

--- a/ui/src/views/SearchHelp.vue
+++ b/ui/src/views/SearchHelp.vue
@@ -71,6 +71,13 @@
             </tbody>
           </template>
         </v-simple-table>
+
+        <p class="subtitle-2 mt-8">Search for bots</p>
+        <p>
+          You can search for individuals based on whether they are marked as
+          bots, using the <code>isBot:true</code> and <code>isBot:false</code>
+          filters.
+        </p>
       </v-card-text>
     </v-card>
   </v-main>

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -329,6 +329,24 @@ describe("IndividualsTable", () => {
     expect(querySpy).toHaveBeenCalledWith(1, 10, { lastUpdated: "<2000-01-01T00:00:00.000Z" });
   });
 
+  test("Searches by isBot", async () => {
+    const querySpy = spyOn(Queries, "getPaginatedIndividuals");
+    const query = jest.fn(() => Promise.resolve(paginatedResponse));
+    const wrapper = mountFunction({
+      mocks: {
+        $apollo: {
+          query
+        }
+      }
+    });
+    await wrapper.setProps({ fetchPage: Queries.getPaginatedIndividuals });
+    await wrapper.setData({ filters: { isBot: true } });
+
+    const response = await wrapper.vm.queryIndividuals(1);
+
+    expect(querySpy).toHaveBeenCalledWith(1, 10, { isBot: true });
+  });
+
   test("Mock query for getCountries", async () => {
     const query = jest.fn(() => Promise.resolve(countriesMocked));
     const wrapper = mountFunction({

--- a/ui/tests/unit/search.spec.js
+++ b/ui/tests/unit/search.spec.js
@@ -60,7 +60,9 @@ describe("Search", () => {
     "lastUpdated:>@",
     "lastUpdated:2000-2001",
     "lastUpdated:===2000-01-01",
-    "lastUpdated:<=2000-01-01>=2000-01-01"
+    "lastUpdated:<=2000-01-01>=2000-01-01",
+    "isBot:1",
+    "isBot:falsee"
   ])("Given an invalid value %p renders an error", async (value) => {
     const wrapper = mountFunction({
       data: () => ({ inputValue: value })
@@ -68,7 +70,7 @@ describe("Search", () => {
 
     const button = wrapper.find("button.mdi-magnify");
     await button.trigger("click");
-    const errorMessage = wrapper.find(".v-messages__message");
+    const errorMessage = wrapper.find(".error--text");
 
     expect(errorMessage.exists()).toBe(true);
   });


### PR DESCRIPTION
Adds the `isBot` filter to the individuals query, which accepts a boolean value and returns a list of individuals filtered by their bot status.