### PR TITLE
Fix integrity issues

### DIFF
--- a/sortinghat/core/log.py
+++ b/sortinghat/core/log.py
@@ -105,7 +105,7 @@ class TransactionsLog:
                           authored_by=username)
 
         try:
-            trx.save()
+            trx.save(force_insert=True)
         except django.db.utils.IntegrityError as exc:
             _handle_integrity_error(Transaction, exc)
 
@@ -155,7 +155,7 @@ class TransactionsLog:
                               entity_type=entity_type, timestamp=timestamp, args=args_dump)
 
         try:
-            operation.save()
+            operation.save(force_insert=True)
         except django.db.utils.IntegrityError as exc:
             _handle_integrity_error(Operation, exc)
 


### PR DESCRIPTION
This PR fixes some integrity issues that we have in the code. First, it fixes a bug which causes to overwrite log objects if the same id is used. Second, it adds a unit test to check if enrollments  with the same data can be inserted twice.