### PR TITLE
Filter individuals by whether or not they have any enrollments

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -269,6 +269,7 @@ class IdentityFilterType(graphene.InputObjectType):
                      two dates, following ISO-8601 format. Examples:\n* `>=2020-10-12T09:35:06.13045+01:00` \
                      \n * `2020-10-12T00:00:00..2020-11-22T00:00:00`.'
     )
+    is_enrolled = graphene.Boolean(required=False)
     last_updated = graphene.String(
         required=False,
         description='Filter with a comparison operator (>, >=, <, <=) and a date OR with a range operator (..) between\
@@ -921,6 +922,8 @@ class SortingHatQuery:
                                                          .filter(start__lte=date2,
                                                                  end__gte=date1)
                                                          .values_list('individual__mk')))
+        if filters and 'is_enrolled' in filters:
+            query = query.filter(enrollments__isnull=not filters['is_enrolled'])
         if filters and 'last_updated' in filters:
             # Accepted date format is ISO 8601, YYYY-MM-DDTHH:MM:SS
             try:

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -152,6 +152,10 @@ export default {
         {
           filter: "enrollmentDate",
           type: "date"
+        },
+        {
+          filter: "isEnrolled",
+          type: "boolean"
         }
       ]
     },

--- a/ui/src/views/SearchHelp.vue
+++ b/ui/src/views/SearchHelp.vue
@@ -202,6 +202,13 @@
             </tbody>
           </template>
         </v-simple-table>
+
+        <p class="subtitle-2 mt-8">Filter by enrollment status</p>
+        <p>
+          You can search for individuals based on whether they have any
+          affiliation, using the <code>isEnrolled:true</code> and
+          <code>isEnrolled:false</code> filters.
+        </p>
       </v-card-text>
     </v-card>
   </v-main>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -87,7 +87,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -452,7 +452,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -817,7 +817,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1182,7 +1182,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1547,7 +1547,7 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1912,7 +1912,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -94,7 +94,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -461,7 +461,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub


### PR DESCRIPTION
This PR adds the `isEnrolled` filter to the `individuals` query, which returns a list of individuals that are affiliated or not to any organizations.