### PR TITLE
[gha] Add CI workflow action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: build
+
+on: 
+  push:
+    branches:
+      - muggle
+  pull_request:
+    branches:
+      - muggle
+
+jobs:
+
+  backend:
+    
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      matrix:
+        python-version: [3.6]
+
+    runs-on: ubuntu-latest
+    name: Python ${{ matrix.python-version }}    
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip==18.1 setuptools==49.6.0 wheel
+        pip install -r requirements.txt
+        pip install flake8
+    - name: Set MySQL mode
+      env:
+        DB_HOST: 127.0.0.1
+        DB_PORT: ${{ job.services.mysql.ports[3306] }} 
+      run: |
+        mysql --host $DB_HOST --port $DB_PORT -uroot -proot -e "SET GLOBAL sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
+    - name: Lint with flake8
+      run: flake8 .
+    - name: Tests
+      run: python manage.py test --settings=config.settings.testing
+
+  frontend:
+
+    strategy:
+      matrix:
+        node-version: [12.x, 13.x, 14.x]
+
+    runs-on: ubuntu-latest
+    name: Node ${{ matrix.node-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        working-directory: ./ui
+        run: yarn install
+      - name: Run ESLint
+        working-directory: ./ui
+        run: yarn lint
+      - name: Run unit tests
+        working-directory: ./ui
+        run: yarn test:unit -u

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -12,6 +12,8 @@ if len(sys.argv) > 1 and sys.argv[1] == 'test':
     logging.disable(logging.CRITICAL)
 
 
+SILENCED_SYSTEM_CHECKS = ["django_mysql.E016"]
+
 SECRET_KEY = 'fake-key'
 
 INSTALLED_APPS = [
@@ -34,7 +36,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'USER': 'root',
-        'PASSWORD': '',
+        'PASSWORD': 'root',
         'NAME': 'sortinghat_db',
         'OPTIONS': {
             'charset': 'utf8mb4',
@@ -44,7 +46,9 @@ DATABASES = {
             'NAME': 'testhat',
             'CHARSET': 'utf8mb4',
             'COLLATION': 'utf8mb4_unicode_520_ci',
-        }
+        },
+        'HOST': '127.0.0.1',
+        'PORT': 3306
     }
 }
 


### PR DESCRIPTION
This commit adds the github action ci workflow to the repository. This CI workflow is triggered whenever there is a push or pull_request event to the muggle branch. It runs the test suite of the backend app and the frontend app whenever the workflow is triggered.

The database configuration for the workflow is also updated.

Fixes https://github.com/chaoss/grimoirelab-sortinghat/issues/475.