### PR TITLE
[ui] Make table items per page editable

### DIFF
--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -67,6 +67,7 @@
       :expanded.sync="expandedItems"
       item-key="uuid"
       :page.sync="page"
+      :items-per-page="itemsPerPage"
     >
       <template v-slot:item="{ item, expand, isExpanded }">
         <individual-entry
@@ -116,13 +117,25 @@
       </template>
     </v-data-table>
 
-    <div class="text-center pt-2">
-      <v-pagination
-        v-model="page"
-        :length="pageCount"
-        :total-visible="7"
-        @input="queryIndividuals($event)"
-      ></v-pagination>
+    <div class="d-flex align-baseline text-center pt-2">
+      <v-col cols="8" class="ml-auto">
+        <v-pagination
+          v-model="page"
+          :length="pageCount"
+          :total-visible="7"
+          @input="queryIndividuals($event)"
+        ></v-pagination>
+      </v-col>
+      <v-col cols="2">
+        <v-text-field
+          :value="itemsPerPage"
+          label="Items per page"
+          type="number"
+          min="1"
+          :max="totalResults"
+          @change="changeItemsPerPage($event)"
+        ></v-text-field>
+      </v-col>
     </div>
 
     <v-dialog v-model="dialog.open" max-width="500px">
@@ -202,11 +215,6 @@ export default {
       type: Function,
       required: true
     },
-    itemsPerPage: {
-      type: Number,
-      required: false,
-      default: 10
-    },
     highlightIndividual: {
       type: String,
       required: false
@@ -273,6 +281,7 @@ export default {
         text: ""
       },
       totalResults: 0,
+      itemsPerPage: 10,
       allSelected: false
     };
   },
@@ -476,6 +485,12 @@ export default {
     },
     selectAll(value) {
       this.individuals.forEach(individual => (individual.isSelected = value));
+    },
+    changeItemsPerPage(value) {
+      if (value) {
+        this.itemsPerPage = parseInt(value, 10);
+        this.queryIndividuals(1);
+      }
     }
   }
 };

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -48,13 +48,21 @@
       </template>
     </v-data-table>
 
-    <div class="text-center pt-2">
+    <div class="pagination d-flex align-baseline text-center pt-2">
       <v-pagination
         v-model="page"
         :length="pageCount"
         :total-visible="5"
         @input="getOrganizations($event)"
       ></v-pagination>
+      <v-text-field
+        :value="itemsPerPage"
+        label="Items per page"
+        type="number"
+        min="1"
+        :max="totalResults"
+        @change="changeItemsPerPage($event)"
+      ></v-text-field>
     </div>
 
     <organization-modal
@@ -122,11 +130,6 @@ export default {
       type: Function,
       required: true
     },
-    itemsPerPage: {
-      type: Number,
-      required: false,
-      default: 10
-    },
     addOrganization: {
       type: Function,
       required: true
@@ -172,7 +175,8 @@ export default {
       },
       selectedOrganization: "",
       filters: {},
-      totalResults: 0
+      totalResults: 0,
+      itemsPerPage: 10
     };
   },
   created() {
@@ -257,6 +261,12 @@ export default {
     filterSearch(filters) {
       this.filters = filters;
       this.getOrganizations(1);
+    },
+    changeItemsPerPage(value) {
+      if (value) {
+        this.itemsPerPage = parseInt(value, 10);
+        this.getOrganizations(1);
+      }
     }
   }
 };
