### PR TITLE
Handle Vue routes from Django urls

### DIFF
--- a/sortinghat/app/urls.py
+++ b/sortinghat/app/urls.py
@@ -2,7 +2,7 @@
 
 
 from django.conf import settings
-from django.urls import path
+from django.urls import path, re_path
 from django.views.generic import TemplateView
 
 from sortinghat.core.views import SortingHatGraphQLView
@@ -10,6 +10,6 @@ from sortinghat.core.views import SortingHatGraphQLView
 from .schema import schema
 
 urlpatterns = [
-    path('', TemplateView.as_view(template_name="index.html")),
-    path('api/', SortingHatGraphQLView.as_view(graphiql=settings.DEBUG, schema=schema))
+    path('api/', SortingHatGraphQLView.as_view(graphiql=settings.DEBUG, schema=schema)),
+    re_path(r'^(?!static).*$', TemplateView.as_view(template_name="index.html"))
 ]


### PR DESCRIPTION
This PR replaces the empty `path` for the UI with a regular expression to capture Vue's routes.
Fixes #585 .