### PR TITLE
[ui] Add logging messages

### DIFF
--- a/ui/.storybook/preview.js
+++ b/ui/.storybook/preview.js
@@ -2,6 +2,7 @@ import "@mdi/font/css/materialdesignicons.css";
 import Vue from "vue";
 import * as _Vuetify from "vuetify/lib";
 import { configure, addDecorator } from "@storybook/vue";
+import Logger from "../src/plugins/logger";
 
 const Vuetify = _Vuetify.default;
 
@@ -19,6 +20,7 @@ Vue.use(Vuetify, {
     ...VComponents
   }
 });
+Vue.use(Logger);
 
 const VuetifyConfig = new Vuetify({
   icons: {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -51,6 +51,7 @@ export default {
       Cookies.remove("sh_authtoken");
       Cookies.remove("sh_user");
       this.$router.push("/login");
+      this.$logger.info(`Log out user ${this.user}`);
     }
   }
 };

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -364,6 +364,10 @@ export default {
         individuals.map(individual => this.deleteItem(individual.uuid))
       );
       if (response) {
+        this.$logger.debug(
+          "Deleted individuals",
+          individuals.map(individual => individual.uuid)
+        );
         this.queryIndividuals(this.page);
         this.dialog.open = false;
       }
@@ -387,6 +391,7 @@ export default {
           update: formatIndividuals([response.data.merge.individual]),
           remove: fromUuids
         });
+        this.$logger.debug("Merged individuals", { fromUuids, toUuid });
       }
     },
     mergeSelected(individuals) {
@@ -402,6 +407,7 @@ export default {
         );
         this.$emit("saveIndividual", unmergedItems[0]);
         this.queryIndividuals(this.page);
+        this.$logger.debug("Unmerged individuals", uuids);
       }
     },
     move(event) {
@@ -415,6 +421,7 @@ export default {
         this.$emit("updateWorkspace", {
           update: formatIndividuals([response.data.moveIdentity.individual])
         });
+        this.$logger.debug("Moved identity", { fromUuid, toUuid });
       }
     },
     async updateProfileInfo(data, uuid) {
@@ -425,6 +432,7 @@ export default {
           this.$emit("updateWorkspace", {
             update: formatIndividuals([response.data.updateProfile.individual])
           });
+          this.$logger.debug(`Updated profile ${uuid}`, data);
         }
       } catch (error) {
         Object.assign(this.snackbar, { open: true, text: error });
@@ -436,18 +444,22 @@ export default {
           const response = await this.lockIndividual(uuid);
           if (response) {
             this.queryIndividuals();
+            this.$logger.debug(`Locked individual ${uuid}`);
           }
         } catch (error) {
           Object.assign(this.snackbar, { open: true, text: error });
+          this.$logger.error(`Error locking individual ${uuid}: ${error}`);
         }
       } else {
         try {
           const response = await this.unlockIndividual(uuid);
           if (response) {
             this.queryIndividuals();
+            this.$logger.debug(`Unlocked individual ${uuid}`);
           }
         } catch (error) {
           Object.assign(this.snackbar, { open: true, text: error });
+          this.$logger.error(`Error unlocking individual ${uuid}: ${error}`);
         }
       }
     },
@@ -464,9 +476,14 @@ export default {
           this.$emit("updateWorkspace", {
             update: formatIndividuals([response.data.withdraw.individual])
           });
+          this.$logger.debug("Removed affiliation", { uuid, ...organization });
         }
       } catch (error) {
         Object.assign(this.snackbar, { open: true, text: error });
+        this.$logger.error(`Error removing affiliation: ${error}`, {
+          uuid,
+          ...organization
+        });
       }
     },
     async updateEnrollmentDate(data) {
@@ -479,9 +496,11 @@ export default {
             ])
           });
           this.queryIndividuals();
+          this.$logger.debug("Updated enrollment", data);
         }
       } catch (error) {
         Object.assign(this.snackbar, { open: true, text: error });
+        this.$logger.error(`Error updating enrollment: ${error}`, data);
       }
     },
     filterSearch(filters) {

--- a/ui/src/components/OrganizationModal.vue
+++ b/ui/src/components/OrganizationModal.vue
@@ -119,6 +119,7 @@ export default {
           const response = await this.addOrganization(this.form.name);
           if (response && !response.error) {
             this.savedData.name = this.form.name;
+            this.$logger.debug(`Added organization ${this.form.name}`);
             if (
               this.form.domains.length === 0 &&
               this.savedData.domains.length === 0
@@ -163,18 +164,30 @@ export default {
         }
       } catch (error) {
         this.errorMessage = error;
+        this.$logger.error(`Error updating domains: ${error}`, {
+          organization: this.form.name,
+          newDomains,
+          deletedDomains
+        });
       }
     },
     async addOrganizationDomain(domain, organization) {
       const response = await this.addDomain(domain, organization);
       if (response && !response.error) {
         this.savedData.domains.push(domain);
+        this.$logger.debug("Added domain", { domain, organization });
         return response;
+      } else if (response.errors) {
+        this.$logger.error(
+          `Error adding domain: ${response.errors[0].message}`,
+          { domain, organization }
+        );
       }
     },
     async deleteOrganizationDomain(domain) {
       const response = await this.deleteDomain(domain);
       if (response) {
+        this.$logger.debug(`Deleted domain ${domain}`);
         return response;
       }
     },

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -220,9 +220,14 @@ export default {
             });
           });
           this.$emit("updateIndividuals");
