### PR TITLE
[sortinghat/utils] Fix merge_date_ranges

### DIFF
--- a/sortinghat/utils.py
+++ b/sortinghat/utils.py
@@ -69,7 +69,7 @@ def merge_date_ranges(dates):
         if en < MIN_PERIOD_DATE or en > MAX_PERIOD_DATE:
             raise ValueError("end date %s is out of bounds" % str(en))
 
-        if st <= saved[1]:
+        if st < saved[1]:
             if saved[0] == MIN_PERIOD_DATE:
                 saved[0] = st
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,6 +125,15 @@ class TestMergeDateRanges(unittest.TestCase):
         self.assertEqual(ranges[0], (datetime.datetime(1999, 1, 1), datetime.datetime(2000, 1, 1)))
         self.assertEqual(ranges[1], (datetime.datetime(2006, 1, 1), datetime.datetime(2008, 1, 1)))
 
+        # Case 11
+        dates = [(datetime.datetime(2009, 1, 1), datetime.datetime(2010, 1, 1)),
+                 (datetime.datetime(2010, 1, 1), datetime.datetime(2100, 1, 1))]
+
+        ranges = [r for r in merge_date_ranges(dates)]
+        self.assertEqual(len(ranges), 2)
+        self.assertEqual(ranges[0], (datetime.datetime(2009, 1, 1), datetime.datetime(2010, 1, 1)))
+        self.assertEqual(ranges[1], (datetime.datetime(2010, 1, 1), datetime.datetime(2100, 1, 1)))
+
     def test_dates_out_of_bounds(self):
         """Check whether it raises an exception when dates are out of bounds"""
 


### PR DESCRIPTION
This code fixes when we have two dates and in the first the `end`
date is the same as the `start` date of the second and the `end`
date is MAX_PERIOD_DATE. They both have the same organization.

For instance:
```
- organization: Chaoss
  start: 2000-01-01
  end: 2001-01-01
- organization: Chaoss
  start: 2001-01-01
  end: 2100-01-01
```

The current behavior only creates one enrollment (the first one)
due to the `st` is the same as `saved[1]` and the `en` is
MAX_PERIOD_DATE. Thus, the `saved[1] = min(saved[1], en)` and the
second enrollment is merged wrongly.
```
Enrollments:
  Chaoss 2000-01-01 00:00:00 2001-01-01 00:00:00
```

The fix behavior will create two enrollments because when the
`st` is not less than instead of less than or equal to `saved[1]`
it will create a new one.
```
Enrollments:
  Chaoss 2000-01-01 00:00:00 2001-01-01 00:00:00
  Chaoss 2001-01-01 00:00:00 2100-01-01 00:00:00
```

Fixes #588 

Signed-off-by: Quan Zhou <quan@bitergia.com>