@@ -282,5 +292,16 @@ export default {
   max-width: 400px;
   position: absolute;
   top: -400px;
+}
+
+.pagination {
+  nav {
+    margin-left: 17%;
+    flex-grow: 1;
+  }
+  .v-input {
+    min-width: 17%;
+    max-width: 17%;
+  }
 }
 </style>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -225,20 +225,47 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -555,20 +582,47 @@ exports[`IndividualsTable Mock query for merge 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -885,20 +939,47 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -1215,20 +1296,47 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -1545,20 +1653,47 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -1875,20 +2010,47 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -2199,7 +2361,7 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="pagination d-flex align-baseline text-center pt-2"
   >
     <v-pagination-stub
       currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
@@ -2212,6 +2374,22 @@ exports[`OrganizationsTable Mock mutation for addDomain 1`] = `
       totalvisible="5"
       value="0"
       wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+    />
+     
+    <v-text-field-stub
+      backgroundcolor=""
+      clearicon="$clear"
+      errorcount="1"
+      errormessages=""
+      label="Items per page"
+      loaderheight="2"
+      max="0"
+      messages=""
+      min="1"
+      rules=""
+      successmessages=""
+      type="number"
+      value="10"
     />
   </div>
    
@@ -2453,7 +2631,7 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="pagination d-flex align-baseline text-center pt-2"
   >
     <v-pagination-stub
       currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
@@ -2466,6 +2644,22 @@ exports[`OrganizationsTable Mock mutation for addOrganization 1`] = `
       totalvisible="5"
       value="0"
       wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+    />
+     
+    <v-text-field-stub
+      backgroundcolor=""
+      clearicon="$clear"
+      errorcount="1"
+      errormessages=""
+      label="Items per page"
+      loaderheight="2"
+      max="0"
+      messages=""
+      min="1"
+      rules=""
+      successmessages=""
+      type="number"
+      value="10"
     />
   </div>
    
@@ -2707,7 +2901,7 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="pagination d-flex align-baseline text-center pt-2"
   >
     <v-pagination-stub
       currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
@@ -2720,6 +2914,22 @@ exports[`OrganizationsTable Mock mutation for deleteDomain 1`] = `
       totalvisible="5"
       value="0"
       wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+    />
+     
+    <v-text-field-stub
+      backgroundcolor=""
+      clearicon="$clear"
+      errorcount="1"
+      errormessages=""
+      label="Items per page"
+      loaderheight="2"
+      max="0"
+      messages=""
+      min="1"
+      rules=""
+      successmessages=""
+      type="number"
+      value="10"
     />
   </div>
    
@@ -2961,7 +3171,7 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="pagination d-flex align-baseline text-center pt-2"
   >
     <v-pagination-stub
       currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
@@ -2974,6 +3184,22 @@ exports[`OrganizationsTable Mock mutation for deleteOrganization 1`] = `
       totalvisible="5"
       value="0"
       wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+    />
+     
+    <v-text-field-stub
+      backgroundcolor=""
+      clearicon="$clear"
+      errorcount="1"
+      errormessages=""
+      label="Items per page"
+      loaderheight="2"
+      max="0"
+      messages=""
+      min="1"
+      rules=""
+      successmessages=""
+      type="number"
+      value="10"
     />
   </div>
    
@@ -3213,7 +3439,7 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="pagination d-flex align-baseline text-center pt-2"
   >
     <v-pagination-stub
       currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
@@ -3226,6 +3452,22 @@ exports[`OrganizationsTable Mock mutation for enroll 1`] = `
       totalvisible="5"
       value="0"
       wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+    />
+     
+    <v-text-field-stub
+      backgroundcolor=""
+      clearicon="$clear"
+      errorcount="1"
+      errormessages=""
+      label="Items per page"
+      loaderheight="2"
+      max="0"
+      messages=""
+      min="1"
+      rules=""
+      successmessages=""
+      type="number"
+      value="10"
     />
   </div>
    

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -232,20 +232,47 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -564,20 +591,47 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="d-flex align-baseline text-center pt-2"
   >
-    <v-pagination-stub
-      currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
-      length="0"
-      nextarialabel="$vuetify.pagination.ariaLabel.next"
-      nexticon="$next"
-      pagearialabel="$vuetify.pagination.ariaLabel.page"
-      previcon="$prev"
-      previousarialabel="$vuetify.pagination.ariaLabel.previous"
-      totalvisible="7"
-      value="0"
-      wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
-    />
+    <v-col-stub
+      class="ml-auto"
+      cols="8"
+      tag="div"
+    >
+      <v-pagination-stub
+        currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
+        length="0"
+        nextarialabel="$vuetify.pagination.ariaLabel.next"
+        nexticon="$next"
+        pagearialabel="$vuetify.pagination.ariaLabel.page"
+        previcon="$prev"
+        previousarialabel="$vuetify.pagination.ariaLabel.previous"
+        totalvisible="7"
+        value="0"
+        wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+      />
+    </v-col-stub>
+     
+    <v-col-stub
+      cols="2"
+      tag="div"
+    >
+      <v-text-field-stub
+        backgroundcolor=""
+        clearicon="$clear"
+        errorcount="1"
+        errormessages=""
+        label="Items per page"
+        loaderheight="2"
+        max="0"
+        messages=""
+        min="1"
+        rules=""
+        successmessages=""
+        type="number"
+        value="10"
+      />
+    </v-col-stub>
   </div>
    
   <v-dialog-stub
@@ -841,7 +895,7 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
   />
    
   <div
-    class="text-center pt-2"
+    class="pagination d-flex align-baseline text-center pt-2"
   >
     <v-pagination-stub
       currentpagearialabel="$vuetify.pagination.ariaLabel.currentPage"
@@ -854,6 +908,22 @@ exports[`OrganizationsTable Mock query for getPaginatedOrganizations 1`] = `
       totalvisible="5"
       value="0"
       wrapperarialabel="$vuetify.pagination.ariaLabel.wrapper"
+    />
+     
+    <v-text-field-stub
+      backgroundcolor=""
+      clearicon="$clear"
+      errorcount="1"
+      errormessages=""
+      label="Items per page"
+      loaderheight="2"
+      max="0"
+      messages=""
+      min="1"
+      rules=""
+      successmessages=""
+      type="number"
+      value="10"
     />
   </div>
    

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -5850,41 +5850,90 @@ exports[`Storyshots IndividualsTable Default 1`] = `
       </div>
        
       <div
-        class="text-center pt-2"
+        class="d-flex align-baseline text-center pt-2"
       >
-        <nav
-          aria-label="Pagination Navigation"
-          role="navigation"
+        <div
+          class="ml-auto col col-8"
         >
-          <ul
-            class="v-pagination theme--light"
+          <nav
+            aria-label="Pagination Navigation"
+            role="navigation"
           >
-            <li>
-              <button
-                aria-label="Previous page"
-                class="v-pagination__navigation v-pagination__navigation--disabled"
-                type="button"
+            <ul
+              class="v-pagination theme--light"
+            >
+              <li>
+                <button
+                  aria-label="Previous page"
+                  class="v-pagination__navigation v-pagination__navigation--disabled"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-chevron-left theme--light"
+                  />
+                </button>
+              </li>
+              <li>
+                <button
+                  aria-label="Next page"
+                  class="v-pagination__navigation v-pagination__navigation--disabled"
+                  type="button"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-chevron-right theme--light"
+                  />
+                </button>
+              </li>
+            </ul>
+          </nav>
+        </div>
+         
+        <div
+          class="col col-2"
+        >
+          <div
+            class="v-input v-input--is-label-active v-input--is-dirty theme--light v-text-field"
+          >
+            <div
+              class="v-input__control"
+            >
+              <div
+                class="v-input__slot"
               >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-chevron-left theme--light"
-                />
-              </button>
-            </li>
-            <li>
-              <button
-                aria-label="Next page"
-                class="v-pagination__navigation v-pagination__navigation--disabled"
-                type="button"
+                <div
+                  class="v-text-field__slot"
+                >
+                  <label
+                    class="v-label v-label--active theme--light"
+                    for="input-768"
+                    style="left: 0px; position: absolute;"
+                  >
+                    Items per page
+                  </label>
+                  <input
+                    id="input-768"
+                    max="0"
+                    min="1"
+                    type="number"
+                  />
+                </div>
+              </div>
+              <div
+                class="v-text-field__details"
               >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-chevron-right theme--light"
-                />
-              </button>
-            </li>
-          </ul>
-        </nav>
+                <div
+                  class="v-messages theme--light"
+                >
+                  <div
+                    class="v-messages__wrapper"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
        
       <div
@@ -6254,13 +6303,13 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-967"
+                  for="input-970"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-967"
+                  id="input-970"
                   type="text"
                 />
               </div>
@@ -6368,7 +6417,7 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
       </div>
        
       <div
-        class="text-center pt-2"
+        class="pagination d-flex align-baseline text-center pt-2"
       >
         <nav
           aria-label="Pagination Navigation"
@@ -6403,6 +6452,47 @@ exports[`Storyshots OrganizationsTable Default 1`] = `
             </li>
           </ul>
         </nav>
+         
+        <div
+          class="v-input v-input--is-label-active v-input--is-dirty theme--light v-text-field"
+        >
+          <div
+            class="v-input__control"
+          >
+            <div
+              class="v-input__slot"
+            >
+              <div
+                class="v-text-field__slot"
+              >
+                <label
+                  class="v-label v-label--active theme--light"
+                  for="input-983"
+                  style="left: 0px; position: absolute;"
+                >
+                  Items per page
+                </label>
+                <input
+                  id="input-983"
+                  max="0"
+                  min="1"
+                  type="number"
+                />
+              </div>
+            </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
        
       <div
@@ -6713,13 +6803,13 @@ exports[`Storyshots Search Default 1`] = `
             >
               <label
                 class="v-label theme--light"
-                for="input-1054"
+                for="input-1060"
                 style="left: 0px; position: absolute;"
               >
                 Search
               </label>
               <input
-                id="input-1054"
+                id="input-1060"
                 type="text"
               />
             </div>
@@ -7325,7 +7415,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1144"
+                    id="input-1150"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -7336,7 +7426,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1144"
+                  for="input-1150"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -7366,13 +7456,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1149"
+                    for="input-1155"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1149"
+                    id="input-1155"
                     type="text"
                   />
                 </div>
@@ -7523,41 +7613,90 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
         </div>
          
         <div
-          class="text-center pt-2"
+          class="d-flex align-baseline text-center pt-2"
         >
-          <nav
-            aria-label="Pagination Navigation"
-            role="navigation"
+          <div
+            class="ml-auto col col-8"
           >
-            <ul
-              class="v-pagination theme--light"
+            <nav
+              aria-label="Pagination Navigation"
+              role="navigation"
             >
-              <li>
-                <button
-                  aria-label="Previous page"
-                  class="v-pagination__navigation v-pagination__navigation--disabled"
-                  type="button"
+              <ul
+                class="v-pagination theme--light"
+              >
+                <li>
+                  <button
+                    aria-label="Previous page"
+                    class="v-pagination__navigation v-pagination__navigation--disabled"
+                    type="button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate mdi mdi-chevron-left theme--light"
+                    />
+                  </button>
+                </li>
+                <li>
+                  <button
+                    aria-label="Next page"
+                    class="v-pagination__navigation v-pagination__navigation--disabled"
+                    type="button"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate mdi mdi-chevron-right theme--light"
+                    />
+                  </button>
+                </li>
+              </ul>
+            </nav>
+          </div>
+           
+          <div
+            class="col col-2"
+          >
+            <div
+              class="v-input v-input--is-label-active v-input--is-dirty theme--light v-text-field"
+            >
+              <div
+                class="v-input__control"
+              >
+                <div
+                  class="v-input__slot"
                 >
-                  <i
-                    aria-hidden="true"
-                    class="v-icon notranslate mdi mdi-chevron-left theme--light"
-                  />
-                </button>
-              </li>
-              <li>
-                <button
-                  aria-label="Next page"
-                  class="v-pagination__navigation v-pagination__navigation--disabled"
-                  type="button"
+                  <div
+                    class="v-text-field__slot"
+                  >
+                    <label
+                      class="v-label v-label--active theme--light"
+                      for="input-1174"
+                      style="left: 0px; position: absolute;"
+                    >
+                      Items per page
+                    </label>
+                    <input
+                      id="input-1174"
+                      max="0"
+                      min="1"
+                      type="number"
+                    />
+                  </div>
+                </div>
+                <div
+                  class="v-text-field__details"
                 >
-                  <i
-                    aria-hidden="true"
-                    class="v-icon notranslate mdi mdi-chevron-right theme--light"
-                  />
-                </button>
-              </li>
-            </ul>
-          </nav>
+                  <div
+                    class="v-messages theme--light"
+                  >
+                    <div
+                      class="v-messages__wrapper"
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
          
         <div


### PR DESCRIPTION
Adds an input to the `IndividualsTable` and `OrganizationsTable` footer where users can select how many items per page are shown.