### PR TITLE
Filter individuals by enrollment date

### DIFF
--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -135,7 +135,7 @@ export default {
         },
         {
           filter: "lastUpdated",
-          type: "string"
+          type: "date"
         },
         {
           filter: "source",
@@ -144,6 +144,10 @@ export default {
         {
           filter: "enrollment",
           type: "string"
+        },
+        {
+          filter: "enrollmentDate",
+          type: "date"
         }
       ]
     },
@@ -194,8 +198,8 @@ export default {
             !this.validFilters.find(vfilter => vfilter.filter === filter)
           ) {
             this.errorMessage = `Invalid filter "${filter}"`;
-          } else if (filter === "lastUpdated") {
-            this.parseLastUpdated(text);
+          } else if (this.isDateFilter(filter)) {
+            this.parseDateFilter(text, filter);
           } else if (this.isBooleanFilter(filter)) {
             this.parseBooleanFilter(filter, text);
           } else {
@@ -210,7 +214,7 @@ export default {
         this.filters.term = terms.join(" ").trim();
       }
     },
-    parseLastUpdated(inputValue) {
+    parseDateFilter(inputValue, filter) {
       const operator = ["<=", ">=", "<", ">", ".."].find(value =>
         inputValue.includes(value)
       );
@@ -222,7 +226,7 @@ export default {
       const values = inputValue.replace(operator, ` ${operator} `).split(" ");
 
       try {
-        this.filters.lastUpdated = values
+        this.filters[filter] = values
           .map(value => {
             if (value) {
               return value === operator
@@ -252,7 +256,9 @@ export default {
         const filter = match[1];
         const value = match[2];
         if (this.validFilters.find(vfilter => vfilter.filter === filter)) {
-          if (this.isBooleanFilter(filter)) {
+          if (this.isDateFilter(filter)) {
+            this.parseDateFilter(value, filter);
+          } else if (this.isBooleanFilter(filter)) {
             this.parseBooleanFilter(filter, value);
           } else {
             this.filters[filter] = value;
@@ -278,13 +284,19 @@ export default {
       );
       return validFilter.type === "boolean";
     },
+    isDateFilter(filter) {
+      const validFilter = this.validFilters.find(
+        vfilter => vfilter.filter === filter
+      );
+      return validFilter.type === "date";
+    },
     setFilter(item) {
       this.inputValue = this.inputValue || "";
-      if (item.filter === "lastUpdated") {
+      if (this.isDateFilter(item.filter)) {
         const [month, day, year] = new Date()
           .toLocaleDateString("en-US")
           .split("/");
-        this.inputValue += `lastUpdated:>=${year}-${month}-${day} `;
+        this.inputValue += `${item.filter}:>=${year}-${month}-${day} `;
       } else if (this.isBooleanFilter(item.filter)) {
         this.inputValue += `${item.filter}:true `;
       } else {

--- a/ui/src/views/SearchHelp.vue
+++ b/ui/src/views/SearchHelp.vue
@@ -139,6 +139,69 @@
           that include spaces should be wrapped between double quotes. For
           example: <code>enrollment:"Dumbledore's Army"</code>.
         </p>
+
+        <p class="subtitle-2">Filter by enrollment date</p>
+        <p>
+          You can filter individuals based on when they were affiliated to an
+          organization, using the <code>enrollmentDate</code> filter.
+        </p>
+        <v-simple-table>
+          <template v-slot:default>
+            <thead>
+              <tr>
+                <th class="text-left" width="30%">
+                  Filter
+                </th>
+                <th class="text-left">
+                  Explanation
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td width="30%"><code>enrollmentDate:>YYYY-MM-DD</code></td>
+                <td>
+                  Matches individuals that were affiliated to an organization
+                  after the given date.
+                </td>
+              </tr>
+              <tr>
+                <td width="30%"><code>enrollmentDate:>=YYYY-MM-DD</code></td>
+                <td>
+                  Matches individuals that were affiliated to an organization on
+                  or after the given date.
+                </td>
+              </tr>
+              <tr>
+                <td width="30%">
+                  <code>enrollmentDate:&lt;YYYY-MM-DD</code>
+                </td>
+                <td>
+                  Matches individuals that were affiliated to an organization
+                  before the given date.
+                </td>
+              </tr>
+              <tr>
+                <td width="30%">
+                  <code>enrollmentDate:&lt;=YYYY-MM-DD</code>
+                </td>
+                <td>
+                  Matches individuals that were affiliated to an organization on
+                  or before the given date.
+                </td>
+              </tr>
+              <tr>
+                <td width="30%">
+                  <code>enrollmentDate:YYYY-MM-DD..YYYY-MM-DD</code>
+                </td>
+                <td>
+                  Matches individuals that were affiliated to an organization
+                  between the given dates.
+                </td>
+              </tr>
+            </tbody>
+          </template>
+        </v-simple-table>
       </v-card-text>
     </v-card>
   </v-main>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -87,7 +87,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -452,7 +452,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -817,7 +817,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1182,7 +1182,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1547,7 +1547,7 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1912,7 +1912,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -94,7 +94,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -461,7 +461,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub

--- a/ui/tests/unit/search.spec.js
+++ b/ui/tests/unit/search.spec.js
@@ -32,24 +32,33 @@ describe("Search", () => {
   });
 
   test.each([
-    ["lastUpdated:<2000", "<2000-01-01T00:00:00.000Z"],
-    ["lastUpdated:<=2000-08-10", "<=2000-08-10T00:00:00.000Z"],
-    ["lastUpdated:>2000", ">2000-01-01T00:00:00.000Z"],
-    ["lastUpdated:>=2000-02-03", ">=2000-02-03T00:00:00.000Z"],
+    ["dateFilter:<2000", "<2000-01-01T00:00:00.000Z"],
+    ['dateFilter:"<2000"', "<2000-01-01T00:00:00.000Z"],
+    ["dateFilter:<=2000-08-10", "<=2000-08-10T00:00:00.000Z"],
+    ["dateFilter:>2000", ">2000-01-01T00:00:00.000Z"],
+    ["dateFilter:>=2000-02-03", ">=2000-02-03T00:00:00.000Z"],
     [
-      "lastUpdated:2000..2001",
+      "dateFilter:2000..2001",
       "2000-01-01T00:00:00.000Z..2001-01-01T00:00:00.000Z"
     ],
-    ["test lastUpdated:<2000", "<2000-01-01T00:00:00.000Z"]
-  ])("Given %p parses lastUpdated filter", async (value, expected) => {
+    ["test dateFilter:<2000", "<2000-01-01T00:00:00.000Z"]
+  ])("Given %p parses date filter", async (value, expected) => {
     const wrapper = mountFunction({
+      propsData: {
+        validFilters: [
+          {
+            filter: "dateFilter",
+            type: "date"
+          }
+        ]
+      },
       data: () => ({ inputValue: value })
     });
 
     const button = wrapper.find("button.mdi-magnify");
     await button.trigger("click");
 
-    expect(wrapper.vm.filters.lastUpdated).toBe(expected);
+    expect(wrapper.vm.filters.dateFilter).toBe(expected);
   });
 
   test.each([


### PR DESCRIPTION
Adds the `enrollmentDate` filter, which allows individuals to be filtered by the dates of their enrollment in an organization.
The valid filter formats are:
- A comparison operator (>, >=, <, <=) and a date (e.g. `>=YYYY-MM-DDTHH:MM:SSZ`).
- A range operator (..) between two dates (e.g. `YYYY-MM-DDTHH:MM:SSZ..YYYY-MM-DDTHH:MM:SSZ`)

Fixes #520 