### PR TITLE
Remove credentials from Vuex Store on logout 

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -50,6 +50,8 @@ export default {
     logOut() {
       Cookies.remove("sh_authtoken");
       Cookies.remove("sh_user");
+      this.$store.commit("setToken", undefined);
+      this.$store.commit("loginUser", undefined);
       this.$router.push("/login");
       this.$logger.info(`Log out user ${this.user}`);
     }


### PR DESCRIPTION
This PR solves an issue #536 (Credentials are not removed from Store while logout) which is a security issue because in the present application when we go for logout, a logout() called which only deletes Credentials from Cookies and the credentials in vuex store remains as it is, So this issue is solved by removing credentials from vuex store when removing credentials from Cookies.

To know more briefly about issues, you can check issue #536