### PR TITLE
[ui] Select all individuals for batch operations

### DIFF
--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -47,7 +47,20 @@
         </v-edit-dialog>
       </div>
     </v-row>
-    <v-subheader>Identities ({{ identitiesCount }})</v-subheader>
+    <v-subheader class="d-flex justify-space-between">
+      <span>Identities ({{ identitiesCount }})</span>
+      <v-btn
+        v-if="!compact"
+        text
+        small
+        outlined
+        :disabled="identitiesCount === 1 || isLocked"
+        @click="splitAll"
+      >
+        <v-icon small left>mdi-call-split</v-icon>
+        Split all
+      </v-btn>
+    </v-subheader>
     <v-simple-table v-if="compact" dense>
       <template v-slot:default>
         <thead v-if="identitiesCount > 0">
@@ -126,7 +139,7 @@
           <template v-slot:activator="{ on }">
             <v-btn
               icon
-              :disabled="identity.uuid === uuid"
+              :disabled="identity.uuid === uuid || isLocked"
               v-on="on"
               @click="$emit('unmerge', [identity.uuid, uuid])"
             >
@@ -148,7 +161,20 @@
       </v-list-item>
     </v-list>
 
-    <v-subheader>Organizations ({{ enrollments.length }})</v-subheader>
+    <v-subheader class="d-flex justify-space-between">
+      Organizations ({{ enrollments.length }})
+      <v-btn
+        v-if="!compact"
+        text
+        small
+        outlined
+        :disabled="enrollments.length < 1 || isLocked"
+        @click="withdrawAll"
+      >
+        <v-icon small left>mdi-delete</v-icon>
+        Remove all
+      </v-btn>
+    </v-subheader>
     <v-simple-table v-if="compact" dense>
       <template v-slot:default>
         <thead v-if="enrollments.length > 0">
@@ -310,6 +336,7 @@
                   <v-btn
                     icon
                     v-on="on"
+                    :disabled="isLocked"
                     @click="
                       $emit('withdraw', {
                         name: enrollment.organization.name,
@@ -423,6 +450,19 @@ export default {
       if (response) {
         this.countries = response;
       }
+    },
+    splitAll() {
+      const uuids = this.flatIdentities.map(identity => identity.uuid);
+      this.$emit("unmerge", uuids);
+    },
+    withdrawAll() {
+      this.enrollments.forEach(enrollment => {
+        this.$emit("withdraw", {
+          name: enrollment.organization.name,
+          fromDate: enrollment.start,
+          toDate: enrollment.end
+        });
+      });
     }
   },
   computed: {

--- a/ui/src/components/IndividualEntry.vue
+++ b/ui/src/components/IndividualEntry.vue
@@ -131,6 +131,11 @@
           </v-btn>
         </template>
         <v-list>
+          <v-list-item @click="$emit('select', $event)">
+            <v-list-item-title>
+              {{ isSelected ? "Deselect individual" : "Select individual" }}
+            </v-list-item-title>
+          </v-list-item>
           <v-list-item @click="$emit('saveIndividual', $event)">
             <v-list-item-title>Save in workspace</v-list-item-title>
           </v-list-item>

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -19,6 +19,7 @@
 
     <v-row class="actions">
       <v-checkbox
+        v-model="allSelected"
         value
         :indeterminate="isIndeterminate"
         :label="
@@ -271,7 +272,8 @@ export default {
         open: false,
         text: ""
       },
-      totalResults: 0
+      totalResults: 0,
+      allSelected: false
     };
   },
   computed: {
@@ -311,6 +313,7 @@ export default {
         this.pageCount = response.data.individuals.pageInfo.numPages;
         this.page = response.data.individuals.pageInfo.page;
         this.totalResults = response.data.individuals.pageInfo.totalResults;
+        this.allSelected = false;
         this.$emit("updateIndividuals", this.individuals);
       }
     },
