### PR TITLE
Order individuals by profile name

### DIFF
--- a/sortinghat/core/models.py
+++ b/sortinghat/core/models.py
@@ -176,7 +176,7 @@ class Individual(EntityBase):
 
     class Meta:
         db_table = 'individuals'
-        ordering = ('last_modified', 'created_at',)
+        ordering = ('last_modified', 'created_at', 'profile__name',)
 
     def __str__(self):
         return self.mk

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2538,6 +2538,43 @@ class TestQueryIndividuals(django.test.TestCase):
         indv = individuals[2]
         self.assertEqual(indv['mk'], indv1.mk)
 
+    def test_order_by_profile_name(self):
+        """Check whether it returns the individuals ordered by their name"""
+
+        indv1 = Individual.objects.create(mk='a9b403e150dd4af8953a52a4bb841051e4b705d9')
+        indv2 = Individual.objects.create(mk='185c4b709e5446d250b4fde0e34b78a2b4fde0e3')
+        indv3 = Individual.objects.create(mk='c6d2504fde0e34b78a185c4b709e5442d045451c')
+        Profile.objects.create(name='AA', individual=indv1)
+        Profile.objects.create(name='ZZ', individual=indv2)
+        Profile.objects.create(name='MM', individual=indv3)
+
+        # Test ascending order
+        client = graphene.test.Client(schema)
+        executed = client.execute(SH_INDIVIDUALS_ORDER_BY % 'profile__name',
+                                  context_value=self.context_value)
+
+        individuals = executed['data']['individuals']['entities']
+
+        indv = individuals[0]
+        self.assertEqual(indv['mk'], indv1.mk)
+        indv = individuals[1]
+        self.assertEqual(indv['mk'], indv3.mk)
+        indv = individuals[2]
+        self.assertEqual(indv['mk'], indv2.mk)
+
+        # Test descending order
+        executed = client.execute(SH_INDIVIDUALS_ORDER_BY % '-profile__name',
+                                  context_value=self.context_value)
+
+        individuals = executed['data']['individuals']['entities']
+
+        indv = individuals[0]
+        self.assertEqual(indv['mk'], indv2.mk)
+        indv = individuals[1]
+        self.assertEqual(indv['mk'], indv3.mk)
+        indv = individuals[2]
+        self.assertEqual(indv['mk'], indv1.mk)
+
     def test_pagination(self):
         """Check whether it returns the individuals searched when using pagination"""
 

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -44,6 +44,10 @@
           {
             text: 'Created date',
             value: 'createdAt'
+          },
+          {
+            text: 'Name',
+            value: 'profile__name'
           }
         ]"
       />


### PR DESCRIPTION
Allows individuals to be sorted by their name, both from the API and from the UI.
Fixes #514.