### PR TITLE
Gender recommendations

### DIFF
--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -93,6 +93,8 @@ STATIC_URL = '/'
 
 MEDIA_URL = 'http://media.example.com/'
 
+SORTINGHAT_GENDERIZE_API_KEY = None
+
 INSTALLED_APPS = [
     'django_rq',
     'graphene_django',
@@ -110,7 +112,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
         'USER': 'root',
-        'PASSWORD': '',
+        'PASSWORD': 'root',
         'NAME': 'sortinghat_db',
         'OPTIONS': {'charset': 'utf8mb4'},
         'TEST': {

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -16,6 +16,8 @@ SILENCED_SYSTEM_CHECKS = ["django_mysql.E016"]
 
 SECRET_KEY = 'fake-key'
 
+SORTINGHAT_GENDERIZE_API_KEY = 'fake-key'
+
 INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -28,7 +28,7 @@ import django_rq.utils
 import pandas
 import rq
 
-from .api import enroll, merge
+from .api import enroll, merge, update_profile
 from .context import SortingHatContext
 from .errors import BaseError, NotFoundError, EqualIndividualError
 from .log import TransactionsLog
@@ -220,7 +220,7 @@ def recommend_matches(ctx, source_uuids, target_uuids, criteria, verbose=False):
 
 
 @django_rq.job
-def recommend_gender(ctx, uuids, api_token=None):
+def recommend_gender(ctx, uuids):
     """Generate a list of gender recommendations from a set of individuals.
 
     This job generates a list of recommendations with the
@@ -228,7 +228,6 @@ def recommend_gender(ctx, uuids, api_token=None):
 
     :param ctx: context where this job is run
     :param uuids: list of individuals identifiers
-    :api_token: genderize.io API token
 
     :returns: a dictionary with the recommended gender and accuracy of the
         prediction for each individual.
@@ -248,7 +247,7 @@ def recommend_gender(ctx, uuids, api_token=None):
 
     trxl = TransactionsLog.open('recommend_gender', job_ctx)
 
-    for rec in engine.recommend('gender', uuids, api_token):
+    for rec in engine.recommend('gender', uuids):
         results[rec.key] = {'gender': rec.options[0],
                            'accuracy': rec.options[1]}
 
@@ -421,6 +420,72 @@ def unify(ctx, source_uuids, target_uuids, criteria):
     return job_result
 
 
+@django_rq.job
+def genderize(ctx, uuids=None):
+    """Assign a gender to a set of individuals using recommendations.
+
+    This job autocompletes the gender information (stored in
+    the profile) of unique identities after obtaining a list
+    of recommendations for their gender based on their name.
+
+    Individuals are defined by any of their valid keys or UUIDs.
+    When the parameter `uuids` is empty, the job will take all
+    the individuals stored in the registry.
+
+    :param ctx: context where this job is run
+    :param uuids: list of individuals identifiers
+
+    :returns: a dictionary with which individual profiles were
+        updated and the errors found running the job
+    """
+    job = rq.get_current_job()
+
+    if not uuids:
+        logger.info(f"Running job {job.id} 'genderize'; uuids='all'; ...")
+        uuids = Individual.objects.values_list('mk', flat=True).iterator()
+    else:
+        logger.info(f"Running job {job.id} 'genderize'; uuids={list(uuids)}; ...")
+        uuids = iter(uuids)
+
+    results = {}
+    errors = []
+    job_result = {
+        'results': results,
+        'errors': errors
+    }
+
+    engine = RecommendationEngine()
+
+    # Create a new context to include the reference
+    # to the job id that will perform the transaction.
+    job_ctx = SortingHatContext(ctx.user, job.id)
+
+    # Create an empty transaction to log which job
+    # will generate the enroll transactions.
+    trxl = TransactionsLog.open('autogender', job_ctx)
+
+    nsuccess = 0
+
+    for chunk in _iter_split(uuids, size=MAX_CHUNK_SIZE):
+        for rec in engine.recommend('gender', chunk):
+            gender, acc = rec.options
+            updated, errs = _update_individual_gender(job_ctx, rec.key, rec.options)
+            results[rec.key] = updated
+            errors.extend(errs)
+
+            if updated:
+                nsuccess += 1
+
+    trxl.close()
+
+    logger.info(
+        f"Job {job.id} 'genderize' completed; "
+        f"{nsuccess} individuals have been updated"
+    )
+
+    return job_result
+
+
 def _merge_individuals(job_ctx, source_indv, target_indvs):
     """Merge a set of individuals.
 
@@ -499,6 +564,28 @@ def _affiliate_individual(job_ctx, uuid, organizations):
     )
 
     return affiliated, errors
+
+
+def _update_individual_gender(job_ctx, uuid, recommendation):
+    errors = []
+    gender, gender_acc = recommendation
+
+    logger.debug(
+        f"Updating individual profile; "
+        f"job={job_ctx.job_id} uuid={uuid} gender={gender} gender_acc={gender_acc}; ..."
+    )
+
+    try:
+        update_profile(job_ctx, uuid, gender=gender, gender_acc=gender_acc)
+    except BaseError as exc:
+        errors.append(str(exc))
+
+    logger.debug(
+        f"Profile updated with {len(errors)} errors; "
+        f"job={job_ctx.job_id} uuid={uuid} gender={gender} gender_acc={gender_acc}; ..."
+    )
+
+    return recommendation, errors
 
 
 def _iter_split(iterator, size=None):

--- a/sortinghat/core/recommendations/engine.py
+++ b/sortinghat/core/recommendations/engine.py
@@ -24,6 +24,7 @@ import collections
 from ..errors import RecommendationEngineError
 from .affiliation import recommend_affiliations
 from .matching import recommend_matches
+from .gender import recommend_gender
 
 
 Recommendation = collections.namedtuple(
@@ -41,7 +42,8 @@ class RecommendationEngine:
     """
     RECOMMENDATION_TYPES = {
         'affiliation': recommend_affiliations,
-        'matches': recommend_matches
+        'matches': recommend_matches,
+        'gender': recommend_gender
     }
 
     def recommend(self, name, *args, **kwargs):

--- a/sortinghat/core/recommendations/gender.py
+++ b/sortinghat/core/recommendations/gender.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2021 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Eva Millán <evamillan@bitergia.com>
+#
+
+
+import logging
+import re
+
+import requests
+import urllib3.util
+
+from ..db import find_individual_by_uuid
+from ..errors import NotFoundError, InvalidValueError
+
+logger = logging.getLogger(__name__)
+
+name_pattern = re.compile(r"(^\w+)\s\w+")
+
+
+def recommend_gender(uuids):
+    """Recommend possible genders for a list of individuals.
+
+    Returns a generator of gender recommendations based on the
+    individuals first name, using the genderize.io API. The
+    genders returned by the API are 'male' and 'female'.
+
+    Each recommendation contains the uuid of the individual, the
+    suggested gender and the accuracy of the prediction.
+
+    When the individual does not have a name set, or the name
+    does not follow a 'FirstName LastName' pattern, or the individual
+    is not found, it will not be included in the result.
+
+    :param uuids: list of individual identifiers
+    :returns: a generator of recommendations
+    """
+
+    logger.debug(
+        f"Generating genders recommendations; "
+        f"uuids={uuids}; ..."
+    )
+
+    for uuid in uuids:
+        try:
+            individual = find_individual_by_uuid(uuid)
+            name = _get_individual_name(individual)
+            gender, accuracy = _genderize(name)
+        except NotFoundError:
+            message = f"Skipping {uuid}: Individual not found"
+            logger.warning(message)
+            continue
+        except InvalidValueError:
+            message = f"Skipping {uuid}: No valid name"
+            logger.warning(message)
+            continue
+        except requests.exceptions.RequestException as e:
+            message = f"Skipping {uuid} due to a connection error: {str(e)}"
+            logger.warning(message)
+            continue
+        else:
+            yield uuid, (gender, accuracy)
+
+    logger.info(f"Gender recommendations generated; uuids='{uuids}'")
+
+
+def _get_individual_name(individual):
+    """Get the first name of an individual from their profile"""
+
+    try:
+        name_match = name_pattern.match(individual.profile.name)
+        first_name = name_match.group(1).lower()
+    except Exception as e:
+        raise InvalidValueError(msg=str(e))
+    else:
+        return first_name
+
+
+def _genderize(name):
+    """Fetch gender from genderize.io"""
+
+    from django.conf import settings
+
+    api_key = settings.SORTINGHAT_GENDERIZE_API_KEY
+    genderize_api_url = "https://api.genderize.io/"
+    total_retries = 10
+    max_retries = 5
+    sleep_time = 0.25
+    status_forcelist = [502]
+
+    params = {
+        'name': name
+    }
+
+    if api_key:
+        params['apikey'] = api_key
+
+    session = requests.Session()
+
+    retries = urllib3.util.Retry(total=total_retries,
+                                 connect=max_retries,
+                                 status=max_retries,
+                                 status_forcelist=status_forcelist,
+                                 backoff_factor=sleep_time,
+                                 raise_on_status=True)
+
+    session.mount('http://', requests.adapters.HTTPAdapter(max_retries=retries))
+    session.mount('https://', requests.adapters.HTTPAdapter(max_retries=retries))
+
+    r = session.get(genderize_api_url, params=params)
+
+    result = r.json()
+
+    r.raise_for_status()
+
+    gender = result.get('gender', None)
+    prob = result.get('probability', None)
+    acc = int(prob * 100) if prob else None
+
+    return gender, acc

--- a/tests/rec/test_engine.py
+++ b/tests/rec/test_engine.py
@@ -95,4 +95,4 @@ class TestRecommendationEngine(TestCase):
         """Test the list of supported recommendation types"""
 
         types = RecommendationEngine.types()
-        self.assertListEqual(types, ['affiliation', 'matches'])
+        self.assertListEqual(types, ['affiliation', 'matches', 'gender'])

--- a/tests/rec/test_gender.py
+++ b/tests/rec/test_gender.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2021 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#     Miguel Ángel Fernández <mafesan@bitergia.com>
+#     Eva Millán <evamillan@bitergia.com>
+#
+
+
+import json
+import httpretty
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from sortinghat.core import api
+from sortinghat.core.context import SortingHatContext
+from sortinghat.core.recommendations.gender import recommend_gender
+
+GENDERIZE_API_URL = "https://api.genderize.io/"
+
+
+def setup_genderize_server():
+    """Setup a mock HTTP server for genderize.io"""
+
+    http_requests = []
+
+    def request_callback(method, uri, headers):
+        last_request = httpretty.last_request()
+        http_requests.append(last_request)
+
+        params = last_request.querystring
+        name = params['name'][0].lower()
+
+        if name == 'error':
+            return 502, headers, 'Bad Gateway'
+
+        if name == 'john':
+            data = {
+                'gender': 'male',
+                'probability': 0.92
+            }
+        elif name == 'jane':
+            data = {
+                'gender': 'female',
+                'probability': 0.89
+            }
+        else:
+            data = {
+                'gender': None,
+                'probability': None
+            }
+
+        body = json.dumps(data)
+
+        return (200, headers, body)
+
+    httpretty.register_uri(httpretty.GET,
+                           GENDERIZE_API_URL,
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    return http_requests
+
+
+class TestRecommendGender(TestCase):
+    """Unit tests for recommend_gender"""
+
+    def setUp(self):
+        """Initialize database with a dataset"""
+
+        self.user = get_user_model().objects.create(username='test')
+        self.ctx = SortingHatContext(self.user)
+
+        self.john_smith = api.add_identity(self.ctx,
+                                           name='John Smith',
+                                           source='scm')
+        self.jane_doe = api.add_identity(self.ctx,
+                                         name='Jane Doe',
+                                         source='scm')
+        self.smith = api.add_identity(self.ctx,
+                                      name='Smith',
+                                      source='scm')
+        self.no_name = api.add_identity(self.ctx,
+                                        email='email@example.com',
+                                        source='scm')
+
+    @httpretty.activate
+    def test_recommend_gender(self):
+        """Check if it returns a gender for valid names"""
+
+        setup_genderize_server()
+
+        uuids = [self.john_smith.uuid, self.jane_doe.uuid]
+        recs = list(recommend_gender(uuids))
+
+        self.assertEqual(len(recs), 2)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], self.john_smith.uuid)
+        gender, acc = rec[1]
+        self.assertEqual(gender, 'male')
+        self.assertEqual(acc, 92)
+
+        rec = recs[1]
+        self.assertEqual(rec[0], self.jane_doe.uuid)
+        gender, acc = rec[1]
+        self.assertEqual(gender, 'female')
+        self.assertEqual(acc, 89)
+
+    @httpretty.activate
+    def test_no_name(self):
+        """Check if no recommendations are generated when an
+            individual does not have a valid name"""
+
+        setup_genderize_server()
+
+        uuids = [self.smith.uuid, self.no_name.uuid]
+        recs = list(recommend_gender(uuids))
+
+        self.assertEqual(len(recs), 0)
+
+    def test_not_found_individual(self):
+        """Check if no recommendations are generated when an
+        individual does not exist"""
+
+        recs = list(recommend_gender(['FFFFFFFFFFFFFFFFFF']))
+
+        self.assertEqual(len(recs), 0)
+
+    @httpretty.activate
+    def test_api_key(self):
+        """Test if genderize API is called with apikey parameter"""
+
+        setup_genderize_server()
+
+        uuids = [self.john_smith.uuid]
+        recs = list(recommend_gender(uuids))
+
+        expected = {
+            'name': ['john'],
+            'apikey': ['fake-key']
+        }
+
+        request = httpretty.last_request()
+        self.assertEqual(request.querystring, expected)
+
+    @httpretty.activate
+    def test_retry(self):
+        """Test if the request is retried when an error is returned"""
+
+        http_requests = setup_genderize_server()
+
+        # This profile won't be updated due to connection errors
+        # In this case, a 502 HTTP error
+        self.error_name = api.add_identity(self.ctx,
+                                           name='Error Name',
+                                           source='scm')
+
+        uuids = [self.error_name.uuid]
+        recs = list(recommend_gender(uuids))
+
+        # Should have retried 5 times
+        self.assertEqual(len(http_requests), 6)
+
+        self.assertEqual(len(recs), 0)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -23,6 +23,8 @@
 
 import datetime
 import unittest.mock
+import json
+import httpretty
 
 import dateutil
 
@@ -794,9 +796,27 @@ SH_JOB_QUERY_RECOMMEND_GENDER = """{
     result {
       __typename
       ... on GenderRecommendationType {
-      	uuid
-      	gender
+        uuid
+        gender
         accuracy
+      }
+    }
+  }
+}
+"""
+SH_JOB_QUERY_GENDERIZE = """{
+  job(
+    jobId:"%s"
+  ){
+    jobId
+    jobType
+    status
+    errors
+    result {
+      __typename
+      ... on GenderizeResultType {
+        uuid
+        gender
       }
     }
   }
@@ -3847,7 +3867,7 @@ class TestQueryJob(django.test.TestCase):
         # Tests
         client = graphene.test.Client(schema)
 
-        query = SH_JOB_QUERY_RECOMMEND_AFFILIATIONS % '1234-5678-90AB-CDEF'
+        query = SH_JOB_QUERY_RECOMMEND_GENDER % '1234-5678-90AB-CDEF'
 
         executed = client.execute(query,
                                   context_value=self.context_value)
@@ -3858,6 +3878,42 @@ class TestQueryJob(django.test.TestCase):
         self.assertEqual(job_data['status'], 'queued')
         self.assertEqual(job_data['errors'], None)
         self.assertEqual(job_data['result'], None)
+
+    @unittest.mock.patch('sortinghat.core.schema.find_job')
+    def test_genderize_job(self, mock_job):
+        """Check if it returns an genderize result type"""
+
+        result = {
+            'results': {
+                'f507a33bbeffe58ae3eb192fc371e7cea65488f6': ('male', 95)
+            },
+            'errors': []
+        }
+
+        job = MockJob('1234-5678-90AB-CDEF', 'genderize', 'finished', result)
+        mock_job.return_value = job
+
+        # Tests
+        client = graphene.test.Client(schema)
+
+        query = SH_JOB_QUERY_GENDERIZE % '1234-5678-90AB-CDEF'
+
+        executed = client.execute(query,
+                                  context_value=self.context_value)
+
+        job_data = executed['data']['job']
+
+        self.assertEqual(job_data['jobId'], '1234-5678-90AB-CDEF')
+        self.assertEqual(job_data['jobType'], 'genderize')
+        self.assertEqual(job_data['status'], 'finished')
+
+        job_results = job_data['result']
+        self.assertEqual(len(job_results), 1)
+
+        res = job_results[0]
+        self.assertEqual(res['__typename'], 'GenderizeResultType')
+        self.assertEqual(res['uuid'], 'f507a33bbeffe58ae3eb192fc371e7cea65488f6')
+        self.assertEqual(res['gender'], 'male')
 
 
 class TestAddOrganizationMutation(django.test.TestCase):
@@ -7674,3 +7730,146 @@ class TestUnifyMutation(django.test.TestCase):
         msg = executed['errors'][0]['message']
 
         self.assertEqual(msg, AUTHENTICATION_ERROR)
+
+
+def setup_genderize_server():
+    """Setup a mock HTTP server for genderize.io"""
+
+    http_requests = []
+
+    def request_callback(method, uri, headers):
+        last_request = httpretty.last_request()
+        http_requests.append(last_request)
+
+        params = last_request.querystring
+        name = params['name'][0].lower()
+
+        if name == 'error':
+            return 502, headers, 'Bad Gateway'
+
+        if name == 'john':
+            data = {
+                'gender': 'male',
+                'probability': 0.99
+            }
+        elif name == 'jane':
+            data = {
+                'gender': 'female',
+                'probability': 0.99
+            }
+        else:
+            data = {
+                'gender': None,
+                'probability': None
+            }
+
+        body = json.dumps(data)
+
+        return (200, headers, body)
+
+    httpretty.register_uri(httpretty.GET,
+                           "https://api.genderize.io/",
+                           responses=[
+                               httpretty.Response(body=request_callback)
+                           ])
+
+    return http_requests
+
+
+class TestGenderizeMutation(django.test.TestCase):
+    """Unit tests for mutation to autocomplete gender information"""
+
+    SH_GENDERIZE = """
+        mutation genderize($uuids: [String]) {
+            genderize(uuids: $uuids) {
+                jobId
+            }
+        }
+    """
+
+    def setUp(self):
+        """Load initial dataset and set queries context"""
+
+        conn = django_rq.queues.get_redis_connection(None, True)
+        conn.flushall()
+
+        self.user = get_user_model().objects.create(username='test')
+        self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
+        self.context_value.user = self.user
+
+        ctx = SortingHatContext(self.user)
+
+        # Individual 1
+        self.john_smith = api.add_identity(ctx,
+                                           email='jsmith@example.com',
+                                           name='John Smith',
+                                           source='scm')
+        self.jane_roe = api.add_identity(ctx,
+                                         email='jroe@example.com',
+                                         name='Jane Roe',
+                                         source='scm')
+
+    @httpretty.activate
+    @unittest.mock.patch('sortinghat.core.jobs.rq.job.uuid4')
+    def test_genderize(self, mock_job_id_gen):
+        """Check if genderize is applied for the specified individuals"""
+
+        setup_genderize_server()
+
+        mock_job_id_gen.return_value = "1234-5678-90AB-CDEF"
+
+        client = graphene.test.Client(schema)
+
+        params = {
+            'uuids': [self.john_smith.uuid]
+        }
+
+        executed = client.execute(self.SH_GENDERIZE,
+                                  context_value=self.context_value,
+                                  variables=params)
+
+        # Check if the job was run
+        job_id = executed['data']['genderize']['jobId']
+        self.assertEqual(job_id, "1234-5678-90AB-CDEF")
+
+        # Check if the individual's gender was updated
+        indv = Individual.objects.get(mk=self.john_smith.uuid)
+        gender = indv.profile.gender
+        self.assertEqual(gender, "male")
+
+        # Check if the rest of the individuals were not updated
+        indv = Individual.objects.get(mk=self.jane_roe.uuid)
+        gender = indv.profile.gender
+        self.assertEqual(gender, None)
+
+    @httpretty.activate
+    @unittest.mock.patch('sortinghat.core.jobs.rq.job.uuid4')
+    def test_genderize_all(self, mock_job_id_gen):
+        """Check if genderize is applied for all individuals in the registry"""
+
+        setup_genderize_server()
+
+        mock_job_id_gen.return_value = "1234-5678-90AB-CDEF"
+
+        client = graphene.test.Client(schema)
+
+        params = {
+            'uuids': None
+        }
+
+        executed = client.execute(self.SH_GENDERIZE,
+                                  context_value=self.context_value,
+                                  variables=params)
+
+        # Check if the job was run
+        job_id = executed['data']['genderize']['jobId']
+        self.assertEqual(job_id, "1234-5678-90AB-CDEF")
+
+        # Check if all the individuals genders were updated
+        indv1 = Individual.objects.get(mk=self.john_smith.uuid)
+        gender1 = indv1.profile.gender
+        self.assertEqual(gender1, "male")
+
+        indv2 = Individual.objects.get(mk=self.jane_roe.uuid)
+        gender2 = indv2.profile.gender
+        self.assertEqual(gender2, "female")


### PR DESCRIPTION
This PR adds a `recommendGender` mutation, which returns a job with a possible gender for each given individual uuid based on their profile name. The recommendations are provided by the genderize.io API.

Example of the mutation:
```
mutation {
  recommendGender(uuids: ["uuid"], apiToken: "token") {
    jobId
  }
}
```
Example of the job query:
```
query {
  job(jobId: "id") {
    jobId
    status
    jobType
    result {
      __typename
      ... on GenderRecommendationType {
          uuid
          gender
	  accuracy
      }
    }
    errors
  }
}
```

The individuals' genders can be autocompleted using these same recommendations with the `autogender` mutation.
Example of the mutation:
```
mutation {
  autogender(uuids:["uuid1", "uuid2"], apiToken: "token") {
    jobId
  }
}
```
Example of the job result query:
```
query {
  job(jobId: "id") {
    status
    jobType
    result {
      ... on AutogenderResultType {
        uuid
        gender
        accuracy
      }
    }
    errors
  }
}
```
Closes #471.