### PR TITLE
[deps] Update Jinja version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyMySQL>=0.7.0
 sqlalchemy>=1.2,<1.4
-jinja2==2.11.3
+jinja2>=3.0.3,<3.1.0
 python-dateutil>=2.6.0
 pandas>=0.22.0,<=0.25.3
 numpy<=1.18.3

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(name="sortinghat",
       install_requires=[
         'PyMySQL>=0.7.0',
         'sqlalchemy>=1.2,<1.4',
-        'jinja2==2.11.3',
+        'jinja2>=3.0.3,<3.1.0',
         'python-dateutil>=2.6.0',
         'pandas>=0.22.0,<=0.25.3',
         'numpy<=1.18.3',


### PR DESCRIPTION
Markup has release a new version and Jinja 2.11.3 throws an error.

Pin the version to <3.1.0 since from 3.1 the support for python 3.6 will be discontinued.

Related to https://github.com/chaoss/grimoirelab-sortinghat/issues/603