### PR TITLE
[ui] Update organizations on enrollment change

### DIFF
--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -225,6 +225,7 @@
       :enroll="enroll"
       :get-countries="getCountries"
       @updateTable="queryIndividuals"
+      @updateOrganizations="$emit('updateOrganizations')"
     />
 
     <v-card class="dragged-item" color="primary" dark>
@@ -593,6 +594,7 @@ export default {
           this.$emit("updateWorkspace", {
             update: formatIndividuals([response.data.withdraw.individual])
           });
+          this.$emit("updateOrganizations");
           this.$logger.debug("Removed affiliation", { uuid, ...organization });
         }
       } catch (error) {

--- a/ui/src/components/ProfileModal.vue
+++ b/ui/src/components/ProfileModal.vue
@@ -387,6 +387,7 @@ export default {
           })
         );
         if (response) {
+          this.$emit("updateOrganizations");
           return response;
         }
       } catch (error) {


### PR DESCRIPTION
With this PR, the information on the `Organizations` table is updated when an individual is enrolled or unenrolled from an organization.
Fixes #565.