### PR TITLE
[flake8] Fix flake8 errors

### DIFF
--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -114,7 +114,7 @@ DATABASES = {
     }
 }
 
-#FIXTURE_DIRS = "sortinghat/core/fixtures/"
+# FIXTURE_DIRS = "sortinghat/core/fixtures/"
 
 USE_TZ = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 description-file = README.md
 
 [flake8]
-exclude = .git, .eggs, __pycache__, build, dist, docs, docker, migrations
-ignore = E129, E402, F841
+exclude = .git, .eggs, __pycache__, build, dist, docs, docker, migrations, sortinghat/cli/client/schema.py
+ignore = E129, E402, F841, W504 E128 sortinghat/core/schema.py
 max-line-length = 130

--- a/setup.py
+++ b/setup.py
@@ -23,17 +23,13 @@
 
 import codecs
 import os.path
-import re
-import sys
-import unittest
 
 # Always prefer setuptools over distutils
 from setuptools import setup
-from setuptools.command.test import test as TestClass
 
 here = os.path.abspath(os.path.dirname(__file__))
 readme_md = os.path.join(here, 'README.md')
-#version_py = os.path.join(here, 'sortinghat', '_version.py')
+# version_py = os.path.join(here, 'sortinghat', '_version.py')
 
 # Pypi wants the description to be in reStrcuturedText, but
 # we have it in Markdown. So, let's convert formats.
@@ -43,12 +39,11 @@ try:
     import pypandoc
     long_description = pypandoc.convert(readme_md, 'rst')
 except (IOError, ImportError):
-    print("Warning: pypandoc module not found, or pandoc not installed. "
-          + "Using md instead of rst")
+    print("Warning: pypandoc module not found, or pandoc not installed. Using md instead of rst")
     with codecs.open(readme_md, encoding='utf-8') as f:
         long_description = f.read()
 
-#with codecs.open(version_py, 'r', encoding='utf-8') as fd:
+# with codecs.open(version_py, 'r', encoding='utf-8') as fd:
 #    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
 #                        fd.read(), re.MULTILINE).group(1)
 version = '0.8.0-dev'
@@ -62,17 +57,17 @@ setup(name="sortinghat",
       author_email="sduenas@bitergia.com",
       license="GPLv3",
       classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Topic :: Software Development',
-        'License :: OSI Approved :: '
-        'GNU General Public License v3 or later (GPLv3+)',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4'],
+          'Development Status :: 5 - Production/Stable',
+          'Intended Audience :: Developers',
+          'Topic :: Software Development',
+          'License :: OSI Approved :: '
+          'GNU General Public License v3 or later (GPLv3+)',
+          'Programming Language :: Python :: 3',
+          'Programming Language :: Python :: 3.4'],
       keywords="development repositories analytics",
       setup_requires=[
-        'wheel',
-        'pandoc'],
+          'wheel',
+          'pandoc'],
       install_requires=[
       ],
       entry_points="""

--- a/sortinghat/core/api.py
+++ b/sortinghat/core/api.py
@@ -870,15 +870,15 @@ def update_enrollment(ctx, uuid, organization, from_date, to_date,
         raise InvalidValueError(msg="'organization' cannot be an empty string")
     if from_date is None:
         raise InvalidValueError(msg="'from_date' cannot be None")
-    if from_date is '':
+    if from_date == '':
         raise InvalidValueError(msg="'from_date' cannot be empty")
     if to_date is None:
         raise InvalidValueError(msg="'to_date' cannot be None")
-    if to_date is '':
+    if to_date == '':
         raise InvalidValueError(msg="'to_date' cannot be empty")
     if (not new_from_date) and (not new_to_date):
         raise InvalidValueError(msg="'new_from_date' and 'to_from_date' cannot be None at the same time")
-    if (new_from_date is '') and (new_to_date is ''):
+    if (new_from_date == '') and (new_to_date == ''):
         raise InvalidValueError(msg="'new_from_date' and 'to_from_date' cannot be empty at the same time")
 
     # If any of the new dates is not provided, its value will be set as the former date values

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -59,6 +59,7 @@ def find_job(job_id):
 
     return jobs[0]
 
+
 def get_jobs():
     """Get a list of all jobs
 
@@ -72,23 +73,18 @@ def get_jobs():
                     for id
                     in queue.started_job_registry.get_job_ids()]
     deferred_jobs = [find_job(id)
-                    for id
-                    in queue.deferred_job_registry.get_job_ids()]
-    finished_jobs = [find_job(id)
-                    for id
-                    in queue.finished_job_registry.get_job_ids()]
-    failed_jobs = [find_job(id)
-                  for id
-                  in queue.failed_job_registry.get_job_ids()]
-    scheduled_jobs = [find_job(id)
                      for id
-                     in queue.scheduled_job_registry.get_job_ids()]
-    jobs = (queue.jobs
-           + started_jobs
-           + deferred_jobs
-           + finished_jobs
-           + failed_jobs
-           + scheduled_jobs)
+                     in queue.deferred_job_registry.get_job_ids()]
+    finished_jobs = [find_job(id)
+                     for id
+                     in queue.finished_job_registry.get_job_ids()]
+    failed_jobs = [find_job(id)
+                   for id
+                   in queue.failed_job_registry.get_job_ids()]
+    scheduled_jobs = [find_job(id)
+                      for id
+                      in queue.scheduled_job_registry.get_job_ids()]
+    jobs = (queue.jobs + started_jobs + deferred_jobs + finished_jobs + failed_jobs + scheduled_jobs)
 
     sorted_jobs = sorted(jobs, key=lambda x: x.enqueued_at)
 

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -335,6 +335,7 @@ class OperationPaginatedType(AbstractPaginatedType):
     entities = graphene.List(OperationType)
     page_info = graphene.Field(PaginationType)
 
+
 class JobPaginatedType(AbstractPaginatedType):
     entities = graphene.List(JobType)
     page_info = graphene.Field(PaginationType)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2094,7 +2094,6 @@ class TestQueryIndividuals(django.test.TestCase):
         self.assertEqual(indv['mk'], 'c6d2504fde0e34b78a185c4b709e5442d045451c')
         self.assertEqual(indv['profile']['isBot'], False)
 
-
     def test_filter_non_exist_registry(self):
         """Check whether it returns an empty list when searched with a non existing uuid"""
 
@@ -2123,7 +2122,6 @@ class TestQueryIndividuals(django.test.TestCase):
 
         indvs = executed['data']['individuals']['entities']
         self.assertListEqual(indvs, [])
-
 
     def test_filter_gender(self):
         """Check whether it returns the individual searched when using the gender filter"""
@@ -2918,6 +2916,7 @@ class MockJob:
 
     def get_status(self):
         return self.status
+
     def get_id(self):
         return self.id
 


### PR DESCRIPTION
This PR fixes the flake8 errors present in the muggle branch. This is necessary as a flake8 check must be added in the github action ci workflow.

It adds a configuration to ignore some errors of a file as it is hard to understand the logic if we format the file. It also adds a configuration to excludes a file.