### PR TITLE
Order individuals by createdAt field

### DIFF
--- a/sortinghat/core/models.py
+++ b/sortinghat/core/models.py
@@ -176,7 +176,7 @@ class Individual(EntityBase):
 
     class Meta:
         db_table = 'individuals'
-        ordering = ('last_modified',)
+        ordering = ('last_modified', 'created_at',)
 
     def __str__(self):
         return self.mk

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2491,6 +2491,53 @@ class TestQueryIndividuals(django.test.TestCase):
         indv = individuals[2]
         self.assertEqual(indv['mk'], indv1.mk)
 
+    def test_order_by_created_at(self):
+        """Check whether it returns the individuals ordered by their creation date"""
+
+        indv1 = Individual.objects.create(mk='a9b403e150dd4af8953a52a4bb841051e4b705d9')
+        indv2 = Individual.objects.create(mk='185c4b709e5446d250b4fde0e34b78a2b4fde0e3')
+        indv3 = Individual.objects.create(mk='c6d2504fde0e34b78a185c4b709e5442d045451c')
+
+        # Test default order by mk
+        client = graphene.test.Client(schema)
+        executed = client.execute(SH_INDIVIDUALS_ORDER_BY % 'mk',
+                                  context_value=self.context_value)
+
+        individuals = executed['data']['individuals']['entities']
+
+        indv = individuals[0]
+        self.assertEqual(indv['mk'], indv2.mk)
+        indv = individuals[1]
+        self.assertEqual(indv['mk'], indv1.mk)
+        indv = individuals[2]
+        self.assertEqual(indv['mk'], indv3.mk)
+
+        # Test ascending order
+        executed = client.execute(SH_INDIVIDUALS_ORDER_BY % 'createdAt',
+                                  context_value=self.context_value)
+
+        individuals = executed['data']['individuals']['entities']
+
+        indv = individuals[0]
+        self.assertEqual(indv['mk'], indv1.mk)
+        indv = individuals[1]
+        self.assertEqual(indv['mk'], indv2.mk)
+        indv = individuals[2]
+        self.assertEqual(indv['mk'], indv3.mk)
+
+        # Test descending order
+        executed = client.execute(SH_INDIVIDUALS_ORDER_BY % '-createdAt',
+                                  context_value=self.context_value)
+
+        individuals = executed['data']['individuals']['entities']
+
+        indv = individuals[0]
+        self.assertEqual(indv['mk'], indv3.mk)
+        indv = individuals[1]
+        self.assertEqual(indv['mk'], indv2.mk)
+        indv = individuals[2]
+        self.assertEqual(indv['mk'], indv1.mk)
+
     def test_pagination(self):
         """Check whether it returns the individuals searched when using pagination"""
 

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -36,6 +36,16 @@
         @search="filterSearch"
         filter-selector
         order-selector
+        :order-options="[
+          {
+            text: 'Last updated',
+            value: 'lastModified'
+          },
+          {
+            text: 'Created date',
+            value: 'createdAt'
+          }
+        ]"
       />
       <v-tooltip bottom transition="expand-y-transition" open-delay="200">
         <template v-slot:activator="{ on }">

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -85,7 +85,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
@@ -447,7 +447,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
@@ -809,7 +809,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
@@ -1171,7 +1171,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
@@ -1533,7 +1533,7 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
@@ -1895,7 +1895,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -92,7 +92,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
@@ -456,7 +456,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
     <search-stub
       class="ml-auto pa-0 flex-grow-0"
       filterselector="true"
-      orderoptions="[object Object]"
+      orderoptions="[object Object],[object Object]"
       orderselector="true"
       validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />

--- a/ui/tests/unit/queries.spec.js
+++ b/ui/tests/unit/queries.spec.js
@@ -378,7 +378,10 @@ describe("IndividualsTable", () => {
     expect(querySpy).toHaveBeenCalledWith(1, 10, { country: "Spain" }, null);
   });
 
-  test("Orders query by last modified date", async () => {
+  test.each([
+    "lastModified",
+    "createdAt"
+  ])("Orders query by %p", async (value) => {
     const querySpy = spyOn(Queries, "getPaginatedIndividuals");
     const query = jest.fn(() => Promise.resolve(paginatedResponse));
     const wrapper = mountFunction({
@@ -389,11 +392,11 @@ describe("IndividualsTable", () => {
       }
     });
     await wrapper.setProps({ fetchPage: Queries.getPaginatedIndividuals });
-    await wrapper.setData({ orderBy: "lastModified" });
+    await wrapper.setData({ orderBy: value });
 
     const response = await wrapper.vm.queryIndividuals(1);
 
-    expect(querySpy).toHaveBeenCalledWith(1, 10, {}, "lastModified");
+    expect(querySpy).toHaveBeenCalledWith(1, 10, {}, value);
   });
 
   test("Mock query for getCountries", async () => {


### PR DESCRIPTION
Allows the individuals to be sorted by their creation date, both from the API and from the UI.