### PR TITLE
Add admin command line tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,7 @@ $ poetry shell
 
 Migrations, fixtures and create a superuser:
 ```
-(.venv)$ ./manage.py makemigrations --settings=config.settings.devel
-(.venv)$ ./manage.py migrate --settings=config.settings.devel
-(.venv)$ ./manage.py loaddata sortinghat/core/fixtures/countries.json --settings=config.settings.devel
-(.venv)$ ./manage.py createsuperuser --settings=config.settings.devel
+(.venv)$ sortinghat-admin --config=config.settings.devel setup
 ```
 
 #### Running the backend
@@ -159,6 +156,16 @@ $ yarn build
 Copy the static files to the location where they will be served (`STATIC_ROOT` var):
 ```
 $ ./manage.py collectstatic --settings=config.settings.devel
+```
+
+Create a new database on your MySQL/MariaDB shell:
+```
+mysql> CREATE DATABASE new_sh CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
+```
+
+Set up the service:
+```
+$ sortinghat-admin --config=config.settings.devel setup
 ```
 
 Run the server (use `--dev` flag for `development` mode):

--- a/poetry.lock
+++ b/poetry.lock
@@ -260,6 +260,21 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
+name = "importlib-resources"
+version = "5.2.0"
+description = "Read resources from Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[[package]]
 name = "jinja2"
 version = "2.11.3"
 description = "A very fast and expressive template engine."
@@ -540,7 +555,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.4.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -551,7 +566,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "d7d90b199b3ca4ba94604f3075426974292ca780e12ec1e4e664e1d780b29cb5"
+content-hash = "81e95946fa71150c423e00728be369622f984d5c420ae36dbaf52848f194a606"
 
 [metadata.files]
 aniso8601 = [
@@ -632,6 +647,10 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-3.7.3-py3-none-any.whl", hash = "sha256:b74159469b464a99cb8cc3e21973e4d96e05d3024d337313fedb618a6e86e6f4"},
     {file = "importlib_metadata-3.7.3.tar.gz", hash = "sha256:742add720a20d0467df2f444ae41704000f50e1234f46174b51f9c6031a1bd71"},
+]
+importlib-resources = [
+    {file = "importlib_resources-5.2.0-py3-none-any.whl", hash = "sha256:a0143290bef3cbc99de9e40176e4987780939a955b8632f02ce6c935f42e9bfc"},
+    {file = "importlib_resources-5.2.0.tar.gz", hash = "sha256:22a2c42d8c6a1d30aa8a0e1f57293725bfd5c013d562585e46aff469e0ff78b3"},
 ]
 jinja2 = [
     {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 [tool.poetry.scripts]
 sortinghat = "sortinghat.cli.sortinghat:sortinghat"
 sortinghatd = "sortinghat.server.sortinghatd:sortinghatd"
+sortinghat-admin = "sortinghat.server.sortinghat_admin:sortinghat_admin"
 
 [tool.poetry.dependencies]
 python = "^3.6.1"
@@ -58,6 +59,7 @@ django-cors-headers = "^3.7.0"
 PyJWT = "1.7.1"
 uWSGI = "^2.0"
 django-treebeard = "^4.5.1"
+importlib-resources = "^5.2.0"
 
 [tool.poetry.dev-dependencies]
 fakeredis = "^1.4.1"

--- a/sortinghat/server/sortinghat_admin.py
+++ b/sortinghat/server/sortinghat_admin.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2014-2021 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import logging
+import os
+
+import click
+
+import importlib_resources
+
+from django.core.wsgi import get_wsgi_application
+from django.core import management
+
+
+logger = logging.getLogger('main')
+
+
+@click.group()
+@click.option('--config', envvar='SORTINGHAT_CONFIG',
+              help="Configuration module in Python path syntax, e.g. sortinghat.settings.")
+def sortinghat_admin(config):
+    """SortingHat server administration tool.
+
+    This swiss army knife tool allows to run administrative tasks to
+    configure, initialize, or update the service.
+
+    To run the tool you will need to pass a configuration file module
+    using Python path syntax (e.g. sortinghat.settings). Take into account
+    the module should be accessible by your PYTHON_PATH.
+    """
+    env = os.environ
+
+    if config:
+        env['DJANGO_SETTINGS_MODULE'] = config
+    else:
+        raise click.ClickException(
+            "Configuration file not given. "
+            "Set it with '--config' option "
+            "or 'SORTINGHAT_CONFIG' env variable."
+        )
+
+    _ = get_wsgi_application()
+
+
+@click.command()
+def setup():
+    """Run initialization tasks to configure the service.
+
+    It will setup the database structure and create a user
+    with admin privileges for you.
+
+    To cancel the interactive mode, use the env variables
+    'SORTINGHAT_SUPERUSER_USERNAME' and 'SORTINGHAT_SUPERUSER_PASSWORD'.
+    """
+    env = os.environ
+    env_vars = False
+
+    if 'SORTINGHAT_SUPERUSER_USERNAME' in env:
+        env_vars = True
+    if 'SORTINGHAT_SUPERUSER_PASSWORD' in env:
+        if not env_vars:
+            msg = (
+                "Set both SORTINGHAT_SUPERUSER_USERNAME "
+                "and SORTINGHAT_SUPERUSER_PASSWORD env variables "
+                "to run the mode non-interactive. "
+                "Only one variable was set."
+            )
+            raise click.ClickException(msg)
+        env_vars = True
+
+    no_interactive = env_vars
+
+    click.secho("Configuring SortingHat service...\n", fg='bright_cyan')
+
+    _setup_database()
+    _setup_database_superuser(no_interactive)
+
+    click.secho("\nSortingHat configuration completed", fg='bright_cyan')
+
+
+@click.command()
+def upgrade():
+    """Run pending configuration operations to keep the service up-to-date.
+
+    It allows to run configuration operations in order to update
+    the service to its last version. For example, it will run
+    migrations or load pre-defined data.
+    """
+    click.secho("Upgrading SortingHat service...\n", fg='bright_cyan')
+
+    _setup_database()
+
+    click.secho("SortingHat upgrade completed", fg='bright_cyan')
+
+
+def _setup_database():
+    """Apply migrations and fixtures to the database."""
+
+    click.secho("## SortingHat database setup\n", fg='bright_cyan')
+
+    management.call_command('migrate')
+
+    with importlib_resources.path('sortinghat.core.fixtures', 'countries.json') as p:
+        fixture_countries_path = p
+
+    management.call_command('loaddata', fixture_countries_path)
+
+    click.echo()
+
+
+def _setup_database_superuser(no_interactive=False):
+    """Create database superuser."""
+
+    click.secho("## SortingHat superuser configuration\n", fg='bright_cyan')
+
+    env = os.environ
+    kwargs = {}
+
+    if no_interactive:
+        env['DJANGO_SUPERUSER_USERNAME'] = env['SORTINGHAT_SUPERUSER_USERNAME']
+        env['DJANGO_SUPERUSER_PASSWORD'] = env['SORTINGHAT_SUPERUSER_PASSWORD']
+        kwargs['no_input'] = True
+
+    management.call_command('createsuperuser', **kwargs)
+
+
+sortinghat_admin.add_command(setup)
+sortinghat_admin.add_command(upgrade)


### PR DESCRIPTION
This tool allows to perform some admin related tasks such as, creating new super users or apply database migrations.

Install the code and run the operations with `setup` or `upgrade` commands.

```
$ sortinghat-admin --config=config.settings.devel setup
$ sortinghat-admin --config=config.settings.devel upgrade
```