### PR TITLE
[ui] Allow deploy SortingHat in a sub-path

### DIFF
--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -42,6 +42,7 @@ const routes = [
 
 const router = new Router({
   mode: "history",
+  base: window.location.pathname,
   routes
 });
 

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -2,10 +2,11 @@ var path = require('path');
 const { argv } = require('yargs');
 
 module.exports = {
-  publicPath: "/",
+  publicPath: process.env.NODE_ENV === 'production' ? './' : '/',
   outputDir: path.resolve(__dirname, "../sortinghat/", "core", "static"),
   indexPath: path.resolve(__dirname, "../sortinghat", "core", "templates", "index.html"),
   transpileDependencies: ["vuetify"],
+  productionSourceMap: false,
   chainWebpack: config => {
     config.plugin('define').tap(options => {
       if (argv.api_url) {


### PR DESCRIPTION
This change allows us to deploy SortingHat UI in a sub-path
(https://localhost:8000/sortinghat) instead of root
(https://localhost:8000)

Signed-off-by: Quan Zhou <quan@bitergia.com>