@@ -335,9 +338,12 @@ export default {
     },
     selectIndividual(individual) {
       individual.isSelected = !individual.isSelected;
+      this.allSelected =
+        this.selectedIndividuals.length === this.individuals.length;
     },
     deselectIndividuals() {
       this.individuals.forEach(individual => (individual.isSelected = false));
+      this.allSelected = false;
     },
     async deleteIndividuals(individuals) {
       const response = await Promise.all(

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -7,43 +7,55 @@
         </v-icon>
         Individuals ({{ totalResults }})
       </h4>
+      <v-btn
+        depressed
+        color="secondary"
+        class="black--text"
+        @click.stop="openModal = true"
+      >
+        Add
+      </v-btn>
+    </v-row>
+
+    <v-row class="actions">
+      <v-checkbox
+        value
+        :indeterminate="isIndeterminate"
+        :label="
+          selectedIndividuals.length === 0
+            ? 'Select all'
+            : `${selectedIndividuals.length} selected`
+        "
+        @change="selectAll($event)"
+      >
+      </v-checkbox>
       <search class="ma-0 ml-auto pa-0 flex-grow-0" @search="filterSearch" />
-      <div>
-        <v-tooltip bottom transition="expand-y-transition" open-delay="200">
-          <template v-slot:activator="{ on }">
-            <v-btn
-              icon
-              v-on="on"
-              :disabled="disabledMerge"
-              @click="mergeSelected(selectedIndividuals)"
-            >
-              <v-icon>mdi-call-merge</v-icon>
-            </v-btn>
-          </template>
-          <span>Merge selected</span>
-        </v-tooltip>
-        <v-tooltip bottom transition="expand-y-transition" open-delay="200">
-          <template v-slot:activator="{ on }">
-            <v-btn
-              icon
-              v-on="on"
-              :disabled="disabledActions"
-              @click="confirmDelete(selectedIndividuals)"
-            >
-              <v-icon left>mdi-delete</v-icon>
-            </v-btn>
-          </template>
-          <span>Delete selected</span>
-        </v-tooltip>
-        <v-btn
-          depressed
-          color="secondary"
-          class="black--text"
-          @click.stop="openModal = true"
-        >
-          Add
-        </v-btn>
-      </div>
+      <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+        <template v-slot:activator="{ on }">
+          <v-btn
+            icon
+            v-on="on"
+            :disabled="disabledMerge"
+            @click="mergeSelected(selectedIndividuals)"
+          >
+            <v-icon>mdi-call-merge</v-icon>
+          </v-btn>
+        </template>
+        <span>Merge selected</span>
+      </v-tooltip>
+      <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+        <template v-slot:activator="{ on }">
+          <v-btn
+            icon
+            v-on="on"
+            :disabled="disabledActions"
+            @click="confirmDelete(selectedIndividuals)"
+          >
+            <v-icon>mdi-delete</v-icon>
+          </v-btn>
+        </template>
+        <span>Delete selected</span>
+      </v-tooltip>
     </v-row>
 
     <v-data-table
@@ -277,6 +289,12 @@ export default {
     },
     selectedIndividuals() {
       return this.individuals.filter(individual => individual.isSelected);
+    },
+    isIndeterminate() {
+      return (
+        this.selectedIndividuals.length < this.individuals.length &&
+        this.selectedIndividuals.length !== 0
+      );
     }
   },
   created() {
@@ -332,7 +350,7 @@ export default {
     },
     confirmDelete(individuals) {
       individuals = individuals.filter(individual => !individual.isLocked);
-      const names = individuals.map(individual => individual.name).toString();
+      const names = individuals.map(individual => individual.name).join(", ");
       Object.assign(this.dialog, {
         open: true,
         title: "Delete the selected items?",
@@ -449,6 +467,9 @@ export default {
     filterSearch(filters) {
       this.filters = filters;
       this.queryIndividuals(1);
+    },
+    selectAll(value) {
+      this.individuals.forEach(individual => (individual.isSelected = value));
     }
   }
 };
@@ -460,7 +481,7 @@ export default {
 .actions {
   align-items: baseline;
   justify-content: space-between;
-  padding: 0 26px 24px 26px;
+  padding: 0 26px 10px 26px;
 }
 .dragged-item {
   max-width: 300px;

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -7,10 +7,6 @@
         </v-icon>
         Organizations ({{ totalResults }})
       </h4>
-      <search
-        class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
-        @search="filterSearch"
-      />
       <v-btn
         depressed
         color="secondary"
@@ -19,6 +15,9 @@
       >
         Add
       </v-btn>
+    </v-row>
+    <v-row class="actions">
+      <search class="ma-0 mr-3 pa-0 flex-grow-0" @search="filterSearch" />
     </v-row>
     <v-data-table
       hide-default-header
@@ -268,15 +267,8 @@ export default {
   align-items: baseline;
   justify-content: space-between;
   padding: 0 26px 24px 26px;
-
   .search {
-    width: 155px;
-    &:hover {
-      width: 155px;
-    }
-    &--hidden {
-      width: 33px;
-    }
+    width: 60%;
   }
   .title {
     @media (max-width: 1818px) {

--- a/ui/src/components/Search.stories.js
+++ b/ui/src/components/Search.stories.js
@@ -8,7 +8,7 @@ export default {
 };
 
 const searchTemplate = `
-  <div width="380" class="mx-auto">
+  <div class="mx-auto mt-5">
     <search />
   </div>
 `;

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -1,36 +1,30 @@
 <template>
-  <v-hover v-slot="{ hover }">
-    <v-text-field
-      v-model.trim="inputValue"
-      append-outer-icon="mdi-magnify"
-      class="search ma-0 ml-auto pa-0 flex-grow-0"
-      :class="{
-        'search--hover': hover,
-        'search--hidden': !inputValue && !isFocused && !errorMessage
-      }"
-      :error-messages="errorMessage"
-      clearable
-      label="Search"
-      type="text"
-      hint=" "
-      persistent-hint
-      @click:append-outer="search"
-      @click:clear="clear"
-      @keyup.enter="search"
-      @focus="isFocused = true"
-      @blur="isFocused = false"
-    >
-      <template v-slot:message="{ key, message }">
-        <span>{{ message }}</span>
-        <v-btn href="/search-help" target="_blank" color="primary" text x-small>
-          View search syntax
-          <v-icon x-small right>
-            mdi-help-circle-outline
-          </v-icon>
-        </v-btn>
-      </template>
-    </v-text-field>
-  </v-hover>
+  <v-text-field
+    v-model.trim="inputValue"
+    append-outer-icon="mdi-magnify"
+    class="search ma-0 pa-0 flex-grow-0"
+    :error-messages="errorMessage"
+    clearable
+    label="Search"
+    type="text"
+    hint=" "
+    persistent-hint
+    @click:append-outer="search"
+    @click:clear="clear"
+    @keyup.enter="search"
+    @focus="isFocused = true"
+    @blur="isFocused = false"
+  >
+    <template v-slot:message="{ key, message }">
+      <span>{{ message }}</span>
+      <v-btn href="/search-help" target="_blank" color="primary" text x-small>
+        View search syntax
+        <v-icon x-small right>
+          mdi-help-circle-outline
+        </v-icon>
+      </v-btn>
+    </template>
+  </v-text-field>
 </template>
 
 <script>
@@ -133,28 +127,12 @@ export default {
   }
 };
 </script>
-<style lang="scss">
+<style lang="scss" scoped>
 .search {
-  width: 400px;
+  width: 100%;
+  max-width: 500px;
 
-  &--hidden {
-    width: 33px;
-    transition: width 0.5s;
-
-    ::v-deep .v-text-field__details {
-      max-width: 0;
-      height: 14px;
-    }
-    .v-menu__content {
-      display: none;
-    }
-  }
-
-  &--hover {
-    width: 400px;
-  }
-
-  .v-messages__message {
+  ::v-deep .v-messages__message {
     display: flex;
     justify-content: space-between;
 

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -24,68 +24,110 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -312,68 +354,110 @@ exports[`IndividualsTable Mock query for merge 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -600,68 +684,110 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -888,68 +1014,110 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -1176,68 +1344,110 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -1464,68 +1674,110 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -1829,10 +2081,6 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
     
     </h4>
      
-    <search-stub
-      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
-    />
-     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -1845,6 +2093,15 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
       Add
     
     </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <search-stub
+      class="ma-0 mr-3 pa-0 flex-grow-0"
+    />
   </v-row-stub>
    
   <v-data-table-stub
@@ -2078,10 +2335,6 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
     
     </h4>
      
-    <search-stub
-      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
-    />
-     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -2094,6 +2347,15 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
       Add
     
     </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <search-stub
+      class="ma-0 mr-3 pa-0 flex-grow-0"
+    />
   </v-row-stub>
    
   <v-data-table-stub
@@ -2327,10 +2589,6 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
     
     </h4>
      
-    <search-stub
-      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
-    />
-     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -2343,6 +2601,15 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
       Add
     
     </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <search-stub
+      class="ma-0 mr-3 pa-0 flex-grow-0"
+    />
   </v-row-stub>
    
   <v-data-table-stub
@@ -2576,10 +2843,6 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
     
     </h4>
      
-    <search-stub
-      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
-    />
-     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -2592,6 +2855,15 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
       Add
     
     </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <search-stub
+      class="ma-0 mr-3 pa-0 flex-grow-0"
+    />
   </v-row-stub>
    
   <v-data-table-stub
@@ -2823,10 +3095,6 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
     
     </h4>
      
-    <search-stub
-      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
-    />
-     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -2839,6 +3107,15 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
       Add
     
     </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <search-stub
+      class="ma-0 mr-3 pa-0 flex-grow-0"
+    />
   </v-row-stub>
    
   <v-data-table-stub

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -31,68 +31,110 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -321,68 +363,110 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
     
     </h4>
      
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <v-checkbox-stub
+      backgroundcolor=""
+      errorcount="1"
+      errormessages=""
+      indeterminateicon="$checkboxIndeterminate"
+      label="Select all"
+      messages=""
+      officon="$checkboxOff"
+      onicon="$checkboxOn"
+      ripple="true"
+      rules=""
+      successmessages=""
+      value=""
+      valuecomparator="function deepEqual(a, b) {
+          if (a === b) return true;
+
+          if (a instanceof Date && b instanceof Date && a.getTime() !== b.getTime()) {
+            // If the values are Date, compare them as timestamps
+            return false;
+          }
+
+          if (a !== Object(a) || b !== Object(b)) {
+            // If the values aren't objects, they were already checked for equality
+            return false;
+          }
+
+          var props = Object.keys(a);
+
+          if (props.length !== Object.keys(b).length) {
+            // Different number of props, don't bother to check
+            return false;
+          }
+
+          return props.every(function (p) {
+            return deepEqual(a[p], b[p]);
+          });
+        }"
+    />
+     
     <search-stub
       class="ma-0 ml-auto pa-0 flex-grow-0"
     />
      
-    <div>
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Merge selected
-        </span>
-      </v-tooltip-stub>
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-tooltip-stub
-        bottom="true"
-        closedelay="0"
-        contentclass=""
-        fixed="true"
-        maxwidth="auto"
-        nudgebottom="0"
-        nudgeleft="0"
-        nudgeright="0"
-        nudgetop="0"
-        nudgewidth="0"
-        opendelay="200"
-        openonhover="true"
-        tag="span"
-        transition="expand-y-transition"
-      >
-         
-        <span>
-          Delete selected
-        </span>
-      </v-tooltip-stub>
+      <span>
+        Merge selected
+      </span>
+    </v-tooltip-stub>
+     
+    <v-tooltip-stub
+      bottom="true"
+      closedelay="0"
+      contentclass=""
+      fixed="true"
+      maxwidth="auto"
+      nudgebottom="0"
+      nudgeleft="0"
+      nudgeright="0"
+      nudgetop="0"
+      nudgewidth="0"
+      opendelay="200"
+      openonhover="true"
+      tag="span"
+      transition="expand-y-transition"
+    >
        
-      <v-btn-stub
-        activeclass=""
-        class="black--text"
-        color="secondary"
-        depressed="true"
-        tag="button"
-        type="button"
-      >
-        
-        Add
-      
-      </v-btn-stub>
-    </div>
+      <span>
+        Delete selected
+      </span>
+    </v-tooltip-stub>
   </v-row-stub>
    
   <v-data-table-stub
@@ -639,10 +723,6 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
     
     </h4>
      
-    <search-stub
-      class="ma-0 ml-auto mr-3 pa-0 flex-grow-0"
-    />
-     
     <v-btn-stub
       activeclass=""
       class="black--text"
@@ -655,6 +735,15 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
       Add
     
     </v-btn-stub>
+  </v-row-stub>
+   
+  <v-row-stub
+    class="actions"
+    tag="div"
+  >
+    <search-stub
+      class="ma-0 mr-3 pa-0 flex-grow-0"
+    />
   </v-row-stub>
    
   <v-data-table-stub

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -14,7 +14,7 @@ exports[`Storyshots Avatar Default 1`] = `
       style="height: 40px; min-width: 40px; width: 40px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
     >
       <!---->
-       
+
       <span
         class="white--text"
       >
@@ -43,7 +43,7 @@ exports[`Storyshots Avatar Gravatar 1`] = `
         src="https://www.gravatar.com/avatar/d069902b5862cf6693dad285d7e94a74.jpg?d=blank&s=40"
         style="width: 42px; height: 42px;"
       />
-       
+
       <span
         class="white--text"
       >
@@ -68,7 +68,7 @@ exports[`Storyshots Avatar Single Initial 1`] = `
       style="height: 40px; min-width: 40px; width: 40px; background-color: rgb(0, 161, 86); border-color: #00a156;"
     >
       <!---->
-       
+
       <span
         class="white--text"
       >
@@ -93,15 +93,19 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
       colspan="4"
     >
       <!---->
-       
+
       <!---->
-       
+
       <div
-        class="v-subheader theme--light"
+        class="v-subheader d-flex justify-space-between theme--light"
       >
-        Identities (4)
+        <span>
+          Identities (4)
+        </span>
+
+        <!---->
       </div>
-       
+
       <div
         class="v-data-table v-data-table--dense theme--light"
       >
@@ -116,19 +120,19 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 >
                   Name
                 </th>
-                 
+
                 <th
                   class="text-left"
                 >
                   Email
                 </th>
-                 
+
                 <th
                   class="text-left"
                 >
                   Username
                 </th>
-                 
+
                 <th
                   class="text-left"
                 >
@@ -136,21 +140,21 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 </th>
               </tr>
             </thead>
-             
+
             <tbody>
               <tr>
                 <td>
                   Tom Marvolo Riddle
                 </td>
-                 
+
                 <td>
                   triddle@example.net
                 </td>
-                 
+
                 <td>
                   triddle
                 </td>
-                 
+
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -168,15 +172,15 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   Voldemort
                 </td>
-                 
+
                 <td>
                   -
                 </td>
-                 
+
                 <td>
                   voldemort
                 </td>
-                 
+
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -194,15 +198,15 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   voldemort
                 </td>
-                 
+
                 <td>
                   voldemort@example.net
                 </td>
-                 
+
                 <td>
                   -
                 </td>
-                 
+
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -220,15 +224,15 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   -
                 </td>
-                 
+
                 <td>
                   -
                 </td>
-                 
+
                 <td>
                   voldemort
                 </td>
-                 
+
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -246,13 +250,16 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
           </table>
         </div>
       </div>
-       
+
       <div
-        class="v-subheader theme--light"
+        class="v-subheader d-flex justify-space-between theme--light"
       >
-        Organizations (2)
+
+    Organizations (2)
+
+        <!---->
       </div>
-       
+
       <div
         class="v-data-table v-data-table--dense theme--light"
       >
@@ -267,13 +274,13 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 >
                   Name
                 </th>
-                 
+
                 <th
                   class="text-left"
                 >
                   From
                 </th>
-                 
+
                 <th
                   class="text-left"
                 >
@@ -281,17 +288,17 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 </th>
               </tr>
             </thead>
-             
+
             <tbody>
               <tr>
                 <td>
                   Slytherin
                 </td>
-                 
+
                 <td>
                   1938-09-01
                 </td>
-                 
+
                 <td>
                   1998-05-02
                 </td>
@@ -300,11 +307,11 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   Hogwarts School of Witchcraft and Wizardry
                 </td>
-                 
+
                 <td>
                   1938-09-01
                 </td>
-                 
+
                 <td>
                   1945-06-02
                 </td>
@@ -313,7 +320,7 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
           </table>
         </div>
       </div>
-       
+
       <div
         class="dragged-identity v-card v-sheet theme--dark primary"
       >
@@ -346,7 +353,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
       >
         Profile
       </div>
-       
+
       <div
         class="row indented mb-2 mt"
       >
@@ -356,9 +363,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           <span
             class="grey--text text--darken-2"
           >
-            Gender: 
+            Gender:
           </span>
-           
+
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -368,9 +375,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               <span
                 class="v-small-dialog__activator__content"
               >
-                
+
          -
-        
+
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -381,16 +388,16 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
             <!---->
           </div>
         </div>
-         
+
         <div
           class="ml-6"
         >
           <span
             class="grey--text text--darken-2"
           >
-            Country: 
+            Country:
           </span>
-           
+
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -405,7 +412,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                 >
                   -
                 </span>
-                 
+
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -417,13 +424,33 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           </div>
         </div>
       </div>
-       
+
       <div
-        class="v-subheader theme--light"
+        class="v-subheader d-flex justify-space-between theme--light"
       >
-        Identities (4)
+        <span>
+          Identities (4)
+        </span>
+
+        <button
+          class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
+              style="font-size: 16px;"
+            />
+
+      Split all
+
+          </span>
+        </button>
       </div>
-       
+
       <div
         class="v-list indented v-sheet theme--light v-list--dense row-border"
         role="list"
@@ -447,7 +474,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               />
             </span>
           </div>
-           
+
           <div
             class="v-list-item__content"
           >
@@ -468,14 +495,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-                      
+
           06e6903c91180835b6ee91dd56782c6ca72bc562
-        
+
                     </span>
                   </span>
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -483,7 +510,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Tom Marvolo Riddle
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -491,7 +518,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   triddle@example.net
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -499,7 +526,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   triddle
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -509,7 +536,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -529,7 +556,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -549,7 +576,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           <div
             class="v-list-item__action"
           />
-           
+
           <div
             class="v-list-item__content"
           >
@@ -570,14 +597,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-                      
+
           164e41c60c28698ac30b0d17176d3e720e036918
-        
+
                     </span>
                   </span>
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -585,7 +612,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Voldemort
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -593,7 +620,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -601,7 +628,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -611,7 +638,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -630,7 +657,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -665,7 +692,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               />
             </span>
           </div>
-           
+
           <div
             class="v-list-item__content"
           >
@@ -686,14 +713,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-                      
+
           10982379421b80e13266db011d6e5131dd519016
-        
+
                     </span>
                   </span>
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -701,7 +728,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -709,7 +736,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort@example.net
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -717,7 +744,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -727,7 +754,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -746,7 +773,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -781,7 +808,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               />
             </span>
           </div>
-           
+
           <div
             class="v-list-item__content"
           >
@@ -802,14 +829,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-                      
+
           1f1a9e56dedb45f5969413eeb4442d982e33f0f6
-        
+
                     </span>
                   </span>
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -817,7 +844,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -825,7 +852,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -833,7 +860,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -843,7 +870,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -862,7 +889,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -874,13 +901,32 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           </span>
         </div>
       </div>
-       
+
       <div
-        class="v-subheader theme--light"
+        class="v-subheader d-flex justify-space-between theme--light"
       >
-        Organizations (2)
+
+    Organizations (2)
+
+        <button
+          class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+              style="font-size: 16px;"
+            />
+
+      Remove all
+
+          </span>
+        </button>
       </div>
-       
+
       <div
         class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
@@ -903,7 +949,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Slytherin
                 </span>
               </div>
-               
+
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -916,9 +962,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-                    
+
                   1938-09-01
-                  
+
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -928,7 +974,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-               
+
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -941,9 +987,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-                    
+
                   1998-05-02
-                  
+
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -953,7 +999,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-               
+
               <div
                 class="text-end col-2 col"
               >
@@ -997,7 +1043,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Hogwarts School of Witchcraft and Wizardry
                 </span>
               </div>
-               
+
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -1010,9 +1056,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-                    
+
                   1938-09-01
-                  
+
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1022,7 +1068,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-               
+
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -1035,9 +1081,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-                    
+
                   1945-06-02
-                  
+
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1047,7 +1093,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-               
+
               <div
                 class="text-end col-2 col"
               >
@@ -1074,7 +1120,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           </div>
         </div>
       </div>
-       
+
       <div
         class="dragged-identity v-card v-sheet theme--dark primary"
       >
@@ -1107,7 +1153,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
       >
         Profile
       </div>
-       
+
       <div
         class="row indented mb-2 mt"
       >
@@ -1117,9 +1163,9 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           <span
             class="grey--text text--darken-2"
           >
-            Gender: 
+            Gender:
           </span>
-           
+
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -1129,9 +1175,9 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               <span
                 class="v-small-dialog__activator__content"
               >
-                
+
          -
-        
+
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1142,16 +1188,16 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
             <!---->
           </div>
         </div>
-         
+
         <div
           class="ml-6"
         >
           <span
             class="grey--text text--darken-2"
           >
-            Country: 
+            Country:
           </span>
-           
+
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -1166,7 +1212,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                 >
                   -
                 </span>
-                 
+
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1178,13 +1224,34 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           </div>
         </div>
       </div>
-       
+
       <div
-        class="v-subheader theme--light"
+        class="v-subheader d-flex justify-space-between theme--light"
       >
-        Identities (1)
+        <span>
+          Identities (1)
+        </span>
+
+        <button
+          class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+          disabled="disabled"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
+              style="font-size: 16px;"
+            />
+
+      Split all
+
+          </span>
+        </button>
       </div>
-       
+
       <div
         class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
@@ -1208,7 +1275,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               />
             </span>
           </div>
-           
+
           <div
             class="v-list-item__content"
           >
@@ -1229,14 +1296,14 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                     <span
                       class="v-chip__content"
                     >
-                      
+
           164e41c60c28698ac30b0d17176d3e720e036918
-        
+
                     </span>
                   </span>
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -1244,7 +1311,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                   Hagrid
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -1252,7 +1319,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                   hagrid@example.com
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -1260,7 +1327,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                   hagrid
                 </span>
               </div>
-               
+
               <div
                 class="ma-2 text-center col"
               >
@@ -1270,7 +1337,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               </div>
             </div>
           </div>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -1290,7 +1357,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               </span>
             </button>
           </span>
-           
+
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -1302,18 +1369,38 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           </span>
         </div>
       </div>
-       
+
       <div
-        class="v-subheader theme--light"
+        class="v-subheader d-flex justify-space-between theme--light"
       >
-        Organizations (0)
+
+    Organizations (0)
+
+        <button
+          class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+          disabled="disabled"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+              style="font-size: 16px;"
+            />
+
+      Remove all
+
+          </span>
+        </button>
       </div>
-       
+
       <div
         class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       />
-       
+
       <div
         class="dragged-identity v-card v-sheet theme--dark primary"
       >
@@ -1349,7 +1436,7 @@ exports[`Storyshots ExpandedOrganization Default 1`] = `
         >
           Domains (2)
         </div>
-         
+
         <div
           class="v-list-item theme--light"
           role="listitem"
@@ -1407,7 +1494,7 @@ exports[`Storyshots ExpandedOrganization Empty 1`] = `
         >
           Domains (0)
         </div>
-         
+
       </div>
     </td>
   </div>
@@ -1440,14 +1527,14 @@ exports[`Storyshots Identity Default 1`] = `
             <span
               class="v-chip__content"
             >
-              
+
           1f1a9e56dedb45f5969413eeb4442d982e33f0f6
-        
+
             </span>
           </span>
         </span>
       </div>
-       
+
       <div
         class="ma-2 text-center col"
       >
@@ -1455,7 +1542,7 @@ exports[`Storyshots Identity Default 1`] = `
           Tom Marvolo Riddle
         </span>
       </div>
-       
+
       <div
         class="ma-2 text-center col"
       >
@@ -1463,7 +1550,7 @@ exports[`Storyshots Identity Default 1`] = `
           triddle@example.net
         </span>
       </div>
-       
+
       <div
         class="ma-2 text-center col"
       >
@@ -1471,7 +1558,7 @@ exports[`Storyshots Identity Default 1`] = `
           triddle
         </span>
       </div>
-       
+
       <!---->
     </div>
   </div>
@@ -1504,14 +1591,14 @@ exports[`Storyshots Identity Source 1`] = `
             <span
               class="v-chip__content"
             >
-              
+
           1f1a9e56dedb45f5969413eeb4442d982e33f0f6
-        
+
             </span>
           </span>
         </span>
       </div>
-       
+
       <div
         class="ma-2 text-center col"
       >
@@ -1519,7 +1606,7 @@ exports[`Storyshots Identity Source 1`] = `
           Tom Marvolo Riddle
         </span>
       </div>
-       
+
       <div
         class="ma-2 text-center col"
       >
@@ -1527,7 +1614,7 @@ exports[`Storyshots Identity Source 1`] = `
           triddle@example.net
         </span>
       </div>
-       
+
       <div
         class="ma-2 text-center col"
       >
@@ -1535,7 +1622,7 @@ exports[`Storyshots Identity Source 1`] = `
           triddle
         </span>
       </div>
-       
+
       <div
         class="ma-2 text-center col"
       >
@@ -1574,33 +1661,33 @@ exports[`Storyshots IndividualCard Default 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Tom Marvolo Riddle
-        
+
             <!---->
           </div>
-           
+
           <!---->
-           
+
           <div
             class="v-list-item__subtitle"
           />
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -1623,7 +1710,7 @@ exports[`Storyshots IndividualCard Default 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -1640,7 +1727,7 @@ exports[`Storyshots IndividualCard Default 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -1672,33 +1759,33 @@ exports[`Storyshots IndividualCard Gravatar 1`] = `
             src="https://www.gravatar.com/avatar/d069902b5862cf6693dad285d7e94a74.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             SD
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Santiago Dueñas
-        
+
             <!---->
           </div>
-           
+
           <!---->
-           
+
           <div
             class="v-list-item__subtitle"
           />
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -1721,7 +1808,7 @@ exports[`Storyshots IndividualCard Gravatar 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -1738,7 +1825,7 @@ exports[`Storyshots IndividualCard Gravatar 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -1770,33 +1857,33 @@ exports[`Storyshots IndividualCard Highlighted 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Tom Marvolo Riddle
-        
+
             <!---->
           </div>
-           
+
           <!---->
-           
+
           <div
             class="v-list-item__subtitle"
           />
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -1819,7 +1906,7 @@ exports[`Storyshots IndividualCard Highlighted 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -1836,7 +1923,7 @@ exports[`Storyshots IndividualCard Highlighted 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -1868,33 +1955,33 @@ exports[`Storyshots IndividualCard No Name 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             T
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         triddle@example.net
-        
+
             <!---->
           </div>
-           
+
           <!---->
-           
+
           <div
             class="v-list-item__subtitle"
           />
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -1917,7 +2004,7 @@ exports[`Storyshots IndividualCard No Name 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -1934,7 +2021,7 @@ exports[`Storyshots IndividualCard No Name 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -1966,43 +2053,43 @@ exports[`Storyshots IndividualCard Organization 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Tom Marvolo Riddle
-        
+
             <i
               aria-hidden="true"
               class="v-icon notranslate mb-1 v-icon--right mdi mdi-lock theme--light"
               style="font-size: 16px;"
             />
           </div>
-           
+
           <div
             class="v-list-item__subtitle"
           >
-            
+
         Slytherin
-      
+
           </div>
-           
+
           <div
             class="v-list-item__subtitle"
           />
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -2025,7 +2112,7 @@ exports[`Storyshots IndividualCard Organization 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2042,7 +2129,7 @@ exports[`Storyshots IndividualCard Organization 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -2074,33 +2161,33 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
             src="https://www.gravatar.com/avatar/ea76e4816b86f821de7ae1fdaa409fa6.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             V
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Voldemort
-        
+
             <!---->
           </div>
-           
+
           <!---->
-           
+
           <div
             class="v-list-item__subtitle"
           />
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -2123,7 +2210,7 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2140,7 +2227,7 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -2172,28 +2259,28 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Tom Marvolo Riddle
-        
+
             <!---->
           </div>
-           
+
           <!---->
-           
+
           <div
             class="v-list-item__subtitle"
           >
@@ -2239,7 +2326,7 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             </span>
           </div>
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -2262,7 +2349,7 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2279,7 +2366,7 @@ exports[`Storyshots IndividualCard Sources 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -2311,38 +2398,38 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-           
+
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Tom Marvolo Riddle
-        
+
             <i
               aria-hidden="true"
               class="v-icon notranslate mb-1 v-icon--right mdi mdi-lock theme--light"
               style="font-size: 16px;"
             />
           </div>
-           
+
           <div
             class="v-list-item__subtitle"
           >
-            
+
         Slytherin
-      
+
           </div>
-           
+
           <div
             class="v-list-item__subtitle"
           >
@@ -2388,7 +2475,7 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
             </span>
           </div>
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -2411,7 +2498,7 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2428,7 +2515,7 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
           </button>
         </div>
       </div>
-       
+
     </div>
   </div>
 </div>
@@ -2484,14 +2571,14 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -2507,9 +2594,9 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
+
             Tom Marvolo Riddle
-            
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -2519,7 +2606,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2529,14 +2616,14 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2548,7 +2635,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -2557,7 +2644,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -2570,9 +2657,9 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
+
       triddle@example.com
-      
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -2583,7 +2670,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -2597,7 +2684,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -2614,7 +2701,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -2636,7 +2723,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -2706,14 +2793,14 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -2723,7 +2810,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                       <span>
                         Tom Marvolo Riddle
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2733,14 +2820,14 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                           style="font-size: 16px; display: none;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2752,7 +2839,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -2761,7 +2848,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -2771,7 +2858,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   triddle@example.com
                 </span>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -2785,7 +2872,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -2802,7 +2889,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -2824,7 +2911,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -2894,14 +2981,14 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -2917,9 +3004,9 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
+
             Tom Marvolo Riddle
-            
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -2929,7 +3016,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2939,14 +3026,14 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2958,7 +3045,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -2967,7 +3054,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -2980,9 +3067,9 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
+
       triddle@example.com
-      
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -2993,7 +3080,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -3007,7 +3094,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -3024,7 +3111,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -3046,7 +3133,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3116,14 +3203,14 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                       src="https://www.gravatar.com/avatar/d069902b5862cf6693dad285d7e94a74.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       SD
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -3139,9 +3226,9 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
+
             Santiago Dueñas
-            
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -3151,7 +3238,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3161,14 +3248,14 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3180,16 +3267,16 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
-                      
+
                     </div>
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -3202,9 +3289,9 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
+
       sduenas@bitergia.com
-      
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -3215,7 +3302,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -3229,7 +3316,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -3246,7 +3333,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -3268,7 +3355,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3338,14 +3425,14 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -3361,9 +3448,9 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
+
             Tom Marvolo Riddle
-            
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -3373,7 +3460,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3383,14 +3470,14 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3402,7 +3489,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -3411,7 +3498,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -3424,9 +3511,9 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
+
       triddle@example.com
-      
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -3437,7 +3524,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -3451,7 +3538,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -3468,7 +3555,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -3490,7 +3577,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3560,14 +3647,14 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -3577,7 +3664,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                       <span>
                         Tom Marvolo Riddle
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3587,14 +3674,14 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                           style="font-size: 16px; display: none;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3606,7 +3693,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -3615,7 +3702,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -3625,7 +3712,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   triddle@example.com
                 </span>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -3639,7 +3726,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -3656,7 +3743,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -3678,7 +3765,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3744,14 +3831,14 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     style="height: 40px; min-width: 40px; width: 40px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
                   >
                     <!---->
-                     
+
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -3767,9 +3854,9 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
+
             Tom Marvolo Riddle
-            
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -3779,7 +3866,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3789,14 +3876,14 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3808,7 +3895,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -3817,7 +3904,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -3830,9 +3917,9 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
-      
-      
+
+
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -3843,7 +3930,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -3857,7 +3944,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -3874,7 +3961,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -3896,7 +3983,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3966,14 +4053,14 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       T
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -3989,9 +4076,9 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
-            
-            
+
+
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -4001,7 +4088,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4011,14 +4098,14 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4030,16 +4117,16 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
-                      
+
                     </div>
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -4052,9 +4139,9 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
+
       triddle@example.com
-      
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -4065,7 +4152,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -4079,7 +4166,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -4096,7 +4183,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -4118,7 +4205,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -4188,14 +4275,14 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -4211,9 +4298,9 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
+
             Tom Marvolo Riddle
-            
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -4223,7 +4310,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4233,14 +4320,14 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4252,16 +4339,16 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
-                      
+
                     </div>
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -4274,9 +4361,9 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
+
       triddle@example.com
-      
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -4287,7 +4374,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -4301,7 +4388,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -4318,7 +4405,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -4340,7 +4427,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -4410,14 +4497,14 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                       src="https://www.gravatar.com/avatar/8801bcd41dbffba5928772abf38026fa.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-                     
+
                     <span
                       class="white--text"
                     >
                       V
                     </span>
                   </div>
-                   
+
                   <div
                     class="v-list-item__content"
                   >
@@ -4433,9 +4520,9 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-                            
+
             Voldemort
-            
+
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -4445,7 +4532,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                         </div>
                         <!---->
                       </div>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4455,14 +4542,14 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-                         
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-                       
+
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4474,7 +4561,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                         />
                       </span>
                     </div>
-                     
+
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -4483,7 +4570,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   </div>
                 </div>
               </td>
-               
+
               <td
                 class="text-center"
               >
@@ -4496,9 +4583,9 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-                      
+
       lord.voldemort@example.com
-      
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -4509,7 +4596,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   <!---->
                 </div>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -4523,7 +4610,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 width="140"
               >
@@ -4540,7 +4627,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <div
                   class="v-menu"
                 >
@@ -4562,7 +4649,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -4617,32 +4704,32 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     TR
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Tom Marvolo Riddle
-        
+
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate mb-1 v-icon--right mdi mdi-lock theme--light"
                       style="font-size: 16px;"
                     />
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -4658,7 +4745,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -4681,7 +4768,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -4698,7 +4785,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
           <div
@@ -4717,28 +4804,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(244, 25, 0); border-color: #f41900;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     HP
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Harry Potter
-        
+
                     <!---->
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -4774,7 +4861,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -4797,7 +4884,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -4814,7 +4901,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
           <div
@@ -4833,28 +4920,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 161, 86); border-color: #00a156;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     V
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Voldemort
-        
+
                     <!---->
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -4870,7 +4957,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -4893,7 +4980,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -4910,7 +4997,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
           <div
@@ -4929,28 +5016,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 55, 86); border-color: #003756;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     HG
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Hermione Granger
-        
+
                     <!---->
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -4986,7 +5073,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -5009,7 +5096,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5026,7 +5113,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
           <div
@@ -5045,28 +5132,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 144, 227); border-color: #0090e3;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     AD
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Ambus Dumbledore
-        
+
                     <!---->
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5092,7 +5179,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -5115,7 +5202,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5132,7 +5219,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
           <div
@@ -5151,28 +5238,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 37, 55); border-color: #f52537;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     RW
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Ron Weasley
-        
+
                     <!---->
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5208,7 +5295,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -5231,7 +5318,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5248,7 +5335,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
           <div
@@ -5267,28 +5354,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 37, 55); border-color: #f52537;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     SS
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Severus Snape
-        
+
                     <!---->
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5324,7 +5411,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -5347,7 +5434,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5364,7 +5451,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
           <div
@@ -5383,28 +5470,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 144, 227); border-color: #0090e3;"
                 >
                   <!---->
-                   
+
                   <span
                     class="white--text"
                   >
                     H
                   </span>
                 </div>
-                 
+
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-                    
+
         Hagrid
-        
+
                     <!---->
                   </div>
-                   
+
                   <!---->
-                   
+
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5430,7 +5517,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-                 
+
                 <div
                   class="v-list-item__icon"
                 >
@@ -5453,7 +5540,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-                   
+
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5470,7 +5557,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-               
+
             </div>
           </div>
         </div>
@@ -5525,13 +5612,75 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light black--text"
           />
-          
+
       Individuals (0)
-    
+
         </h4>
-         
+
+        <button
+          class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+
+      Add
+
+          </span>
+        </button>
+      </div>
+
+      <div
+        class="row actions"
+      >
         <div
-          class="v-input search ma-0 ml-auto pa-0 flex-grow-0 ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field search--hidden"
+          class="v-input theme--light v-input--selection-controls v-input--checkbox"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-input--selection-controls__input"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-checkbox-blank-outline theme--light"
+                />
+                <input
+                  aria-checked="false"
+                  id="input-741"
+                  role="checkbox"
+                  type="checkbox"
+                  value=""
+                />
+                <div
+                  class="v-input--selection-controls__ripple"
+                />
+              </div>
+              <label
+                class="v-label theme--light"
+                for="input-741"
+                style="left: 0px; position: relative;"
+              >
+                Select all
+              </label>
+            </div>
+            <div
+              class="v-messages theme--light"
+            >
+              <div
+                class="v-messages__wrapper"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="v-input search ma-0 pa-0 flex-grow-0 ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field"
         >
           <div
             class="v-input__control"
@@ -5582,9 +5731,9 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                     class="v-messages__message"
                   >
                     <span>
-                       
+
                     </span>
-                     
+
                     <a
                       class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                       href="/search-help"
@@ -5593,9 +5742,9 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                       <span
                         class="v-btn__content"
                       >
-                        
-        View search syntax
-        
+
+      View search syntax
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -5622,63 +5771,48 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             </div>
           </div>
         </div>
-         
-        <div>
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <button
-              class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-              disabled="disabled"
-              type="button"
-            >
-              <span
-                class="v-btn__content"
-              >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-call-merge theme--light"
-                />
-              </span>
-            </button>
-          </span>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <button
-              class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-              disabled="disabled"
-              type="button"
-            >
-              <span
-                class="v-btn__content"
-              >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
-                />
-              </span>
-            </button>
-          </span>
-           
+
+        <span
+          class="v-tooltip v-tooltip--bottom"
+        >
+          <!---->
           <button
-            class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
+            class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+            disabled="disabled"
             type="button"
           >
             <span
               class="v-btn__content"
             >
-              
-        Add
-      
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-call-merge theme--light"
+              />
             </span>
           </button>
-        </div>
+        </span>
+
+        <span
+          class="v-tooltip v-tooltip--bottom"
+        >
+          <!---->
+          <button
+            class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+            disabled="disabled"
+            type="button"
+          >
+            <span
+              class="v-btn__content"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-delete theme--light"
+              />
+            </span>
+          </button>
+        </span>
       </div>
-       
+
       <div
         class="v-data-table theme--light"
       >
@@ -5714,7 +5848,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           </table>
         </div>
       </div>
-       
+
       <div
         class="text-center pt-2"
       >
@@ -5752,35 +5886,35 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           </ul>
         </nav>
       </div>
-       
+
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-       
+
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-       
+
       <div
         class="dragged-item v-card v-sheet theme--dark primary"
       >
         <div
           class="v-card__subtitle"
         >
-          
+
       Moving
       0
       individual
-    
+
         </div>
       </div>
-       
+
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -5794,9 +5928,9 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             class="v-snack__content"
             role="status"
           >
-            
-    
-  
+
+
+
           </div>
           <div
             class="v-snack__action "
@@ -5827,13 +5961,13 @@ exports[`Storyshots JobsTable Default 1`] = `
           aria-hidden="true"
           class="v-icon notranslate v-icon--left mdi mdi-tray-full theme--light black--text"
         />
-        
+
     Jobs
-  
+
       </h4>
-       
+
       <!---->
-       
+
       <p
         class="text-subtitle-1"
       >
@@ -5863,13 +5997,13 @@ exports[`Storyshots JobsTable Empty 1`] = `
           aria-hidden="true"
           class="v-icon notranslate v-icon--left mdi mdi-tray-full theme--light black--text"
         />
-        
+
     Jobs
-  
+
       </h4>
-       
+
       <!---->
-       
+
       <p
         class="text-subtitle-1"
       >
@@ -5913,13 +6047,13 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
               >
                 Hogwarts School of Witchcraft and Wizardry
               </td>
-               
+
               <td
                 class="text-right text--secondary"
               >
-                
+
     280
-    
+
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -5931,7 +6065,7 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
                   />
                 </span>
               </td>
-               
+
               <td
                 class="text-right"
               >
@@ -5949,7 +6083,7 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
                   type="button"
@@ -5964,7 +6098,7 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
                     />
                   </span>
                 </button>
-                 
+
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
                   type="button"
@@ -6007,12 +6141,12 @@ exports[`Storyshots OrganizationModal Default 1`] = `
         <span
           class="v-btn__content"
         >
-          
+
       Open Dialog
-    
+
         </span>
       </button>
-       
+
       <div
         class="v-dialog__container"
         l=""
@@ -6044,12 +6178,12 @@ exports[`Storyshots OrganizationModal Error On Save 1`] = `
         <span
           class="v-btn__content"
         >
-          
+
       Open Dialog
-    
+
         </span>
       </button>
-       
+
       <div
         class="v-dialog__container"
         l=""
@@ -6084,13 +6218,30 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-sitemap theme--light black--text"
           />
-          
+
       Organizations (0)
-    
+
         </h4>
-         
+
+        <button
+          class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+
+      Add
+
+          </span>
+        </button>
+      </div>
+
+      <div
+        class="row actions"
+      >
         <div
-          class="v-input search ma-0 ml-auto pa-0 flex-grow-0 ma-0 ml-auto mr-3 pa-0 flex-grow-0 theme--light v-text-field search--hidden"
+          class="v-input search ma-0 pa-0 flex-grow-0 ma-0 mr-3 pa-0 flex-grow-0 theme--light v-text-field"
         >
           <div
             class="v-input__control"
@@ -6103,13 +6254,13 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-956"
+                  for="input-964"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-956"
+                  id="input-964"
                   type="text"
                 />
               </div>
@@ -6141,9 +6292,9 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
                     class="v-messages__message"
                   >
                     <span>
-                       
+
                     </span>
-                     
+
                     <a
                       class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                       href="/search-help"
@@ -6152,9 +6303,9 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
                       <span
                         class="v-btn__content"
                       >
-                        
-        View search syntax
-        
+
+      View search syntax
+
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -6181,21 +6332,8 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
             </div>
           </div>
         </div>
-         
-        <button
-          class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
-          type="button"
-        >
-          <span
-            class="v-btn__content"
-          >
-            
-      Add
-    
-          </span>
-        </button>
       </div>
-       
+
       <div
         class="v-data-table theme--light"
       >
@@ -6228,7 +6366,7 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
           </table>
         </div>
       </div>
-       
+
       <div
         class="text-center pt-2"
       >
@@ -6266,21 +6404,21 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
           </ul>
         </nav>
       </div>
-       
+
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-       
+
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-       
+
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -6294,33 +6432,33 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
             class="v-snack__content"
             role="status"
           >
-            
-    
-  
+
+
+
           </div>
           <div
             class="v-snack__action "
           />
         </div>
       </div>
-       
+
       <div
         class="dragged-organization v-card v-sheet theme--dark primary"
       >
         <div
           class="v-card__title"
         >
-          
-      
-    
+
+
+
         </div>
-         
+
         <div
           class="v-card__subtitle"
         >
-          
+
       Drag and drop on an individual to affiliate
-    
+
         </div>
       </div>
     </div>
@@ -6351,28 +6489,28 @@ exports[`Storyshots ProfileCard Default 1`] = `
           style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
         >
           <!---->
-           
+
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-         
+
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-            
+
         Tom Marvolo Riddle
-        
+
             <!---->
           </div>
-           
+
           <!---->
-           
+
           <div
             class="v-list-item__subtitle"
           >
@@ -6408,7 +6546,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
             </span>
           </div>
         </div>
-         
+
         <div
           class="v-list-item__icon"
         >
@@ -6431,7 +6569,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
             </button>
             <!---->
           </div>
-           
+
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -6448,7 +6586,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
           </button>
         </div>
       </div>
-       
+
       <div
         class="v-list-group"
       >
@@ -6461,9 +6599,9 @@ exports[`Storyshots ProfileCard Default 1`] = `
           <div
             class="v-list-item__title"
           >
-            
+
         Identities (4)
-      
+
           </div>
           <div
             class="v-list-item__icon v-list-group__header__append-icon"
@@ -6476,7 +6614,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
         </div>
         <!---->
       </div>
-       
+
       <div
         class="v-list-group"
       >
@@ -6492,9 +6630,9 @@ exports[`Storyshots ProfileCard Default 1`] = `
             <div
               class="v-list-item__title"
             >
-              
+
           Organizations (2)
-        
+
             </div>
           </div>
           <div
@@ -6532,12 +6670,12 @@ exports[`Storyshots ProfileModal Default 1`] = `
         <span
           class="v-btn__content"
         >
-          
+
       Open Dialog
-    
+
         </span>
       </button>
-       
+
       <div
         class="v-dialog__container"
         role="dialog"
@@ -6559,11 +6697,10 @@ exports[`Storyshots Search Default 1`] = `
     class="v-application--wrap"
   >
     <div
-      class="mx-auto"
-      width="380"
+      class="mx-auto mt-5"
     >
       <div
-        class="v-input search ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field search--hidden"
+        class="v-input search ma-0 pa-0 flex-grow-0 theme--light v-text-field"
       >
         <div
           class="v-input__control"
@@ -6576,13 +6713,13 @@ exports[`Storyshots Search Default 1`] = `
             >
               <label
                 class="v-label theme--light"
-                for="input-1045"
+                for="input-1051"
                 style="left: 0px; position: absolute;"
               >
                 Search
               </label>
               <input
-                id="input-1045"
+                id="input-1051"
                 type="text"
               />
             </div>
@@ -6614,9 +6751,9 @@ exports[`Storyshots Search Default 1`] = `
                   class="v-messages__message"
                 >
                   <span>
-                     
+
                   </span>
-                   
+
                   <a
                     class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                     href="/search-help"
@@ -6625,9 +6762,9 @@ exports[`Storyshots Search Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-                      
-        View search syntax
-        
+
+      View search syntax
+
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -6682,11 +6819,11 @@ exports[`Storyshots WorkSpace Default 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
           />
-          
+
       Workspace
-    
+
         </h3>
-         
+
         <div>
           <span
             class="v-tooltip v-tooltip--bottom"
@@ -6707,7 +6844,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
               </span>
             </button>
           </span>
-           
+
           <span
             class="v-tooltip v-tooltip--left"
           >
@@ -6728,7 +6865,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
           </span>
         </div>
       </div>
-       
+
       <div
         class="row pa-md-4 ma-md-0 drag-zone row--dense"
       >
@@ -6752,34 +6889,34 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                   style="width: 32px; height: 32px;"
                 />
-                 
+
                 <span
                   class="white--text"
                 >
                   TR
                 </span>
               </div>
-               
+
               <div
                 class="v-list-item__content"
               >
                 <div
                   class="v-list-item__title font-weight-medium"
                 >
-                  
+
         Tom Marvolo Riddle
-        
+
                   <!---->
                 </div>
-                 
+
                 <div
                   class="v-list-item__subtitle"
                 >
-                  
+
         Slytherin
-      
+
                 </div>
-                 
+
                 <div
                   class="v-list-item__subtitle"
                 >
@@ -6815,7 +6952,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </span>
                 </div>
               </div>
-               
+
               <div
                 class="v-list-item__icon"
               >
@@ -6838,7 +6975,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                   type="button"
@@ -6855,7 +6992,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                 </button>
               </div>
             </div>
-             
+
           </div>
         </div>
         <div
@@ -6878,34 +7015,34 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   src="https://www.gravatar.com/avatar/176607552753021f97aa6620cbae9795.jpg?d=blank&s=40"
                   style="width: 32px; height: 32px;"
                 />
-                 
+
                 <span
                   class="white--text"
                 >
                   HP
                 </span>
               </div>
-               
+
               <div
                 class="v-list-item__content"
               >
                 <div
                   class="v-list-item__title font-weight-medium"
                 >
-                  
+
         Harry Potter
-        
+
                   <!---->
                 </div>
-                 
+
                 <div
                   class="v-list-item__subtitle"
                 >
-                  
+
         Griffyndor
-      
+
                 </div>
-                 
+
                 <div
                   class="v-list-item__subtitle"
                 >
@@ -6941,7 +7078,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </span>
                 </div>
               </div>
-               
+
               <div
                 class="v-list-item__icon"
               >
@@ -6964,7 +7101,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </button>
                   <!---->
                 </div>
-                 
+
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                   type="button"
@@ -6981,11 +7118,11 @@ exports[`Storyshots WorkSpace Default 1`] = `
                 </button>
               </div>
             </div>
-             
+
           </div>
         </div>
       </div>
-       
+
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -6999,16 +7136,16 @@ exports[`Storyshots WorkSpace Default 1`] = `
             class="v-snack__content"
             role="status"
           >
-            
-    
-  
+
+
+
           </div>
           <div
             class="v-snack__action "
           />
         </div>
       </div>
-       
+
       <div
         class="v-dialog__container"
         role="dialog"
@@ -7044,11 +7181,11 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               aria-hidden="true"
               class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
             />
-            
+
       Workspace
-    
+
           </h3>
-           
+
           <div>
             <span
               class="v-tooltip v-tooltip--bottom"
@@ -7069,7 +7206,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </span>
               </button>
             </span>
-             
+
             <span
               class="v-tooltip v-tooltip--left"
             >
@@ -7091,19 +7228,19 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </span>
           </div>
         </div>
-         
+
         <div
           class="row pa-md-5 ma-md-0 d-flex align-center drag-zone row--dense"
         >
           <p
             class="text--disabled"
           >
-            
+
       Save individuals in your work space to perform actions on them.
-    
+
           </p>
         </div>
-         
+
         <div
           class="v-snack v-snack--bottom v-snack--has-background"
           style="padding-bottom: 0px; padding-top: 0px;"
@@ -7117,16 +7254,16 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               class="v-snack__content"
               role="status"
             >
-              
-    
-  
+
+
+
             </div>
             <div
               class="v-snack__action "
             />
           </div>
         </div>
-         
+
         <div
           class="v-dialog__container"
           role="dialog"
@@ -7134,7 +7271,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           <!---->
         </div>
       </div>
-       
+
       <div
         class="container"
       >
@@ -7148,13 +7285,75 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               aria-hidden="true"
               class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light black--text"
             />
-            
+
       Individuals (0)
-    
+
           </h4>
-           
+
+          <button
+            class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
+            type="button"
+          >
+            <span
+              class="v-btn__content"
+            >
+
+      Add
+
+            </span>
+          </button>
+        </div>
+
+        <div
+          class="row actions"
+        >
           <div
-            class="v-input search ma-0 ml-auto pa-0 flex-grow-0 ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field search--hidden"
+            class="v-input theme--light v-input--selection-controls v-input--checkbox"
+          >
+            <div
+              class="v-input__control"
+            >
+              <div
+                class="v-input__slot"
+              >
+                <div
+                  class="v-input--selection-controls__input"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-checkbox-blank-outline theme--light"
+                  />
+                  <input
+                    aria-checked="false"
+                    id="input-1141"
+                    role="checkbox"
+                    type="checkbox"
+                    value=""
+                  />
+                  <div
+                    class="v-input--selection-controls__ripple"
+                  />
+                </div>
+                <label
+                  class="v-label theme--light"
+                  for="input-1141"
+                  style="left: 0px; position: relative;"
+                >
+                  Select all
+                </label>
+              </div>
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div
+            class="v-input search ma-0 pa-0 flex-grow-0 ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field"
           >
             <div
               class="v-input__control"
@@ -7167,13 +7366,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1136"
+                    for="input-1146"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1136"
+                    id="input-1146"
                     type="text"
                   />
                 </div>
@@ -7205,9 +7404,9 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       class="v-messages__message"
                     >
                       <span>
-                         
+
                       </span>
-                       
+
                       <a
                         class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                         href="/search-help"
@@ -7216,9 +7415,9 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                         <span
                           class="v-btn__content"
                         >
-                          
-        View search syntax
-        
+
+      View search syntax
+
                           <i
                             aria-hidden="true"
                             class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -7245,63 +7444,48 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               </div>
             </div>
           </div>
-           
-          <div>
-            <span
-              class="v-tooltip v-tooltip--bottom"
-            >
-              <!---->
-              <button
-                class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-                disabled="disabled"
-                type="button"
-              >
-                <span
-                  class="v-btn__content"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="v-icon notranslate mdi mdi-call-merge theme--light"
-                  />
-                </span>
-              </button>
-            </span>
-             
-            <span
-              class="v-tooltip v-tooltip--bottom"
-            >
-              <!---->
-              <button
-                class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-                disabled="disabled"
-                type="button"
-              >
-                <span
-                  class="v-btn__content"
-                >
-                  <i
-                    aria-hidden="true"
-                    class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
-                  />
-                </span>
-              </button>
-            </span>
-             
+
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
             <button
-              class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
+              class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+              disabled="disabled"
               type="button"
             >
               <span
                 class="v-btn__content"
               >
-                
-        Add
-      
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-call-merge theme--light"
+                />
               </span>
             </button>
-          </div>
+          </span>
+
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+            <button
+              class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+              disabled="disabled"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-delete theme--light"
+                />
+              </span>
+            </button>
+          </span>
         </div>
-         
+
         <div
           class="v-data-table theme--light"
         >
@@ -7337,7 +7521,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </table>
           </div>
         </div>
-         
+
         <div
           class="text-center pt-2"
         >
@@ -7375,35 +7559,35 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </ul>
           </nav>
         </div>
-         
+
         <div
           class="v-dialog__container"
           role="dialog"
         >
           <!---->
         </div>
-         
+
         <div
           class="v-dialog__container"
           role="dialog"
         >
           <!---->
         </div>
-         
+
         <div
           class="dragged-item v-card v-sheet theme--dark primary"
         >
           <div
             class="v-card__subtitle"
           >
-            
+
       Moving
       0
       individual
-    
+
           </div>
         </div>
-         
+
         <div
           class="v-snack v-snack--bottom v-snack--has-background"
           style="padding-bottom: 0px; padding-top: 0px;"
@@ -7417,9 +7601,9 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               class="v-snack__content"
               role="status"
             >
-              
-    
-  
+
+
+
             </div>
             <div
               class="v-snack__action "
@@ -7455,11 +7639,11 @@ exports[`Storyshots WorkSpace Empty 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
           />
-          
+
       Workspace
-    
+
         </h3>
-         
+
         <div>
           <span
             class="v-tooltip v-tooltip--bottom"
@@ -7480,7 +7664,7 @@ exports[`Storyshots WorkSpace Empty 1`] = `
               </span>
             </button>
           </span>
-           
+
           <span
             class="v-tooltip v-tooltip--left"
           >
@@ -7502,19 +7686,19 @@ exports[`Storyshots WorkSpace Empty 1`] = `
           </span>
         </div>
       </div>
-       
+
       <div
         class="row pa-md-5 ma-md-0 d-flex align-center drag-zone row--dense"
       >
         <p
           class="text--disabled"
         >
-          
+
       Save individuals in your work space to perform actions on them.
-    
+
         </p>
       </div>
-       
+
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -7528,16 +7712,16 @@ exports[`Storyshots WorkSpace Empty 1`] = `
             class="v-snack__content"
             role="status"
           >
-            
-    
-  
+
+
+
           </div>
           <div
             class="v-snack__action "
           />
         </div>
       </div>
-       
+
       <div
         class="v-dialog__container"
         role="dialog"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -14,7 +14,7 @@ exports[`Storyshots Avatar Default 1`] = `
       style="height: 40px; min-width: 40px; width: 40px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
     >
       <!---->
-
+       
       <span
         class="white--text"
       >
@@ -43,7 +43,7 @@ exports[`Storyshots Avatar Gravatar 1`] = `
         src="https://www.gravatar.com/avatar/d069902b5862cf6693dad285d7e94a74.jpg?d=blank&s=40"
         style="width: 42px; height: 42px;"
       />
-
+       
       <span
         class="white--text"
       >
@@ -68,7 +68,7 @@ exports[`Storyshots Avatar Single Initial 1`] = `
       style="height: 40px; min-width: 40px; width: 40px; background-color: rgb(0, 161, 86); border-color: #00a156;"
     >
       <!---->
-
+       
       <span
         class="white--text"
       >
@@ -93,19 +93,19 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
       colspan="4"
     >
       <!---->
-
+       
       <!---->
-
+       
       <div
         class="v-subheader d-flex justify-space-between theme--light"
       >
         <span>
           Identities (4)
         </span>
-
+         
         <!---->
       </div>
-
+       
       <div
         class="v-data-table v-data-table--dense theme--light"
       >
@@ -120,19 +120,19 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 >
                   Name
                 </th>
-
+                 
                 <th
                   class="text-left"
                 >
                   Email
                 </th>
-
+                 
                 <th
                   class="text-left"
                 >
                   Username
                 </th>
-
+                 
                 <th
                   class="text-left"
                 >
@@ -140,21 +140,21 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 </th>
               </tr>
             </thead>
-
+             
             <tbody>
               <tr>
                 <td>
                   Tom Marvolo Riddle
                 </td>
-
+                 
                 <td>
                   triddle@example.net
                 </td>
-
+                 
                 <td>
                   triddle
                 </td>
-
+                 
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -172,15 +172,15 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   Voldemort
                 </td>
-
+                 
                 <td>
                   -
                 </td>
-
+                 
                 <td>
                   voldemort
                 </td>
-
+                 
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -198,15 +198,15 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   voldemort
                 </td>
-
+                 
                 <td>
                   voldemort@example.net
                 </td>
-
+                 
                 <td>
                   -
                 </td>
-
+                 
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -224,15 +224,15 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   -
                 </td>
-
+                 
                 <td>
                   -
                 </td>
-
+                 
                 <td>
                   voldemort
                 </td>
-
+                 
                 <td>
                   <span
                     class="v-tooltip v-tooltip--bottom"
@@ -250,16 +250,16 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
           </table>
         </div>
       </div>
-
+       
       <div
         class="v-subheader d-flex justify-space-between theme--light"
       >
-
+        
     Organizations (2)
-
+    
         <!---->
       </div>
-
+       
       <div
         class="v-data-table v-data-table--dense theme--light"
       >
@@ -274,13 +274,13 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 >
                   Name
                 </th>
-
+                 
                 <th
                   class="text-left"
                 >
                   From
                 </th>
-
+                 
                 <th
                   class="text-left"
                 >
@@ -288,17 +288,17 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 </th>
               </tr>
             </thead>
-
+             
             <tbody>
               <tr>
                 <td>
                   Slytherin
                 </td>
-
+                 
                 <td>
                   1938-09-01
                 </td>
-
+                 
                 <td>
                   1998-05-02
                 </td>
@@ -307,11 +307,11 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
                 <td>
                   Hogwarts School of Witchcraft and Wizardry
                 </td>
-
+                 
                 <td>
                   1938-09-01
                 </td>
-
+                 
                 <td>
                   1945-06-02
                 </td>
@@ -320,7 +320,7 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
           </table>
         </div>
       </div>
-
+       
       <div
         class="dragged-identity v-card v-sheet theme--dark primary"
       >
@@ -353,7 +353,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
       >
         Profile
       </div>
-
+       
       <div
         class="row indented mb-2 mt"
       >
@@ -363,9 +363,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           <span
             class="grey--text text--darken-2"
           >
-            Gender:
+            Gender: 
           </span>
-
+           
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -375,9 +375,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               <span
                 class="v-small-dialog__activator__content"
               >
-
+                
          -
-
+        
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -388,16 +388,16 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
             <!---->
           </div>
         </div>
-
+         
         <div
           class="ml-6"
         >
           <span
             class="grey--text text--darken-2"
           >
-            Country:
+            Country: 
           </span>
-
+           
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -412,7 +412,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                 >
                   -
                 </span>
-
+                 
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -424,14 +424,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           </div>
         </div>
       </div>
-
+       
       <div
         class="v-subheader d-flex justify-space-between theme--light"
       >
         <span>
           Identities (4)
         </span>
-
+         
         <button
           class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
           type="button"
@@ -444,13 +444,13 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
               style="font-size: 16px;"
             />
-
+            
       Split all
-
+    
           </span>
         </button>
       </div>
-
+       
       <div
         class="v-list indented v-sheet theme--light v-list--dense row-border"
         role="list"
@@ -474,7 +474,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               />
             </span>
           </div>
-
+           
           <div
             class="v-list-item__content"
           >
@@ -495,14 +495,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-
+                      
           06e6903c91180835b6ee91dd56782c6ca72bc562
-
+        
                     </span>
                   </span>
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -510,7 +510,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Tom Marvolo Riddle
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -518,7 +518,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   triddle@example.net
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -526,7 +526,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   triddle
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -536,7 +536,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -556,7 +556,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -576,7 +576,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           <div
             class="v-list-item__action"
           />
-
+           
           <div
             class="v-list-item__content"
           >
@@ -597,14 +597,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-
+                      
           164e41c60c28698ac30b0d17176d3e720e036918
-
+        
                     </span>
                   </span>
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -612,7 +612,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Voldemort
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -620,7 +620,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -628,7 +628,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -638,7 +638,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -657,7 +657,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -692,7 +692,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               />
             </span>
           </div>
-
+           
           <div
             class="v-list-item__content"
           >
@@ -713,14 +713,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-
+                      
           10982379421b80e13266db011d6e5131dd519016
-
+        
                     </span>
                   </span>
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -728,7 +728,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -736,7 +736,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort@example.net
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -744,7 +744,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -754,7 +754,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -773,7 +773,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -808,7 +808,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               />
             </span>
           </div>
-
+           
           <div
             class="v-list-item__content"
           >
@@ -829,14 +829,14 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     <span
                       class="v-chip__content"
                     >
-
+                      
           1f1a9e56dedb45f5969413eeb4442d982e33f0f6
-
+        
                     </span>
                   </span>
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -844,7 +844,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -852,7 +852,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   -
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -860,7 +860,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   voldemort
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -870,7 +870,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </div>
             </div>
           </div>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -889,7 +889,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -901,13 +901,13 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           </span>
         </div>
       </div>
-
+       
       <div
         class="v-subheader d-flex justify-space-between theme--light"
       >
-
+        
     Organizations (2)
-
+    
         <button
           class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
           type="button"
@@ -920,13 +920,13 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
               class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
               style="font-size: 16px;"
             />
-
+            
       Remove all
-
+    
           </span>
         </button>
       </div>
-
+       
       <div
         class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
@@ -949,7 +949,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Slytherin
                 </span>
               </div>
-
+               
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -962,9 +962,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-
+                    
                   1938-09-01
-
+                  
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -974,7 +974,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-
+               
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -987,9 +987,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-
+                    
                   1998-05-02
-
+                  
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -999,7 +999,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-
+               
               <div
                 class="text-end col-2 col"
               >
@@ -1043,7 +1043,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   Hogwarts School of Witchcraft and Wizardry
                 </span>
               </div>
-
+               
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -1056,9 +1056,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-
+                    
                   1938-09-01
-
+                  
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1068,7 +1068,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-
+               
               <div
                 class="col-3 ma-2 text-center col"
               >
@@ -1081,9 +1081,9 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                     class="v-small-dialog__activator"
                     role="button"
                   >
-
+                    
                   1945-06-02
-
+                  
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1093,7 +1093,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                   <!---->
                 </div>
               </div>
-
+               
               <div
                 class="text-end col-2 col"
               >
@@ -1120,7 +1120,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           </div>
         </div>
       </div>
-
+       
       <div
         class="dragged-identity v-card v-sheet theme--dark primary"
       >
@@ -1153,7 +1153,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
       >
         Profile
       </div>
-
+       
       <div
         class="row indented mb-2 mt"
       >
@@ -1163,9 +1163,9 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           <span
             class="grey--text text--darken-2"
           >
-            Gender:
+            Gender: 
           </span>
-
+           
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -1175,9 +1175,9 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               <span
                 class="v-small-dialog__activator__content"
               >
-
+                
          -
-
+        
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1188,16 +1188,16 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
             <!---->
           </div>
         </div>
-
+         
         <div
           class="ml-6"
         >
           <span
             class="grey--text text--darken-2"
           >
-            Country:
+            Country: 
           </span>
-
+           
           <div
             class="v-menu v-small-dialog theme--light"
           >
@@ -1212,7 +1212,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                 >
                   -
                 </span>
-
+                 
                 <i
                   aria-hidden="true"
                   class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -1224,14 +1224,14 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           </div>
         </div>
       </div>
-
+       
       <div
         class="v-subheader d-flex justify-space-between theme--light"
       >
         <span>
           Identities (1)
         </span>
-
+         
         <button
           class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
           disabled="disabled"
@@ -1245,13 +1245,13 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
               style="font-size: 16px;"
             />
-
+            
       Split all
-
+    
           </span>
         </button>
       </div>
-
+       
       <div
         class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
@@ -1275,7 +1275,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               />
             </span>
           </div>
-
+           
           <div
             class="v-list-item__content"
           >
@@ -1296,14 +1296,14 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                     <span
                       class="v-chip__content"
                     >
-
+                      
           164e41c60c28698ac30b0d17176d3e720e036918
-
+        
                     </span>
                   </span>
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -1311,7 +1311,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                   Hagrid
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -1319,7 +1319,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                   hagrid@example.com
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -1327,7 +1327,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
                   hagrid
                 </span>
               </div>
-
+               
               <div
                 class="ma-2 text-center col"
               >
@@ -1337,7 +1337,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               </div>
             </div>
           </div>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -1357,7 +1357,7 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -1369,13 +1369,13 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           </span>
         </div>
       </div>
-
+       
       <div
         class="v-subheader d-flex justify-space-between theme--light"
       >
-
+        
     Organizations (0)
-
+    
         <button
           class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
           disabled="disabled"
@@ -1389,18 +1389,18 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
               class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
               style="font-size: 16px;"
             />
-
+            
       Remove all
-
+    
           </span>
         </button>
       </div>
-
+       
       <div
         class="v-list indented v-sheet theme--light v-list--dense"
         role="list"
       />
-
+       
       <div
         class="dragged-identity v-card v-sheet theme--dark primary"
       >
@@ -1436,7 +1436,7 @@ exports[`Storyshots ExpandedOrganization Default 1`] = `
         >
           Domains (2)
         </div>
-
+         
         <div
           class="v-list-item theme--light"
           role="listitem"
@@ -1494,7 +1494,7 @@ exports[`Storyshots ExpandedOrganization Empty 1`] = `
         >
           Domains (0)
         </div>
-
+         
       </div>
     </td>
   </div>
@@ -1527,14 +1527,14 @@ exports[`Storyshots Identity Default 1`] = `
             <span
               class="v-chip__content"
             >
-
+              
           1f1a9e56dedb45f5969413eeb4442d982e33f0f6
-
+        
             </span>
           </span>
         </span>
       </div>
-
+       
       <div
         class="ma-2 text-center col"
       >
@@ -1542,7 +1542,7 @@ exports[`Storyshots Identity Default 1`] = `
           Tom Marvolo Riddle
         </span>
       </div>
-
+       
       <div
         class="ma-2 text-center col"
       >
@@ -1550,7 +1550,7 @@ exports[`Storyshots Identity Default 1`] = `
           triddle@example.net
         </span>
       </div>
-
+       
       <div
         class="ma-2 text-center col"
       >
@@ -1558,7 +1558,7 @@ exports[`Storyshots Identity Default 1`] = `
           triddle
         </span>
       </div>
-
+       
       <!---->
     </div>
   </div>
@@ -1591,14 +1591,14 @@ exports[`Storyshots Identity Source 1`] = `
             <span
               class="v-chip__content"
             >
-
+              
           1f1a9e56dedb45f5969413eeb4442d982e33f0f6
-
+        
             </span>
           </span>
         </span>
       </div>
-
+       
       <div
         class="ma-2 text-center col"
       >
@@ -1606,7 +1606,7 @@ exports[`Storyshots Identity Source 1`] = `
           Tom Marvolo Riddle
         </span>
       </div>
-
+       
       <div
         class="ma-2 text-center col"
       >
@@ -1614,7 +1614,7 @@ exports[`Storyshots Identity Source 1`] = `
           triddle@example.net
         </span>
       </div>
-
+       
       <div
         class="ma-2 text-center col"
       >
@@ -1622,7 +1622,7 @@ exports[`Storyshots Identity Source 1`] = `
           triddle
         </span>
       </div>
-
+       
       <div
         class="ma-2 text-center col"
       >
@@ -1661,33 +1661,33 @@ exports[`Storyshots IndividualCard Default 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Tom Marvolo Riddle
-
+        
             <!---->
           </div>
-
+           
           <!---->
-
+           
           <div
             class="v-list-item__subtitle"
           />
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -1710,7 +1710,7 @@ exports[`Storyshots IndividualCard Default 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -1727,7 +1727,7 @@ exports[`Storyshots IndividualCard Default 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -1759,33 +1759,33 @@ exports[`Storyshots IndividualCard Gravatar 1`] = `
             src="https://www.gravatar.com/avatar/d069902b5862cf6693dad285d7e94a74.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             SD
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Santiago Dueñas
-
+        
             <!---->
           </div>
-
+           
           <!---->
-
+           
           <div
             class="v-list-item__subtitle"
           />
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -1808,7 +1808,7 @@ exports[`Storyshots IndividualCard Gravatar 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -1825,7 +1825,7 @@ exports[`Storyshots IndividualCard Gravatar 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -1857,33 +1857,33 @@ exports[`Storyshots IndividualCard Highlighted 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Tom Marvolo Riddle
-
+        
             <!---->
           </div>
-
+           
           <!---->
-
+           
           <div
             class="v-list-item__subtitle"
           />
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -1906,7 +1906,7 @@ exports[`Storyshots IndividualCard Highlighted 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -1923,7 +1923,7 @@ exports[`Storyshots IndividualCard Highlighted 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -1955,33 +1955,33 @@ exports[`Storyshots IndividualCard No Name 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             T
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         triddle@example.net
-
+        
             <!---->
           </div>
-
+           
           <!---->
-
+           
           <div
             class="v-list-item__subtitle"
           />
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -2004,7 +2004,7 @@ exports[`Storyshots IndividualCard No Name 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2021,7 +2021,7 @@ exports[`Storyshots IndividualCard No Name 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -2053,43 +2053,43 @@ exports[`Storyshots IndividualCard Organization 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Tom Marvolo Riddle
-
+        
             <i
               aria-hidden="true"
               class="v-icon notranslate mb-1 v-icon--right mdi mdi-lock theme--light"
               style="font-size: 16px;"
             />
           </div>
-
+           
           <div
             class="v-list-item__subtitle"
           >
-
+            
         Slytherin
-
+      
           </div>
-
+           
           <div
             class="v-list-item__subtitle"
           />
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -2112,7 +2112,7 @@ exports[`Storyshots IndividualCard Organization 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2129,7 +2129,7 @@ exports[`Storyshots IndividualCard Organization 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -2161,33 +2161,33 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
             src="https://www.gravatar.com/avatar/ea76e4816b86f821de7ae1fdaa409fa6.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             V
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Voldemort
-
+        
             <!---->
           </div>
-
+           
           <!---->
-
+           
           <div
             class="v-list-item__subtitle"
           />
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -2210,7 +2210,7 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2227,7 +2227,7 @@ exports[`Storyshots IndividualCard Single Initial 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -2259,28 +2259,28 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Tom Marvolo Riddle
-
+        
             <!---->
           </div>
-
+           
           <!---->
-
+           
           <div
             class="v-list-item__subtitle"
           >
@@ -2326,7 +2326,7 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             </span>
           </div>
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -2349,7 +2349,7 @@ exports[`Storyshots IndividualCard Sources 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2366,7 +2366,7 @@ exports[`Storyshots IndividualCard Sources 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -2398,38 +2398,38 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
             src="https://www.gravatar.com/avatar/0ffaa7f50f46479b4217df22e203bfce.jpg?d=blank&s=40"
             style="width: 32px; height: 32px;"
           />
-
+           
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Tom Marvolo Riddle
-
+        
             <i
               aria-hidden="true"
               class="v-icon notranslate mb-1 v-icon--right mdi mdi-lock theme--light"
               style="font-size: 16px;"
             />
           </div>
-
+           
           <div
             class="v-list-item__subtitle"
           >
-
+            
         Slytherin
-
+      
           </div>
-
+           
           <div
             class="v-list-item__subtitle"
           >
@@ -2475,7 +2475,7 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
             </span>
           </div>
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -2498,7 +2498,7 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -2515,7 +2515,7 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
           </button>
         </div>
       </div>
-
+       
     </div>
   </div>
 </div>
@@ -2571,14 +2571,14 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -2594,9 +2594,9 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
+                            
             Tom Marvolo Riddle
-
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -2606,7 +2606,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2616,14 +2616,14 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2635,7 +2635,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -2644,7 +2644,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -2657,9 +2657,9 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
+                      
       triddle@example.com
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -2670,7 +2670,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -2684,7 +2684,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -2701,7 +2701,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -2723,7 +2723,7 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -2793,14 +2793,14 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -2810,7 +2810,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                       <span>
                         Tom Marvolo Riddle
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2820,14 +2820,14 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                           style="font-size: 16px; display: none;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -2839,7 +2839,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -2848,7 +2848,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -2858,7 +2858,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   triddle@example.com
                 </span>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -2872,7 +2872,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -2889,7 +2889,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -2911,7 +2911,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -2981,14 +2981,14 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -3004,9 +3004,9 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
+                            
             Tom Marvolo Riddle
-
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -3016,7 +3016,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3026,14 +3026,14 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3045,7 +3045,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -3054,7 +3054,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -3067,9 +3067,9 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
+                      
       triddle@example.com
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -3080,7 +3080,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -3094,7 +3094,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -3111,7 +3111,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -3133,7 +3133,7 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3203,14 +3203,14 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                       src="https://www.gravatar.com/avatar/d069902b5862cf6693dad285d7e94a74.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       SD
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -3226,9 +3226,9 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
+                            
             Santiago Dueñas
-
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -3238,7 +3238,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3248,14 +3248,14 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3267,16 +3267,16 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
-
+                      
                     </div>
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -3289,9 +3289,9 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
+                      
       sduenas@bitergia.com
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -3302,7 +3302,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -3316,7 +3316,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -3333,7 +3333,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -3355,7 +3355,7 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3425,14 +3425,14 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -3448,9 +3448,9 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
+                            
             Tom Marvolo Riddle
-
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -3460,7 +3460,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3470,14 +3470,14 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3489,7 +3489,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -3498,7 +3498,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -3511,9 +3511,9 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
+                      
       triddle@example.com
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -3524,7 +3524,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -3538,7 +3538,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -3555,7 +3555,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -3577,7 +3577,7 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3647,14 +3647,14 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -3664,7 +3664,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                       <span>
                         Tom Marvolo Riddle
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3674,14 +3674,14 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                           style="font-size: 16px; display: none;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3693,7 +3693,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -3702,7 +3702,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -3712,7 +3712,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   triddle@example.com
                 </span>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -3726,7 +3726,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -3743,7 +3743,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -3765,7 +3765,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -3831,14 +3831,14 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     style="height: 40px; min-width: 40px; width: 40px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
                   >
                     <!---->
-
+                     
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -3854,9 +3854,9 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
+                            
             Tom Marvolo Riddle
-
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -3866,7 +3866,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3876,14 +3876,14 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -3895,7 +3895,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -3904,7 +3904,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -3917,9 +3917,9 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
-
-
+                      
+      
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -3930,7 +3930,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -3944,7 +3944,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -3961,7 +3961,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -3983,7 +3983,7 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -4053,14 +4053,14 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       T
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -4076,9 +4076,9 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
-
-
+                            
+            
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -4088,7 +4088,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4098,14 +4098,14 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4117,16 +4117,16 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
-
+                      
                     </div>
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -4139,9 +4139,9 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
+                      
       triddle@example.com
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -4152,7 +4152,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -4166,7 +4166,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -4183,7 +4183,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -4205,7 +4205,7 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -4275,14 +4275,14 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                       src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       TR
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -4298,9 +4298,9 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
+                            
             Tom Marvolo Riddle
-
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -4310,7 +4310,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4320,14 +4320,14 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4339,16 +4339,16 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
-
+                      
                     </div>
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -4361,9 +4361,9 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
+                      
       triddle@example.com
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -4374,7 +4374,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -4388,7 +4388,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -4405,7 +4405,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -4427,7 +4427,7 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -4497,14 +4497,14 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                       src="https://www.gravatar.com/avatar/8801bcd41dbffba5928772abf38026fa.jpg?d=blank&s=40"
                       style="width: 42px; height: 42px;"
                     />
-
+                     
                     <span
                       class="white--text"
                     >
                       V
                     </span>
                   </div>
-
+                   
                   <div
                     class="v-list-item__content"
                   >
@@ -4520,9 +4520,9 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                           <span
                             class="v-small-dialog__activator__content"
                           >
-
+                            
             Voldemort
-
+            
                             <i
                               aria-hidden="true"
                               class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
@@ -4532,7 +4532,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                         </div>
                         <!---->
                       </div>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4542,14 +4542,14 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
-
+                         
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate aligned v-icon--right mdi mdi-robot theme--light"
                           style="font-size: 16px; display: none;"
                         />
                       </span>
-
+                       
                       <span
                         class="v-tooltip v-tooltip--bottom"
                       >
@@ -4561,7 +4561,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                         />
                       </span>
                     </div>
-
+                     
                     <div
                       class="v-list-item__subtitle"
                     >
@@ -4570,7 +4570,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   </div>
                 </div>
               </td>
-
+               
               <td
                 class="text-center"
               >
@@ -4583,9 +4583,9 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                     <span
                       class="v-small-dialog__activator__content"
                     >
-
+                      
       lord.voldemort@example.com
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
@@ -4596,7 +4596,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   <!---->
                 </div>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -4610,7 +4610,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 width="140"
               >
@@ -4627,7 +4627,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <div
                   class="v-menu"
                 >
@@ -4649,7 +4649,7 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -4704,32 +4704,32 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     TR
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Tom Marvolo Riddle
-
+        
                     <i
                       aria-hidden="true"
                       class="v-icon notranslate mb-1 v-icon--right mdi mdi-lock theme--light"
                       style="font-size: 16px;"
                     />
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -4745,7 +4745,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -4768,7 +4768,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -4785,7 +4785,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
           <div
@@ -4804,28 +4804,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(244, 25, 0); border-color: #f41900;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     HP
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Harry Potter
-
+        
                     <!---->
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -4861,7 +4861,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -4884,7 +4884,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -4901,7 +4901,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
           <div
@@ -4920,28 +4920,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 161, 86); border-color: #00a156;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     V
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Voldemort
-
+        
                     <!---->
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -4957,7 +4957,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -4980,7 +4980,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -4997,7 +4997,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
           <div
@@ -5016,28 +5016,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 55, 86); border-color: #003756;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     HG
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Hermione Granger
-
+        
                     <!---->
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5073,7 +5073,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -5096,7 +5096,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5113,7 +5113,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
           <div
@@ -5132,28 +5132,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 144, 227); border-color: #0090e3;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     AD
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Ambus Dumbledore
-
+        
                     <!---->
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5179,7 +5179,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -5202,7 +5202,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5219,7 +5219,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
           <div
@@ -5238,28 +5238,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 37, 55); border-color: #f52537;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     RW
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Ron Weasley
-
+        
                     <!---->
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5295,7 +5295,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -5318,7 +5318,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5335,7 +5335,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
           <div
@@ -5354,28 +5354,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 37, 55); border-color: #f52537;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     SS
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Severus Snape
-
+        
                     <!---->
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5411,7 +5411,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -5434,7 +5434,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5451,7 +5451,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
           <div
@@ -5470,28 +5470,28 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(0, 144, 227); border-color: #0090e3;"
                 >
                   <!---->
-
+                   
                   <span
                     class="white--text"
                   >
                     H
                   </span>
                 </div>
-
+                 
                 <div
                   class="v-list-item__content"
                 >
                   <div
                     class="v-list-item__title font-weight-medium"
                   >
-
+                    
         Hagrid
-
+        
                     <!---->
                   </div>
-
+                   
                   <!---->
-
+                   
                   <div
                     class="v-list-item__subtitle"
                   >
@@ -5517,7 +5517,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </span>
                   </div>
                 </div>
-
+                 
                 <div
                   class="v-list-item__icon"
                 >
@@ -5540,7 +5540,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                     </button>
                     <!---->
                   </div>
-
+                   
                   <button
                     class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                     type="button"
@@ -5557,7 +5557,7 @@ exports[`Storyshots IndividualsGrid Default 1`] = `
                   </button>
                 </div>
               </div>
-
+               
             </div>
           </div>
         </div>
@@ -5612,11 +5612,11 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light black--text"
           />
-
+          
       Individuals (0)
-
+    
         </h4>
-
+         
         <button
           class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
           type="button"
@@ -5624,13 +5624,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           <span
             class="v-btn__content"
           >
-
+            
       Add
-
+    
           </span>
         </button>
       </div>
-
+       
       <div
         class="row actions"
       >
@@ -5652,7 +5652,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 />
                 <input
                   aria-checked="false"
-                  id="input-741"
+                  id="input-744"
                   role="checkbox"
                   type="checkbox"
                   value=""
@@ -5663,7 +5663,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               </div>
               <label
                 class="v-label theme--light"
-                for="input-741"
+                for="input-744"
                 style="left: 0px; position: relative;"
               >
                 Select all
@@ -5678,7 +5678,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             </div>
           </div>
         </div>
-
+         
         <div
           class="v-input search ma-0 pa-0 flex-grow-0 ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field"
         >
@@ -5693,13 +5693,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-737"
+                  for="input-749"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-737"
+                  id="input-749"
                   type="text"
                 />
               </div>
@@ -5731,9 +5731,9 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                     class="v-messages__message"
                   >
                     <span>
-
+                       
                     </span>
-
+                     
                     <a
                       class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                       href="/search-help"
@@ -5742,9 +5742,9 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                       <span
                         class="v-btn__content"
                       >
-
+                        
       View search syntax
-
+      
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -5771,7 +5771,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             </div>
           </div>
         </div>
-
+         
         <span
           class="v-tooltip v-tooltip--bottom"
         >
@@ -5791,7 +5791,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             </span>
           </button>
         </span>
-
+         
         <span
           class="v-tooltip v-tooltip--bottom"
         >
@@ -5812,7 +5812,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           </button>
         </span>
       </div>
-
+       
       <div
         class="v-data-table theme--light"
       >
@@ -5848,7 +5848,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           </table>
         </div>
       </div>
-
+       
       <div
         class="text-center pt-2"
       >
@@ -5886,35 +5886,35 @@ exports[`Storyshots IndividualsTable Default 1`] = `
           </ul>
         </nav>
       </div>
-
+       
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-
+       
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-
+       
       <div
         class="dragged-item v-card v-sheet theme--dark primary"
       >
         <div
           class="v-card__subtitle"
         >
-
+          
       Moving
       0
       individual
-
+    
         </div>
       </div>
-
+       
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -5928,9 +5928,9 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             class="v-snack__content"
             role="status"
           >
-
-
-
+            
+    
+  
           </div>
           <div
             class="v-snack__action "
@@ -5961,13 +5961,13 @@ exports[`Storyshots JobsTable Default 1`] = `
           aria-hidden="true"
           class="v-icon notranslate v-icon--left mdi mdi-tray-full theme--light black--text"
         />
-
+        
     Jobs
-
+  
       </h4>
-
+       
       <!---->
-
+       
       <p
         class="text-subtitle-1"
       >
@@ -5997,13 +5997,13 @@ exports[`Storyshots JobsTable Empty 1`] = `
           aria-hidden="true"
           class="v-icon notranslate v-icon--left mdi mdi-tray-full theme--light black--text"
         />
-
+        
     Jobs
-
+  
       </h4>
-
+       
       <!---->
-
+       
       <p
         class="text-subtitle-1"
       >
@@ -6047,13 +6047,13 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
               >
                 Hogwarts School of Witchcraft and Wizardry
               </td>
-
+               
               <td
                 class="text-right text--secondary"
               >
-
+                
     280
-
+    
                 <span
                   class="v-tooltip v-tooltip--bottom"
                 >
@@ -6065,7 +6065,7 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
                   />
                 </span>
               </td>
-
+               
               <td
                 class="text-right"
               >
@@ -6083,7 +6083,7 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
                   type="button"
@@ -6098,7 +6098,7 @@ exports[`Storyshots OrganizationEntry Default 1`] = `
                     />
                   </span>
                 </button>
-
+                 
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
                   type="button"
@@ -6141,12 +6141,12 @@ exports[`Storyshots OrganizationModal Default 1`] = `
         <span
           class="v-btn__content"
         >
-
+          
       Open Dialog
-
+    
         </span>
       </button>
-
+       
       <div
         class="v-dialog__container"
         l=""
@@ -6178,12 +6178,12 @@ exports[`Storyshots OrganizationModal Error On Save 1`] = `
         <span
           class="v-btn__content"
         >
-
+          
       Open Dialog
-
+    
         </span>
       </button>
-
+       
       <div
         class="v-dialog__container"
         l=""
@@ -6218,11 +6218,11 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-sitemap theme--light black--text"
           />
-
+          
       Organizations (0)
-
+    
         </h4>
-
+         
         <button
           class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
           type="button"
@@ -6230,13 +6230,13 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
           <span
             class="v-btn__content"
           >
-
+            
       Add
-
+    
           </span>
         </button>
       </div>
-
+       
       <div
         class="row actions"
       >
@@ -6254,13 +6254,13 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-964"
+                  for="input-967"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-964"
+                  id="input-967"
                   type="text"
                 />
               </div>
@@ -6292,9 +6292,9 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
                     class="v-messages__message"
                   >
                     <span>
-
+                       
                     </span>
-
+                     
                     <a
                       class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                       href="/search-help"
@@ -6303,9 +6303,9 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
                       <span
                         class="v-btn__content"
                       >
-
+                        
       View search syntax
-
+      
                         <i
                           aria-hidden="true"
                           class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -6333,7 +6333,7 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
           </div>
         </div>
       </div>
-
+       
       <div
         class="v-data-table theme--light"
       >
@@ -6366,7 +6366,7 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
           </table>
         </div>
       </div>
-
+       
       <div
         class="text-center pt-2"
       >
@@ -6404,21 +6404,21 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
           </ul>
         </nav>
       </div>
-
+       
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-
+       
       <div
         class="v-dialog__container"
         role="dialog"
       >
         <!---->
       </div>
-
+       
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -6432,33 +6432,33 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
             class="v-snack__content"
             role="status"
           >
-
-
-
+            
+    
+  
           </div>
           <div
             class="v-snack__action "
           />
         </div>
       </div>
-
+       
       <div
         class="dragged-organization v-card v-sheet theme--dark primary"
       >
         <div
           class="v-card__title"
         >
-
-
-
+          
+      
+    
         </div>
-
+         
         <div
           class="v-card__subtitle"
         >
-
+          
       Drag and drop on an individual to affiliate
-
+    
         </div>
       </div>
     </div>
@@ -6489,28 +6489,28 @@ exports[`Storyshots ProfileCard Default 1`] = `
           style="height: 30px; min-width: 30px; width: 30px; background-color: rgb(245, 142, 12); border-color: #f58e0c;"
         >
           <!---->
-
+           
           <span
             class="white--text"
           >
             TR
           </span>
         </div>
-
+         
         <div
           class="v-list-item__content"
         >
           <div
             class="v-list-item__title font-weight-medium"
           >
-
+            
         Tom Marvolo Riddle
-
+        
             <!---->
           </div>
-
+           
           <!---->
-
+           
           <div
             class="v-list-item__subtitle"
           >
@@ -6546,7 +6546,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
             </span>
           </div>
         </div>
-
+         
         <div
           class="v-list-item__icon"
         >
@@ -6569,7 +6569,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
             </button>
             <!---->
           </div>
-
+           
           <button
             class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
             type="button"
@@ -6586,7 +6586,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
           </button>
         </div>
       </div>
-
+       
       <div
         class="v-list-group"
       >
@@ -6599,9 +6599,9 @@ exports[`Storyshots ProfileCard Default 1`] = `
           <div
             class="v-list-item__title"
           >
-
+            
         Identities (4)
-
+      
           </div>
           <div
             class="v-list-item__icon v-list-group__header__append-icon"
@@ -6614,7 +6614,7 @@ exports[`Storyshots ProfileCard Default 1`] = `
         </div>
         <!---->
       </div>
-
+       
       <div
         class="v-list-group"
       >
@@ -6630,9 +6630,9 @@ exports[`Storyshots ProfileCard Default 1`] = `
             <div
               class="v-list-item__title"
             >
-
+              
           Organizations (2)
-
+        
             </div>
           </div>
           <div
@@ -6670,12 +6670,12 @@ exports[`Storyshots ProfileModal Default 1`] = `
         <span
           class="v-btn__content"
         >
-
+          
       Open Dialog
-
+    
         </span>
       </button>
-
+       
       <div
         class="v-dialog__container"
         role="dialog"
@@ -6713,13 +6713,13 @@ exports[`Storyshots Search Default 1`] = `
             >
               <label
                 class="v-label theme--light"
-                for="input-1051"
+                for="input-1054"
                 style="left: 0px; position: absolute;"
               >
                 Search
               </label>
               <input
-                id="input-1051"
+                id="input-1054"
                 type="text"
               />
             </div>
@@ -6751,9 +6751,9 @@ exports[`Storyshots Search Default 1`] = `
                   class="v-messages__message"
                 >
                   <span>
-
+                     
                   </span>
-
+                   
                   <a
                     class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                     href="/search-help"
@@ -6762,9 +6762,9 @@ exports[`Storyshots Search Default 1`] = `
                     <span
                       class="v-btn__content"
                     >
-
+                      
       View search syntax
-
+      
                       <i
                         aria-hidden="true"
                         class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -6819,11 +6819,11 @@ exports[`Storyshots WorkSpace Default 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
           />
-
+          
       Workspace
-
+    
         </h3>
-
+         
         <div>
           <span
             class="v-tooltip v-tooltip--bottom"
@@ -6844,7 +6844,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--left"
           >
@@ -6865,7 +6865,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
           </span>
         </div>
       </div>
-
+       
       <div
         class="row pa-md-4 ma-md-0 drag-zone row--dense"
       >
@@ -6889,34 +6889,34 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   src="https://www.gravatar.com/avatar/7de6f21c7c424087449be402ae2f2159.jpg?d=blank&s=40"
                   style="width: 32px; height: 32px;"
                 />
-
+                 
                 <span
                   class="white--text"
                 >
                   TR
                 </span>
               </div>
-
+               
               <div
                 class="v-list-item__content"
               >
                 <div
                   class="v-list-item__title font-weight-medium"
                 >
-
+                  
         Tom Marvolo Riddle
-
+        
                   <!---->
                 </div>
-
+                 
                 <div
                   class="v-list-item__subtitle"
                 >
-
+                  
         Slytherin
-
+      
                 </div>
-
+                 
                 <div
                   class="v-list-item__subtitle"
                 >
@@ -6952,7 +6952,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </span>
                 </div>
               </div>
-
+               
               <div
                 class="v-list-item__icon"
               >
@@ -6975,7 +6975,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                   type="button"
@@ -6992,7 +6992,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                 </button>
               </div>
             </div>
-
+             
           </div>
         </div>
         <div
@@ -7015,34 +7015,34 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   src="https://www.gravatar.com/avatar/176607552753021f97aa6620cbae9795.jpg?d=blank&s=40"
                   style="width: 32px; height: 32px;"
                 />
-
+                 
                 <span
                   class="white--text"
                 >
                   HP
                 </span>
               </div>
-
+               
               <div
                 class="v-list-item__content"
               >
                 <div
                   class="v-list-item__title font-weight-medium"
                 >
-
+                  
         Harry Potter
-
+        
                   <!---->
                 </div>
-
+                 
                 <div
                   class="v-list-item__subtitle"
                 >
-
+                  
         Griffyndor
-
+      
                 </div>
-
+                 
                 <div
                   class="v-list-item__subtitle"
                 >
@@ -7078,7 +7078,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </span>
                 </div>
               </div>
-
+               
               <div
                 class="v-list-item__icon"
               >
@@ -7101,7 +7101,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   </button>
                   <!---->
                 </div>
-
+                 
                 <button
                   class="v-btn v-btn--flat v-btn--icon v-btn--round v-btn--text theme--light v-size--default"
                   type="button"
@@ -7118,11 +7118,11 @@ exports[`Storyshots WorkSpace Default 1`] = `
                 </button>
               </div>
             </div>
-
+             
           </div>
         </div>
       </div>
-
+       
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -7136,16 +7136,16 @@ exports[`Storyshots WorkSpace Default 1`] = `
             class="v-snack__content"
             role="status"
           >
-
-
-
+            
+    
+  
           </div>
           <div
             class="v-snack__action "
           />
         </div>
       </div>
-
+       
       <div
         class="v-dialog__container"
         role="dialog"
@@ -7181,11 +7181,11 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               aria-hidden="true"
               class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
             />
-
+            
       Workspace
-
+    
           </h3>
-
+           
           <div>
             <span
               class="v-tooltip v-tooltip--bottom"
@@ -7206,7 +7206,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </span>
               </button>
             </span>
-
+             
             <span
               class="v-tooltip v-tooltip--left"
             >
@@ -7228,19 +7228,19 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </span>
           </div>
         </div>
-
+         
         <div
           class="row pa-md-5 ma-md-0 d-flex align-center drag-zone row--dense"
         >
           <p
             class="text--disabled"
           >
-
+            
       Save individuals in your work space to perform actions on them.
-
+    
           </p>
         </div>
-
+         
         <div
           class="v-snack v-snack--bottom v-snack--has-background"
           style="padding-bottom: 0px; padding-top: 0px;"
@@ -7254,16 +7254,16 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               class="v-snack__content"
               role="status"
             >
-
-
-
+              
+    
+  
             </div>
             <div
               class="v-snack__action "
             />
           </div>
         </div>
-
+         
         <div
           class="v-dialog__container"
           role="dialog"
@@ -7271,7 +7271,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           <!---->
         </div>
       </div>
-
+       
       <div
         class="container"
       >
@@ -7285,11 +7285,11 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               aria-hidden="true"
               class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light black--text"
             />
-
+            
       Individuals (0)
-
+    
           </h4>
-
+           
           <button
             class="black--text v-btn v-btn--depressed theme--light v-size--default secondary"
             type="button"
@@ -7297,13 +7297,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             <span
               class="v-btn__content"
             >
-
+              
       Add
-
+    
             </span>
           </button>
         </div>
-
+         
         <div
           class="row actions"
         >
@@ -7325,7 +7325,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1141"
+                    id="input-1144"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -7336,7 +7336,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1141"
+                  for="input-1144"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -7351,7 +7351,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               </div>
             </div>
           </div>
-
+           
           <div
             class="v-input search ma-0 pa-0 flex-grow-0 ma-0 ml-auto pa-0 flex-grow-0 theme--light v-text-field"
           >
@@ -7366,13 +7366,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1146"
+                    for="input-1149"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1146"
+                    id="input-1149"
                     type="text"
                   />
                 </div>
@@ -7404,9 +7404,9 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       class="v-messages__message"
                     >
                       <span>
-
+                         
                       </span>
-
+                       
                       <a
                         class="v-btn v-btn--flat v-btn--text theme--light v-size--x-small primary--text"
                         href="/search-help"
@@ -7415,9 +7415,9 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                         <span
                           class="v-btn__content"
                         >
-
+                          
       View search syntax
-
+      
                           <i
                             aria-hidden="true"
                             class="v-icon notranslate v-icon--right mdi mdi-help-circle-outline theme--light"
@@ -7444,7 +7444,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               </div>
             </div>
           </div>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -7464,7 +7464,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--bottom"
           >
@@ -7485,7 +7485,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </button>
           </span>
         </div>
-
+         
         <div
           class="v-data-table theme--light"
         >
@@ -7521,7 +7521,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </table>
           </div>
         </div>
-
+         
         <div
           class="text-center pt-2"
         >
@@ -7559,35 +7559,35 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
             </ul>
           </nav>
         </div>
-
+         
         <div
           class="v-dialog__container"
           role="dialog"
         >
           <!---->
         </div>
-
+         
         <div
           class="v-dialog__container"
           role="dialog"
         >
           <!---->
         </div>
-
+         
         <div
           class="dragged-item v-card v-sheet theme--dark primary"
         >
           <div
             class="v-card__subtitle"
           >
-
+            
       Moving
       0
       individual
-
+    
           </div>
         </div>
-
+         
         <div
           class="v-snack v-snack--bottom v-snack--has-background"
           style="padding-bottom: 0px; padding-top: 0px;"
@@ -7601,9 +7601,9 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               class="v-snack__content"
               role="status"
             >
-
-
-
+              
+    
+  
             </div>
             <div
               class="v-snack__action "
@@ -7639,11 +7639,11 @@ exports[`Storyshots WorkSpace Empty 1`] = `
             aria-hidden="true"
             class="v-icon notranslate v-icon--left mdi mdi-pin theme--light black--text"
           />
-
+          
       Workspace
-
+    
         </h3>
-
+         
         <div>
           <span
             class="v-tooltip v-tooltip--bottom"
@@ -7664,7 +7664,7 @@ exports[`Storyshots WorkSpace Empty 1`] = `
               </span>
             </button>
           </span>
-
+           
           <span
             class="v-tooltip v-tooltip--left"
           >
@@ -7686,19 +7686,19 @@ exports[`Storyshots WorkSpace Empty 1`] = `
           </span>
         </div>
       </div>
-
+       
       <div
         class="row pa-md-5 ma-md-0 d-flex align-center drag-zone row--dense"
       >
         <p
           class="text--disabled"
         >
-
+          
       Save individuals in your work space to perform actions on them.
-
+    
         </p>
       </div>
-
+       
       <div
         class="v-snack v-snack--bottom v-snack--has-background"
         style="padding-bottom: 0px; padding-top: 0px;"
@@ -7712,16 +7712,16 @@ exports[`Storyshots WorkSpace Empty 1`] = `
             class="v-snack__content"
             role="status"
           >
-
-
-
+            
+    
+  
           </div>
           <div
             class="v-snack__action "
           />
         </div>
       </div>
-
+       
       <div
         class="v-dialog__container"
         role="dialog"


### PR DESCRIPTION
Adds a checkbox that selects or deselects all individuals on `IndividualsTable` to perform batch operations. 

- Locked individuals can be selected, but they still can't be merged or deleted.
- The action buttons and search boxes on both individuals and organizations tables are moved to a new row to make space for it, so the search box doesn't need to be closed by default.
-  New buttons to split all identities and to remove all affiliations are also added to `ExpandedIndividuals`. They are disabled for locked individuals.

This is a preview of the changes:
![imagen](https://user-images.githubusercontent.com/26812577/109641276-d15c8100-7b51-11eb-9ae7-9e759ea3c650.png)
