### PR TITLE
[config/settings] Add RQ_QUEUES password parameter

### DIFF
--- a/sortinghat/config/settings.py
+++ b/sortinghat/config/settings.py
@@ -272,6 +272,7 @@ RQ_QUEUES = {
     'default': {
         'HOST': os.environ.get('SORTINGHAT_REDIS_HOST', '127.0.0.1'),
         'PORT': os.environ.get('SORTINGHAT_REDIS_PORT', 6379),
+        'PASSWORD': os.environ.get('SORTINGHAT_REDIS_PASSWORD', ''),
         'ASYNC': os.environ.get('SORTINGHAT_WORKERS_ASYNC', True),
         'DB': os.environ.get('SORTINGHAT_REDIS_DB', 0),
     }


### PR DESCRIPTION
This code allows connecting to a Redis with password.
    
Signed-off-by: Quan Zhou <quan@bitergia.com>
