### PR TITLE
Authenticate before entering login route

### DIFF
--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -40,6 +40,10 @@ router.beforeEach((to, from, next) => {
     } else {
       next();
     }
+  } else if (to.path === "/login" && isAuthenticated) {
+    next({
+      path: "/"
+    });
   } else {
     next();
   }


### PR DESCRIPTION
Signed-off-by: Sourabh Saraswat <saraswatsourabh5@gmail.com>

This PR solves an issue #532 (Before Route Enter authentication on Login route) as described there in issue, So now if an authenticated user having credentials try to visit login route without getting logout from the application then that user will be redirected to dashboard again.   

**To know more briefly about issues, you can check issue #532.**