### PR TITLE
[gender] Improve name patterns

### DIFF
--- a/sortinghat/core/recommendations/gender.py
+++ b/sortinghat/core/recommendations/gender.py
@@ -24,6 +24,7 @@
 
 import logging
 import re
+from functools import lru_cache
 
 import requests
 import urllib3.util
@@ -127,6 +128,7 @@ def _get_individual_name(individual, strict):
         return first_name
 
 
+@lru_cache(maxsize=128)
 def _genderize(name):
     """Fetch gender from genderize.io"""
 

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -919,15 +919,16 @@ class RecommendGender(graphene.Mutation):
     class Arguments:
         uuids = graphene.List(graphene.String)
         exclude = graphene.Boolean(required=False)
+        no_strict_matching = graphene.Boolean(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
 
     @check_auth
-    def mutate(self, info, uuids=None, exclude=True):
+    def mutate(self, info, uuids=None, exclude=True, no_strict_matching=False):
         user = info.context.user
         ctx = SortingHatContext(user)
 
-        job = enqueue(recommend_gender, ctx, uuids, exclude)
+        job = enqueue(recommend_gender, ctx, uuids, exclude, no_strict_matching)
 
         return RecommendGender(
             job_id=job.id
@@ -979,15 +980,16 @@ class Genderize(graphene.Mutation):
     class Arguments:
         uuids = graphene.List(graphene.String)
         exclude = graphene.Boolean(required=False)
+        no_strict_matching = graphene.Boolean(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
 
     @check_auth
-    def mutate(self, info, uuids=None, exclude=True):
+    def mutate(self, info, uuids=None, exclude=True, no_strict_matching=False):
         user = info.context.user
         ctx = SortingHatContext(user)
 
-        job = enqueue(genderize, ctx, uuids, exclude)
+        job = enqueue(genderize, ctx, uuids, exclude, no_strict_matching)
 
         return Genderize(
             job_id=job.id
@@ -1476,7 +1478,7 @@ class SortingHatMutation(graphene.ObjectType):
     )
     recommend_gender = RecommendGender.Field(
         description='Recommend genders for a list of individuals based on their names\
-        using the genderize.io API.'
+        using the genderize.io API. `noStrictMatching` disables strict name validation.'
     )
     affiliate = Affiliate.Field(
         description='Affiliate a set of individuals using recommendations.'
@@ -1486,7 +1488,7 @@ class SortingHatMutation(graphene.ObjectType):
     )
     genderize = Genderize.Field(
         description='Autocomplete the gender information of a set of individuals\
-        using genderize.io recommendations.'
+        using genderize.io recommendations. `noStrictMatching` disables strict name validation.'
     )
     add_recommender_exclusion_term = AddRecommenderExclusionTerm.Field(
         description='Add a recommender exclusion to the registry.'

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1088,12 +1088,12 @@ def setup_genderize_server():
         if name == 'john':
             data = {
                 'gender': 'male',
-                'probability': 0.99
+                'probability': 0.92
             }
         elif name == 'jane':
             data = {
                 'gender': 'female',
-                'probability': 0.99
+                'probability': 0.89
             }
         else:
             data = {
@@ -1141,11 +1141,11 @@ class TestRecommendGender(TestCase):
             'results': {
                 self.jsmith.uuid: {
                     'gender': 'male',
-                    'accuracy': 99
+                    'accuracy': 92
                 },
                 self.jdoe.uuid: {
                     'gender': 'female',
-                    'accuracy': 99
+                    'accuracy': 89
                 }
             }
         }
@@ -1209,7 +1209,7 @@ class TestGenderize(TestCase):
 
         expected = {
             'results': {
-                self.jsmith.uuid: ('male', 99)
+                self.jsmith.uuid: ('male', 92)
             },
             'errors': []
         }
@@ -1227,7 +1227,7 @@ class TestGenderize(TestCase):
         gender = individual.profile.gender
         accuracy = individual.profile.gender_acc
         self.assertEqual(gender, 'male')
-        self.assertEqual(accuracy, 99)
+        self.assertEqual(accuracy, 92)
 
     @httpretty.activate
     def test_genderize_all(self):
@@ -1237,8 +1237,8 @@ class TestGenderize(TestCase):
 
         expected = {
             'results': {
-                self.jsmith.uuid: ('male', 99),
-                self.jdoe.uuid: ('female', 99)
+                self.jsmith.uuid: ('male', 92),
+                self.jdoe.uuid: ('female', 89)
             },
             'errors': []
         }


### PR DESCRIPTION
This PR implements the suggestions on issue #570, differentiating between strict and loose name matching and caching the recommendation results. By default, the name validation will check for name following a `Name Lastname` pattern, with any number of spaces between them, and for the name to be at least two characters long. This can be disabled with the `no_strict_matching` flag, which will only check that the name has a minimum of 2 characters.