### PR TITLE
[gha] Update tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,11 @@
-name: build
+name: tests
 
-on: 
+on:
   push:
     branches:
       - muggle
+    tags:
+      - '!*.*.*'
   pull_request:
     branches:
       - muggle
@@ -23,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.6, 3.7, 3.8]
 
     runs-on: ubuntu-latest
     name: Python ${{ matrix.python-version }}    

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sorting Hat [![build](https://github.com/chaoss/grimoirelab-sortinghat/actions/workflows/ci.yml/badge.svg?branch=muggle)](https://github.com/chaoss/grimoirelab-sortinghat/actions/workflows/ci.yml?query=workflow:build+branch:muggle+event:push)
+# Sorting Hat [![tests](https://github.com/chaoss/grimoirelab-sortinghat/workflows/tests/badge.svg?branch=muggle)](https://github.com/chaoss/grimoirelab-sortinghat/actions?query=workflow:tests+branch:muggle+event:push)
 
 **Warning**: This is the developing branch of the new version of Sorting Hat. We're moving Sorting Hat into a service.
 The documentation below would be totally incorrect or inaccurate. 


### PR DESCRIPTION
This PR renames the ci github actions workflow to avoid ambiguity. It also adds a rule to restrict the tests workflow to run when a release tag is pushed to the repository to avoid redundant workflows.

It also adds additional python versions 3.7, 3.8 for running the test suite.