### PR TITLE
Pin PyJWT to 1.7.1 to fix incompatibility problem with django-graphql-jwt

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -341,17 +341,16 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pyjwt"
-version = "2.0.1"
+version = "1.7.1"
 description = "JSON Web Token implementation in Python"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = "*"
 
 [package.extras]
-crypto = ["cryptography (>=3.3.1,<4.0.0)"]
-dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1,<4.0.0)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
+crypto = ["cryptography (>=1.4)"]
+flake8 = ["flake8", "flake8-import-order", "pep8-naming"]
+test = ["pytest (>=4.0.1,<5.0.0)", "pytest-cov (>=2.6.0,<3.0.0)", "pytest-runner (>=4.2,<5.0.0)"]
 
 [[package]]
 name = "python-dateutil"
@@ -532,7 +531,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "934320cdf8a9efcee78bf6d77c020160cb86c9fe76d75ae6dc42592b12019549"
+content-hash = "0ff3fbf97a1d33cc67245de53435dc81b362fb3de5f490433ed55397a3646c38"
 
 [metadata.files]
 aniso8601 = [
@@ -749,8 +748,8 @@ pyflakes = [
     {file = "pyflakes-2.3.0.tar.gz", hash = "sha256:e59fd8e750e588358f1b8885e5a4751203a0516e0ee6d34811089ac294c8806f"},
 ]
 pyjwt = [
-    {file = "PyJWT-2.0.1-py3-none-any.whl", hash = "sha256:b70b15f89dc69b993d8a8d32c299032d5355c82f9b5b7e851d1a6d706dffe847"},
-    {file = "PyJWT-2.0.1.tar.gz", hash = "sha256:a5c70a06e1f33d81ef25eecd50d50bd30e34de1ca8b2b9fa3fe0daaabcf69bf7"},
+    {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},
+    {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ django-rq = "^2.3.2"
 pandas = "^1.0.5"
 grimoirelab_toolkit = "^0.1.8"
 django-cors-headers = "^3.7.0"
+PyJWT = "1.7.1"
 
 [tool.poetry.dev-dependencies]
 fakeredis = "^1.4.1"


### PR DESCRIPTION
The package "django-graphql-jwt" is incomatible with the latest version of PyJWT (2.0.1). This raises an error when the mutation "totenAuth" is called because django-graphql-jwt is calling PyJWT API incorrectly. This patch fixes the problem reported in #496.

Without this version the next mutation raised an error:

```
mutation tokenAuth {
  tokenAuth(username:"root", password:"*******") {
  	token
  }
}
```
```

  "errors": [
    {
      "message": "'str' object has no attribute 'decode'",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "tokenAuth"
      ],
      "extensions": {
        "code": 128
      }
    }
  ],
  "data": {
    "tokenAuth": null
  }
}

```

Now it returns something like:

```
{
  "data": {
    "tokenAuth": {
      "token": "************************"
    }
  }
}
```
