### PR TITLE
[api] Fix delete_team method

### DIFF
--- a/sortinghat/core/api.py
+++ b/sortinghat/core/api.py
@@ -732,13 +732,10 @@ def delete_team(ctx, team_name, organization=None):
 
     :raises NotFoundError: raised when the team does not
         exist in the registry.
-    :raises InvalidValueError: raised when the team name or organization name
-        is None or an empty string.
+    :raises InvalidValueError: raised when the team name
+        is None or an empty string or when organization name
+        is invalid.
     """
-    if organization is None:
-        raise InvalidValueError(msg="'org_name' cannot be None")
-    if organization == '':
-        raise InvalidValueError(msg="'org_name' cannot be an empty string")
     if team_name is None:
         raise InvalidValueError(msg="'team_name' cannot be None")
     if team_name == '':
@@ -746,12 +743,13 @@ def delete_team(ctx, team_name, organization=None):
 
     trxl = TransactionsLog.open('delete_team', ctx)
 
-    try:
-        organization = find_organization(organization)
-    except ValueError as e:
-        raise InvalidValueError(msg=str(e))
-    except NotFoundError as exc:
-        raise exc
+    if organization:
+        try:
+            organization = find_organization(organization)
+        except ValueError as e:
+            raise InvalidValueError(msg=str(e))
+        except NotFoundError as exc:
+            raise exc
 
     try:
         team = find_team(team_name, organization)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2129,27 +2129,25 @@ class TestDeleteTeam(TestCase):
         self.assertEqual(team.organization, self.org)
 
     def test_organization_is_none(self):
-        """Check if it fails when organization name is `None`"""
+        """Check if it passes when team does not belong to any organization"""
 
-        api.add_team(self.ctx, "suborg", "Example", None)
+        api.add_team(self.ctx, "suborg")
 
-        trx_date = datetime_utcnow()
-
-        with self.assertRaisesRegex(InvalidValueError, TEAM_ORG_NAME_MISSING):
-            api.delete_team(self.ctx, "suborg", None)
-
-        transactions = Transaction.objects.filter(created_at__gt=trx_date)
-        self.assertEqual(len(transactions), 0)
+        team = api.delete_team(self.ctx, "suborg")
+        self.assertIsInstance(team, Team)
+        self.assertEqual(team.name, "suborg")
+        self.assertEqual(team.organization, None)
 
     def test_organization_name_is_empty(self):
-        """Check if it fails when organization name is an empty string`"""
+        """Check if it fails when organization name is empty for a
+           team that belongs to an organization"""
 
         api.add_team(self.ctx, "suborg", "Example", None)
 
         trx_date = datetime_utcnow()
 
-        with self.assertRaisesRegex(InvalidValueError, TEAM_ORG_NAME_MISSING):
-            api.delete_team(self.ctx, "suborg", "")
+        with self.assertRaisesRegex(NotFoundError, NOT_FOUND_ERROR.format(entity="suborg")):
+            api.delete_team(self.ctx, "suborg")
 
         transactions = Transaction.objects.filter(created_at__gt=trx_date)
         self.assertEqual(len(transactions), 0)


### PR DESCRIPTION
Previously, the delete_team method could not handle deleting teams
that do not belong to any organization. This change removes the
requirement for delete_team to have organization as a parameter.

Signed-off-by: Rashmi-K-A <k.a.rashmi04@gmail.com>