### PR TITLE
[server] Create database during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Activate the virtual environment:
 $ poetry shell
 ```
 
-Migrations, fixtures and create a superuser:
+Database creation, apply migrations and fixtures, and create a superuser:
 ```
 (.venv)$ sortinghat-admin --config sortinghat.config.settings setup
 ```
@@ -170,12 +170,8 @@ Copy the static files to the location where they will be served (`STATIC_ROOT` v
 $ ./manage.py collectstatic --settings=sortinghat.config.settings
 ```
 
-Create a new database on your MySQL/MariaDB shell:
-```
-mysql> CREATE DATABASE new_sh CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
-```
-
-Set up the service:
+Set up the service creating a database and a superuser to access the
+app:
 ```
 $ sortinghat-admin --config sortinghat.config.settings setup
 ```
@@ -225,12 +221,7 @@ JSON file
 
 2. Create a new database.
    ```
-   mysql> CREATE DATABASE new_sh CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
-   ```
-
-3. Execute Django migrate.
-   ```
-   $ python3 manage.py migrate --settings=sortinghat.config.settings
+   $ sortinghat-admin --config sortinghat.config.settings setup
    ```
 
 4. Load fixture JSON file using Django

--- a/sortinghat/server/sortinghat_admin.py
+++ b/sortinghat/server/sortinghat_admin.py
@@ -90,6 +90,7 @@ def setup():
 
     click.secho("Configuring SortingHat service...\n", fg='bright_cyan')
 
+    _create_database()
     _setup_database()
     _setup_database_superuser(no_interactive)
 
@@ -109,6 +110,35 @@ def upgrade():
     _setup_database()
 
     click.secho("SortingHat upgrade completed", fg='bright_cyan')
+
+
+def _create_database():
+    """Create an empty database."""
+
+    import MySQLdb
+    from django.conf import settings
+
+    db_params = settings.DATABASES['default']
+    database = db_params['NAME']
+
+    click.secho("## SortingHat database creation\n", fg='bright_cyan')
+
+    try:
+        cursor = MySQLdb.connect(
+            user=db_params['USER'],
+            password=db_params['PASSWORD'],
+            host=db_params['HOST'],
+            port=db_params['PORT']
+        ).cursor()
+        cursor.execute(
+            f"CREATE DATABASE IF NOT EXISTS {database} "
+            "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;"
+        )
+    except MySQLdb.DatabaseError as exc:
+        msg = f"Error creating database '{database}': {exc}."
+        raise click.ClickException(msg)
+
+    click.echo(f"SortingHat database '{database}' created.\n")
 
 
 def _setup_database():


### PR DESCRIPTION
With this patch, the command 'sortinghat-admin setup' creates an empty database before migrations and fixtures
are applied.

The new database will have the name of the variable 'NAME' under the default database settings.

This database will be only created if it doesn't exist.
