### PR TITLE
Search individuals by country

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -259,6 +259,7 @@ class IdentityFilterType(graphene.InputObjectType):
     is_locked = graphene.Boolean(required=False)
     is_bot = graphene.Boolean(required=False)
     gender = graphene.String(required=False)
+    country = graphene.String(required=False)
     last_updated = graphene.String(
         required=False,
         description='Filter with a comparison operator (>, >=, <, <=) and a date OR with a range operator (..) between\
@@ -865,6 +866,13 @@ class SortingHatQuery:
                                                  .values_list('individual__mk')))
         if filters and 'gender' in filters:
             query = query.filter(profile__gender=filters['gender'])
+        if filters and 'country' in filters:
+            country = filters['country']
+            query = query.filter(mk__in=Subquery(Profile.objects
+                                                 .filter(Q(country__name__icontains=country) |
+                                                         Q(country__code=country) |
+                                                         Q(country__alpha3=country))
+                                                 .values_list('individual__mk')))
         if filters and 'last_updated' in filters:
             # Accepted date format is ISO 8601, YYYY-MM-DDTHH:MM:SS
             try:

--- a/ui/src/views/SearchHelp.vue
+++ b/ui/src/views/SearchHelp.vue
@@ -85,6 +85,44 @@
           wrapped in double quotes. For example:
           <code>gender:"non binary"</code>.
         </p>
+
+        <p class="subtitle-2 mt-6">Filter by country</p>
+        <p>
+          You can filter individuals based on their country using the
+          <code>country</code> filter.
+        </p>
+        <v-simple-table>
+          <template v-slot:default>
+            <thead>
+              <tr>
+                <th class="text-left" width="30%">
+                  Filter
+                </th>
+                <th class="text-left">
+                  Explanation
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td width="30%"><code>country:name</code></td>
+                <td>
+                  Matches individuals from the given country. Country names that
+                  include spaces should be wrapped in double quotes. For
+                  example: <code>country:"Dominican Republic"</code>
+                </td>
+              </tr>
+              <tr>
+                <td width="30%"><code>country:code</code></td>
+                <td>
+                  Matches individuals from a given country using ISO (Alpha-2
+                  and Alpha-3) country codes. For example:
+                  <code>country:USA</code>.
+                </td>
+              </tr>
+            </tbody>
+          </template>
+        </v-simple-table>
       </v-card-text>
     </v-card>
   </v-main>

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -365,6 +365,24 @@ describe("IndividualsTable", () => {
     expect(querySpy).toHaveBeenCalledWith(1, 10, { isBot: true });
   });
 
+  test("Searches by country", async () => {
+    const querySpy = spyOn(Queries, "getPaginatedIndividuals");
+    const query = jest.fn(() => Promise.resolve(paginatedResponse));
+    const wrapper = mountFunction({
+      mocks: {
+        $apollo: {
+          query
+        }
+      }
+    });
+    await wrapper.setProps({ fetchPage: Queries.getPaginatedIndividuals });
+    await wrapper.setData({ filters: { country: "Spain" } });
+
+    const response = await wrapper.vm.queryIndividuals(1);
+
+    expect(querySpy).toHaveBeenCalledWith(1, 10, { country: "Spain" });
+  });
+
   test("Mock query for getCountries", async () => {
     const query = jest.fn(() => Promise.resolve(countriesMocked));
     const wrapper = mountFunction({

--- a/ui/tests/unit/search.spec.js
+++ b/ui/tests/unit/search.spec.js
@@ -88,4 +88,20 @@ describe("Search", () => {
 
     expect(wrapper.vm.filters.gender).toBe(expected);
   });
+
+  test.each([
+    [`country:"United Kingdom"`, "United Kingdom"],
+    [`country:"United States of America"`, "United States of America"],
+    ["country:Spain", "Spain"],
+    [`country:"UK"`, "UK"]
+  ])("Given %p parses country filter", async (value, expected) => {
+    const wrapper = mountFunction({
+      data: () => ({ inputValue: value })
+    });
+
+    const button = wrapper.find("button.mdi-magnify");
+    await button.trigger("click");
+
+    expect(wrapper.vm.filters.country).toBe(expected);
+  });
 });


### PR DESCRIPTION
Adds the `country` filter to the `individuals` query, which returns individuals with a given country name or country ISO codes.
In the UI `Search` component, the syntax is `country:"country name"`.