### PR TITLE
[schema] Remove deprecated 'delete_individual' parameter

### DIFF
--- a/sortinghat/cli/client/schema.py
+++ b/sortinghat/cli/client/schema.py
@@ -490,7 +490,6 @@ class SortingHatMutation(sgqlc.types.Type):
     )
     delete_identity = sgqlc.types.Field(
         DeleteIdentity, graphql_name='deleteIdentity', args=sgqlc.types.ArgDict((
-            ('delete_individual', sgqlc.types.Arg(Boolean, graphql_name='deleteIndividual', default=None)),
             ('uuid', sgqlc.types.Arg(String, graphql_name='uuid', default=None)),
         ))
     )

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -453,7 +453,6 @@ class AddIdentity(graphene.Mutation):
 class DeleteIdentity(graphene.Mutation):
     class Arguments:
         uuid = graphene.String()
-        delete_individual = graphene.Boolean()
 
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)


### PR DESCRIPTION
This parameter is not available anymore to remove individuals. Individuals or identities are removed when their uuid is given
when 'deleteIdentity' mutation is called.