### PR TITLE
[schema] Return error when job has failed

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -937,6 +937,8 @@ class SortingHatQuery:
             result = [
                 UnifyResultType(merged=job.result['results'])
             ]
+        elif status == 'failed':
+            errors = [job.exc_info]
 
         return JobType(job_id=job_id,
                        job_type=job_type,


### PR DESCRIPTION
When querying for a failed job, returns the error log from the `exec_info` attribute instead of from the empty `result`.
Fixes #487.