### PR TITLE
Remove '-u' from the unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
         run: yarn lint
       - name: Run unit tests
         working-directory: ./ui
-        run: yarn test:unit -u
+        run: yarn test:unit

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ frontend and backend.
 #### Frontend test suite
 ```
 $ cd ui/
-$ yarn test:unit -u
+$ yarn test:unit
 ```
 
 ## License


### PR DESCRIPTION
The '-u' argument was needed to update the failing snapshots. It is not required anymore, this PR removes it.