+          this.$logger.debug("Enrolled individuals", { organization, uuids });
         }
       } catch (error) {
         Object.assign(this.snackbar, { open: true, text: error });
+        this.$logger.error(`Error enrolling individuals: ${error}`, {
+          organization,
+          uuids
+        });
       }
     },
     openModal(organization) {
@@ -251,9 +256,13 @@ export default {
         if (response) {
           this.getOrganizations(this.page);
           this.$emit("updateIndividuals");
+          this.$logger.debug(`Deleted organization ${organization}`);
         }
       } catch (error) {
         Object.assign(this.snackbar, { open: true, text: error });
+        this.$logger.error(
+          `Error deleting organization ${organization}: ${error}`
+        );
       }
     },
     startDrag(item, event) {

--- a/ui/src/components/ProfileModal.vue
+++ b/ui/src/components/ProfileModal.vue
@@ -294,37 +294,48 @@ export default {
       }
     },
     async createIndividual() {
+      const data = {
+        email: this.profileForm.email === "" ? null : this.profileForm.email,
+        name: this.profileForm.name === "" ? null : this.profileForm.name,
+        source: this.profileForm.source,
+        username:
+          this.profileForm.username === "" ? null : this.profileForm.username
+      };
       try {
         const response = await this.addIdentity(
-          this.profileForm.email === "" ? null : this.profileForm.email,
-          this.profileForm.name === "" ? null : this.profileForm.name,
-          this.profileForm.source,
-          this.profileForm.username === "" ? null : this.profileForm.username
+          data.email,
+          data.name,
+          data.source,
+          data.username
         );
         if (response && response.data.addIdentity) {
           this.savedData.individual = response.data.addIdentity.uuid;
+          this.$logger.debug("Added identity", data);
           return this.savedData.individual;
         }
       } catch (error) {
         this.errorMessage = error;
+        this.$logger.error(`Error adding identity: ${error}`, data);
       }
     },
     async addProfileInfo(uuid) {
+      const data = {
+        gender: this.profileForm.gender,
+        countryCode: this.profileForm.country
+          ? this.profileForm.country.code
+          : null,
+        isBot: this.profileForm.isBot
+      };
       try {
-        const data = {
-          gender: this.profileForm.gender,
-          countryCode: this.profileForm.country
-            ? this.profileForm.country.code
-            : null,
-          isBot: this.profileForm.isBot
-        };
         const response = await this.updateProfile(data, uuid);
         if (response && response.data.updateProfile) {
           this.savedData.profile = response.data.updateProfile;
+          this.$logger.debug(`Updated individual ${uuid} profile`, data);
           return this.savedData.profile;
         }
       } catch (error) {
         this.errorMessage = error;
+        this.$logger.error(`Error updating profile ${uuid}: ${error}`, data);
       }
     },
     async addEnrollments() {
@@ -344,6 +355,15 @@ export default {
                 fromDate,
                 toDate
               );
+              this.$logger.debug(
+                `Enrolled individual ${this.savedData.individual}`,
+                {
+                  uuid: this.savedData.individual,
+                  organization: enrollment.organization,
+                  fromDate,
+                  toDate
+                }
+              );
               return response;
             }
           })
@@ -353,6 +373,10 @@ export default {
         }
       } catch (error) {
         this.errorMessage = error;
+        this.$logger.error(
+          `Error enrolling individual ${this.savedData.individual}: ${error}`,
+          this.enrollmentsForm
+        );
       }
     },
     async getCountryList() {

--- a/ui/src/components/WorkSpace.vue
+++ b/ui/src/components/WorkSpace.vue
@@ -198,6 +198,7 @@ export default {
           fromUuids
         );
         this.$emit("updateIndividuals");
+        this.$logger.debug("Merged individuals", { fromUuids, toUuid });
       }
       this.dialog.open = false;
     },
@@ -239,12 +240,14 @@ export default {
             [fromUuid]
           );
           this.$emit("updateIndividuals");
