### PR TITLE
[ui] Fix console warning when workspace is empty

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -269,7 +269,7 @@ export default {
     }
   },
   async mounted() {
-    if (this.workspace.length > 0) {
+    if (this.workspace && this.workspace.length > 0) {
       const response = await Promise.all(
         this.workspace.map(uuid => getIndividualByUuid(this.$apollo, uuid))
       );


### PR DESCRIPTION
Checks if there is a saved workspace before requesting its items when the dashboard is loaded, fixing the Vue console error mentioned in #534.