+          this.$logger.debug("Moved identity", { fromUuid, toUuid });
         }
       } catch (error) {
         Object.assign(this.snackbar, {
           open: true,
           text: error
         });
+        this.$logger.error("Error merging individuals", { fromUuid, toUuid });
       }
     },
     onDrag(event) {

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -10,6 +10,7 @@ import { createHttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import Cookies from "js-cookie";
 import { ApolloLink } from "apollo-link";
+import Logger from "./plugins/logger";
 
 // Force HTTP GET to the Django Server for getting the csrf token
 let xmlHttp = new XMLHttpRequest();
@@ -52,6 +53,7 @@ const apolloClient = new ApolloClient({
 
 Vue.use(VueApollo);
 Vue.use(VueRouter);
+Vue.use(Logger);
 
 const apolloProvider = new VueApollo({
   defaultClient: apolloClient

--- a/ui/src/plugins/logger.js
+++ b/ui/src/plugins/logger.js
@@ -1,0 +1,18 @@
+export default {
+  install(Vue) {
+    function log(type, message, ...args) {
+      if (process.env.NODE_ENV === "production") {
+        return;
+      }
+      console[type](message, ...args);
+    }
+
+    Vue.prototype.$logger = {
+      error: (message, ...rest) => log("error", message, ...rest),
+      debug: (message, ...rest) => log("debug", message, ...rest),
+      log: (message, ...rest) => log("log", message, ...rest),
+      info: (message, ...rest) => log("info", message, ...rest),
+      warn: (message, ...rest) => log("warn", message, ...rest)
+    };
+  }
+};

--- a/ui/src/plugins/logger.js
+++ b/ui/src/plugins/logger.js
@@ -1,7 +1,7 @@
 export default {
   install(Vue) {
     function log(type, message, ...args) {
-      if (process.env.NODE_ENV === "production") {
+      if (process.env.NODE_ENV === "production" && type === "debug") {
         return;
       }
       console[type](message, ...args);

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -59,9 +59,11 @@ export default {
         const response = await this.login(authDetails);
         if (response) {
           this.$router.push("/");
+          this.$logger.info(`Log in user ${this.username}`);
         }
       } catch (error) {
         this.errorMessage = error;
+        this.$logger.error(`Error logging in user ${this.username}: ${error}`);
       }
     }
   }

--- a/ui/tests/unit/logger.spec.js
+++ b/ui/tests/unit/logger.spec.js
@@ -1,0 +1,53 @@
+import Logger from "@/plugins/logger";
+import { createLocalVue } from "@vue/test-utils";
+
+describe("Logger plugin", () => {
+  const localVue = createLocalVue();
+  localVue.use(Logger);
+
+  // Mock console functions to prevent the tests from printing the messages
+  jest.spyOn(console, "error").mockImplementation(jest.fn());
+  jest.spyOn(console, "debug").mockImplementation(jest.fn());
+  jest.spyOn(console, "log").mockImplementation(jest.fn());
+  jest.spyOn(console, "info").mockImplementation(jest.fn());
+  jest.spyOn(console, "warn").mockImplementation(jest.fn());
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Logs error message", () => {
+    localVue.prototype.$logger.error("Test error message");
+
+    expect(console.error.mock.calls.length).toBe(1);
+    expect(console.error.mock.calls[0][0]).toBe("Test error message");
+  });
+
+  test("Logs debug message", () => {
+    localVue.prototype.$logger.debug("Test debug message");
+
+    expect(console.debug.mock.calls.length).toBe(1);
+    expect(console.debug.mock.calls[0][0]).toBe("Test debug message");
+  });
+
+  test("Logs default message", () => {
+    localVue.prototype.$logger.log("Test default message");
+
+    expect(console.log.mock.calls.length).toBe(1);
+    expect(console.log.mock.calls[0][0]).toBe("Test default message");
+  });
+
+  test("Logs info message", () => {
+    localVue.prototype.$logger.info("Test info message");
+
+    expect(console.info.mock.calls.length).toBe(1);
+    expect(console.info.mock.calls[0][0]).toBe("Test info message");
+  });
+
+  test("Logs warning message", () => {
+    localVue.prototype.$logger.warn("Test warning message");
+
+    expect(console.warn.mock.calls.length).toBe(1);
+    expect(console.warn.mock.calls[0][0]).toBe("Test warning message");
+  });
+})


### PR DESCRIPTION
Logs a message to the console when the following operations are performed, including the values that were changed:
- Add identity
- Move identity
- Update profile
- Enroll in organization
- Update enrollment
- Remove enrollment
- Merge identities
- Split identities
- Delete identity
- Add organization
- Add domain
- Remove domain
- Log in/out

The logs are not shown in production mode (when running `yarn serve --mode production`, for example).