### PR TITLE
[ui] Enroll individuals in teams

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -278,8 +278,15 @@ const WITHDRAW = gql`
     $group: String!
     $fromDate: DateTime
     $toDate: DateTime
+    $parentOrg: String
   ) {
-    withdraw(uuid: $uuid, group: $group, fromDate: $fromDate, toDate: $toDate) {
+    withdraw(
+      uuid: $uuid
+      group: $group
+      fromDate: $fromDate
+      toDate: $toDate
+      parentOrg: $parentOrg
+    ) {
       uuid
       individual {
         isLocked
@@ -533,14 +540,15 @@ const deleteDomain = (apollo, domain) => {
   return response;
 };
 
-const withdraw = (apollo, uuid, group, fromDate, toDate) => {
+const withdraw = (apollo, uuid, group, fromDate, toDate, parentOrg) => {
   let response = apollo.mutate({
     mutation: WITHDRAW,
     variables: {
       uuid: uuid,
       group: group,
       fromDate: fromDate,
-      toDate: toDate
+      toDate: toDate,
+      parentOrg: parentOrg
     }
   });
   return response;

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -133,8 +133,15 @@ const ENROLL = gql`
     $group: String!
     $fromDate: DateTime
     $toDate: DateTime
+    $parentOrg: String
   ) {
-    enroll(uuid: $uuid, group: $group, fromDate: $fromDate, toDate: $toDate) {
+    enroll(
+      uuid: $uuid
+      group: $group
+      fromDate: $fromDate
+      toDate: $toDate
+      parentOrg: $parentOrg
+    ) {
       uuid
       individual {
         isLocked
@@ -447,14 +454,15 @@ const moveIdentity = (apollo, fromUuid, toUuid) => {
   return response;
 };
 
-const enroll = (apollo, uuid, group, fromDate, toDate) => {
+const enroll = (apollo, uuid, group, fromDate, toDate, parentOrg) => {
   let response = apollo.mutate({
     mutation: ENROLL,
     variables: {
       uuid: uuid,
       group: group,
       fromDate: fromDate,
-      toDate: toDate
+      toDate: toDate,
+      parentOrg: parentOrg
     }
   });
   return response;

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -347,6 +347,7 @@ const UPDATE_ENROLLMENT = gql`
     $group: String!
     $toDate: DateTime!
     $uuid: String!
+    $parentOrg: String
   ) {
     updateEnrollment(
       fromDate: $fromDate
@@ -355,6 +356,7 @@ const UPDATE_ENROLLMENT = gql`
       group: $group
       toDate: $toDate
       uuid: $uuid
+      parentOrg: $parentOrg
     ) {
       uuid
       individual {
@@ -582,7 +584,8 @@ const updateEnrollment = (apollo, data) => {
       newToDate: data.newToDate,
       group: data.group,
       toDate: data.toDate,
-      uuid: data.uuid
+      uuid: data.uuid,
+      parentOrg: data.parentOrg
     }
   });
   return response;

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -135,6 +135,9 @@ const GET_PAGINATED_INDIVIDUALS = gql`
           group {
             name
             type
+            parentOrg {
+              name
+            }
           }
         }
       }

--- a/ui/src/components/EnrollmentList.stories.js
+++ b/ui/src/components/EnrollmentList.stories.js
@@ -1,0 +1,76 @@
+import EnrollmentList from "./EnrollmentList.vue";
+
+export default {
+  title: "EnrollmentList",
+  excludeStories: /.*Data$/
+};
+
+const template = `
+  <enrollment-list
+    :enrollments="enrollments"
+    :compact="compact"
+    :isLocked="false"
+  />`;
+
+const enrollments = [
+  {
+    start: "1892-09-01T00:00:00+00:00",
+    end: "1997-06-30T00:00:00+00:00",
+    group: {
+      name: "Hogwarts",
+      type: "organization"
+    }
+  },
+  {
+    start: "1892-09-01T00:00:00+00:00",
+    end: "1899-06-02T00:00:00+00:00",
+    group: {
+      name: "Gryffindor",
+      type: "team",
+      parentOrg: { name: "Hogwarts" }
+    }
+  },
+  {
+    start: "1910-09-01T00:00:00+00:00",
+    end: "1969-06-01T00:00:00+00:00",
+    group: {
+      name: "Transfiguration department",
+      type: "team",
+      parentOrg: { name: "Hogwarts" }
+    }
+  },
+  {
+    start: "1970-10-01T00:00:00+00:00",
+    end: "1997-06-30T00:00:00+00:00",
+    group: {
+      name: "Order of the Phoenix",
+      type: "organization"
+    }
+  },
+  {
+    start: "1991-01-01T00:00:00+00:00",
+    end: "1995-04-02T00:00:00+00:00",
+    group: {
+      name: "International Confederation of Wizards",
+      type: "organization"
+    }
+  }
+];
+
+export const Default = () => ({
+  components: { EnrollmentList },
+  template: template,
+  data: () => ({
+    compact: false,
+    enrollments: enrollments
+  })
+});
+
+export const Compact = () => ({
+  components: { EnrollmentList },
+  template: template,
+  data: () => ({
+    compact: true,
+    enrollments: enrollments
+  })
+});

--- a/ui/src/components/EnrollmentList.vue
+++ b/ui/src/components/EnrollmentList.vue
@@ -1,0 +1,483 @@
+<template>
+  <div>
+    <v-subheader class="d-flex justify-space-between">
+      Organizations ({{ Object.keys(items).length }})
+      <v-btn
+        v-if="!compact"
+        text
+        small
+        outlined
+        :disabled="enrollments.length < 1 || isLocked"
+        @click="withdrawAll"
+      >
+        <v-icon small left>mdi-delete</v-icon>
+        Remove all
+      </v-btn>
+    </v-subheader>
+    <v-simple-table v-if="compact" dense>
+      <template v-slot:default>
+        <thead v-if="enrollments.length > 0">
+          <tr>
+            <th class="text-left">Name</th>
+            <th class="text-left">From</th>
+            <th class="text-left">To</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="enrollment in enrollments" :key="enrollment.name">
+            <td>{{ enrollment.group.name }}</td>
+            <td>{{ formatDate(enrollment.start) }}</td>
+            <td>{{ formatDate(enrollment.end) }}</td>
+          </tr>
+        </tbody>
+      </template>
+    </v-simple-table>
+    <div
+      v-else
+      v-for="(item, name) in items"
+      :key="name"
+      class="indented mt-2 mb-4"
+    >
+      <div
+        v-for="(enrollment, index) in item.enrollments"
+        :key="index"
+        class="mb-2 d-flex justify-space-between align-center"
+      >
+        <div>
+          <v-tooltip bottom>
+            <template v-slot:activator="{ on }">
+              <v-icon v-on="on" class="mr-5" left>
+                mdi-sitemap
+              </v-icon>
+            </template>
+            <span>Organization</span>
+          </v-tooltip>
+          {{ name }}
+
+          <v-menu
+            v-model="enrollment.form.fromDateMenu"
+            :close-on-content-click="false"
+            :return-value.sync="enrollment.form.fromDate"
+            transition="scale-transition"
+            offset-y
+            min-width="290px"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <button
+                v-on="on"
+                v-bind="attrs"
+                class="v-small-dialog__activator"
+              >
+                <span class="grey--text text--darken-2 ml-6">
+                  {{ formatDate(enrollment.start) }}
+                </span>
+                <v-icon small right>
+                  mdi-lead-pencil
+                </v-icon>
+              </button>
+            </template>
+            <v-date-picker
+              v-model="enrollment.form.fromDate"
+              :max="enrollment.end"
+              color="primary"
+              no-title
+              scrollable
+            >
+              <v-spacer></v-spacer>
+              <v-btn
+                text
+                color="primary"
+                @click="enrollment.form.fromDateMenu = false"
+              >
+                Cancel
+              </v-btn>
+              <v-btn
+                text
+                color="primary"
+                @click="
+                  $emit('updateEnrollment', {
+                    fromDate: enrollment.start,
+                    toDate: enrollment.end,
+                    newFromDate: new Date(
+                      enrollment.form.fromDate
+                    ).toISOString(),
+                    group: enrollment.group.name
+                  });
+                  enrollment.form.fromDateMenu = false;
+                "
+              >
+                Save
+              </v-btn>
+            </v-date-picker>
+          </v-menu>
+          -
+          <v-menu
+            v-model="enrollment.form.toDateMenu"
+            :close-on-content-click="false"
+            :return-value.sync="enrollment.form.toDate"
+            transition="scale-transition"
+            offset-y
+            min-width="290px"
+          >
+            <template v-slot:activator="{ on, attrs }">
+              <button
+                v-on="on"
+                v-bind="attrs"
+                class="v-small-dialog__activator ml-5"
+              >
+                <span class="grey--text text--darken-2 ml-2">
+                  {{ formatDate(enrollment.end) }}
+                </span>
+                <v-icon small right>
+                  mdi-lead-pencil
+                </v-icon>
+              </button>
+            </template>
+            <v-date-picker
+              v-model="enrollment.form.toDate"
+              :min="enrollment.start"
+              color="primary"
+              no-title
+              scrollable
+            >
+              <v-spacer></v-spacer>
+              <v-btn
+                text
+                color="primary"
+                @click="enrollment.form.toDateMenu = false"
+              >
+                Cancel
+              </v-btn>
+              <v-btn
+                text
+                color="primary"
+                @click="
+                  $emit('updateEnrollment', {
+                    fromDate: enrollment.start,
+                    toDate: enrollment.end,
+                    newToDate: new Date(enrollment.form.toDate).toISOString(),
+                    group: enrollment.group.name
+                  });
+                  enrollment.form.toDateMenu = false;
+                "
+              >
+                Save
+              </v-btn>
+            </v-date-picker>
+          </v-menu>
+        </div>
+        <div>
+          <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+            <template v-slot:activator="{ on }">
+              <v-btn
+                icon
+                v-on="on"
+                @click="$emit('openModal', enrollment.group.name)"
+              >
+                <v-icon>
+                  mdi-account-multiple-plus
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Add to team</span>
+          </v-tooltip>
+          <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+            <template v-slot:activator="{ on }">
+              <v-btn
+                icon
+                v-on="on"
+                @click="
+                  $emit('withdraw', {
+                    name: enrollment.group.name,
+                    fromDate: enrollment.start,
+                    toDate: enrollment.end
+                  })
+                "
+              >
+                <v-icon>
+                  mdi-delete
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Remove affiliation</span>
+          </v-tooltip>
+        </div>
+      </div>
+
+      <ul class="ma-2 mr-0">
+        <li
+          v-for="team in item.teams"
+          :key="team.group.name"
+          class="d-flex justify-space-between pr-0"
+        >
+          <div class="d-flex align-center">
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on }">
+                <v-icon v-on="on" class="mr-5" left>
+                  mdi-account-multiple
+                </v-icon>
+              </template>
+              <span>Team</span>
+            </v-tooltip>
+            <span class="mr-4">{{ team.group.name }}</span>
+
+            <v-menu
+              v-model="team.form.fromDateMenu"
+              :close-on-content-click="false"
+              :return-value.sync="team.form.fromDate"
+              transition="scale-transition"
+              offset-y
+              min-width="290px"
+            >
+              <template v-slot:activator="{ on, attrs }">
+                <button
+                  v-on="on"
+                  v-bind="attrs"
+                  class="v-small-dialog__activator"
+                >
+                  <span class="grey--text text--darken-2 ml-6">
+                    {{ formatDate(team.start) }}
+                  </span>
+                  <v-icon small right>
+                    mdi-lead-pencil
+                  </v-icon>
+                </button>
+              </template>
+              <v-date-picker
+                v-model="team.form.fromDate"
+                :max="team.end"
+                color="primary"
+                no-title
+                scrollable
+              >
+                <v-spacer></v-spacer>
+                <v-btn
+                  text
+                  color="primary"
+                  @click="team.form.fromDateMenu = false"
+                >
+                  Cancel
+                </v-btn>
+                <v-btn
+                  text
+                  color="primary"
+                  @click="
+                    $emit('updateEnrollment', {
+                      fromDate: team.start,
+                      toDate: team.end,
+                      newFromDate: new Date(team.form.fromDate).toISOString(),
+                      group: team.group.name,
+                      parentOrg: team.group.parentOrg.name
+                    });
+                    team.form.fromDateMenu = false;
+                  "
+                >
+                  Save
+                </v-btn>
+              </v-date-picker>
+            </v-menu>
+            -
+            <v-menu
+              v-model="team.form.toDateMenu"
+              :close-on-content-click="false"
+              :return-value.sync="team.form.toDate"
+              transition="scale-transition"
+              offset-y
+              min-width="290px"
+            >
+              <template v-slot:activator="{ on, attrs }">
+                <button
+                  v-on="on"
+                  v-bind="attrs"
+                  class="v-small-dialog__activator ml-5"
+                >
+                  <span class="grey--text text--darken-2 ml-2">
+                    {{ formatDate(team.end) }}
+                  </span>
+                  <v-icon small right>
+                    mdi-lead-pencil
+                  </v-icon>
+                </button>
+              </template>
+              <v-date-picker
+                v-model="team.form.toDate"
+                :min="team.start"
+                color="primary"
+                no-title
+                scrollable
+              >
+                <v-spacer></v-spacer>
+                <v-btn
+                  text
+                  color="primary"
+                  @click="team.form.toDateMenu = false"
+                >
+                  Cancel
+                </v-btn>
+                <v-btn
+                  text
+                  color="primary"
+                  @click="
+                    $emit('updateEnrollment', {
+                      fromDate: team.start,
+                      toDate: team.end,
+                      newToDate: new Date(team.form.toDate).toISOString(),
+                      group: team.group.name,
+                      parentOrg: team.group.parentOrg.name
+                    });
+                    team.form.toDateMenu = false;
+                  "
+                >
+                  Save
+                </v-btn>
+              </v-date-picker>
+            </v-menu>
+          </div>
+
+          <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+            <template v-slot:activator="{ on }">
+              <v-btn
+                icon
+                v-on="on"
+                @click="
+                  $emit('withdraw', {
+                    name: team.group.name,
+                    fromDate: team.start,
+                    toDate: team.end,
+                    parentOrg: team.group.parentOrg.name
+                  })
+                "
+              >
+                <v-icon>
+                  mdi-delete
+                </v-icon>
+              </v-btn>
+            </template>
+            <span>Remove affiliation</span>
+          </v-tooltip>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "EnrollmentList",
+  props: {
+    enrollments: {
+      type: Array,
+      required: true
+    },
+    compact: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    isLocked: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  data() {
+    return {
+      items: {}
+    };
+  },
+  methods: {
+    formatDate(dateTime) {
+      return dateTime.split("T")[0];
+    },
+    groupEnrollments(enrollments) {
+      return enrollments.reduce(function(acc, obj) {
+        const form = {
+          fromDate: obj.start.split("T")[0],
+          fromDateMenu: false,
+          toDate: obj.end.split("T")[0],
+          toDateMenu: false
+        };
+
+        if (obj.group.parentOrg) {
+          const parent = obj.group.parentOrg.name;
+          if (!acc[parent]) {
+            acc[parent] = {
+              enrollments: [],
+              teams: []
+            };
+          }
+          obj = Object.assign({}, obj, { form: form });
+          acc[parent].teams.push(obj);
+        } else {
+          const key = obj.group.name;
+          if (!acc[key]) {
+            acc[key] = {
+              enrollments: [],
+              teams: []
+            };
+          }
+          obj = Object.assign({}, obj, { form: form });
+          acc[key].enrollments.push(obj);
+        }
+        return acc;
+      }, {});
+    },
+    withdrawAll() {
+      this.enrollments.forEach(enrollment => {
+        this.$emit("withdraw", {
+          name: enrollment.group.name,
+          fromDate: enrollment.start,
+          toDate: enrollment.end,
+          parentOrg: enrollment.group.parentOrg
+            ? enrollment.group.parentOrg.name
+            : null
+        });
+      });
+    }
+  },
+  watch: {
+    enrollments(value) {
+      this.items = this.groupEnrollments(value);
+    }
+  },
+  created() {
+    this.items = this.groupEnrollments(this.enrollments);
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/index.scss";
+.indented {
+  margin-left: 56px;
+  margin-right: 12px;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid #e5e5e5;
+  }
+}
+
+li {
+  list-style-type: none;
+  padding: 8px;
+  padding-left: 16px;
+  border-left: 1px solid #e5e5e5;
+}
+
+.v-small-dialog__activator {
+  .v-icon {
+    opacity: 0;
+    padding-bottom: 2px;
+  }
+
+  &:hover {
+    .v-icon {
+      opacity: 1;
+    }
+  }
+}
+.v-small-dialog,
+::v-deep .v-small-dialog__activator {
+  display: inline-block;
+}
+</style>

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -161,234 +161,16 @@
       </v-list-item>
     </v-list>
 
-    <v-subheader class="d-flex justify-space-between">
-      Organizations ({{ enrollments.length }})
-      <v-btn
-        v-if="!compact"
-        text
-        small
-        outlined
-        :disabled="enrollments.length < 1 || isLocked"
-        @click="withdrawAll"
-      >
-        <v-icon small left>mdi-delete</v-icon>
-        Remove all
-      </v-btn>
-    </v-subheader>
-    <v-simple-table v-if="compact" dense>
-      <template v-slot:default>
-        <thead v-if="enrollments.length > 0">
-          <tr>
-            <th class="text-left">Name</th>
-            <th class="text-left">From</th>
-            <th class="text-left">To</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="enrollment in enrollments" :key="enrollment.name">
-            <td>{{ enrollment.group.name }}</td>
-            <td>{{ formatDate(enrollment.start) }}</td>
-            <td>{{ formatDate(enrollment.end) }}</td>
-          </tr>
-        </tbody>
-      </template>
-    </v-simple-table>
-    <v-list v-else class="indented" dense>
-      <v-list-item
-        v-for="(enrollment, index) in enrollments"
-        :key="enrollment.group.id"
-        class="row-border"
-      >
-        <v-list-item-content>
-          <v-row no-gutters class="flex align-center">
-            <v-col>
-              <span>{{ enrollment.group.name }}</span>
-            </v-col>
-            <v-col class="col-3 ma-2 text-center">
-              <span v-if="isLocked">
-                {{ formatDate(enrollment.start) }}
-              </span>
-              <v-menu
-                v-else
-                v-model="enrollmentsForm[index].fromDateMenu"
-                :close-on-content-click="false"
-                :return-value.sync="enrollmentsForm[index].fromDate"
-                transition="scale-transition"
-                offset-y
-                min-width="290px"
-              >
-                <template v-slot:activator="{ on, attrs }">
-                  <button
-                    v-on="on"
-                    v-bind="attrs"
-                    class="v-small-dialog__activator"
-                  >
-                    {{ formatDate(enrollment.start) }}
-                    <v-icon small right>
-                      mdi-lead-pencil
-                    </v-icon>
-                  </button>
-                </template>
-                <v-date-picker
-                  v-model="enrollmentsForm[index].fromDate"
-                  :max="enrollment.end"
-                  color="primary"
-                  no-title
-                  scrollable
-                >
-                  <v-spacer></v-spacer>
-                  <v-btn
-                    text
-                    color="primary"
-                    @click="enrollmentsForm[index].fromDateMenu = false"
-                  >
-                    Cancel
-                  </v-btn>
-                  <v-btn
-                    text
-                    color="primary"
-                    @click="
-                      $emit('updateEnrollment', {
-                        fromDate: enrollment.start,
-                        toDate: enrollment.end,
-                        newFromDate: new Date(
-                          enrollmentsForm[index].fromDate
-                        ).toISOString(),
-                        group: enrollment.group.name,
-                        uuid: uuid,
-                        parentOrg: enrollment.group.parentOrg
-                          ? enrollment.group.parentOrg.name
-                          : null
-                      });
-                      enrollmentsForm[index].fromDateMenu = false;
-                    "
-                  >
-                    Save
-                  </v-btn>
-                </v-date-picker>
-              </v-menu>
-            </v-col>
-            <v-col class="col-3 ma-2 text-center">
-              <span v-if="isLocked">
-                {{ formatDate(enrollment.end) }}
-              </span>
-              <v-menu
-                v-else
-                v-model="enrollmentsForm[index].toDateMenu"
-                :close-on-content-click="false"
-                :return-value.sync="enrollmentsForm[index].toate"
-                transition="scale-transition"
-                offset-y
-                min-width="290px"
-              >
-                <template v-slot:activator="{ on, attrs }">
-                  <button
-                    v-on="on"
-                    v-bind="attrs"
-                    class="v-small-dialog__activator"
-                  >
-                    {{ formatDate(enrollment.end) }}
-                    <v-icon small right>
-                      mdi-lead-pencil
-                    </v-icon>
-                  </button>
-                </template>
-                <v-date-picker
-                  v-model="enrollmentsForm[index].toDate"
-                  :min="enrollment.start"
-                  color="primary"
-                  no-title
-                  scrollable
-                >
-                  <v-spacer></v-spacer>
-                  <v-btn
-                    text
-                    color="primary"
-                    @click="enrollmentsForm[index].toDateMenu = false"
-                  >
-                    Cancel
-                  </v-btn>
-                  <v-btn
-                    text
-                    color="primary"
-                    @click="
-                      $emit('updateEnrollment', {
-                        fromDate: enrollment.start,
-                        toDate: enrollment.end,
-                        newToDate: new Date(
-                          enrollmentsForm[index].toDate
-                        ).toISOString(),
-                        group: enrollment.group.name,
-                        uuid: uuid,
-                        parentOrg: enrollment.group.parentOrg
-                          ? enrollment.group.parentOrg.name
-                          : null
-                      });
-                      enrollmentsForm[index].toDateMenu = false;
-                    "
-                  >
-                    Save
-                  </v-btn>
-                </v-date-picker>
-              </v-menu>
-            </v-col>
-            <v-col class="text-end col-2">
-              <v-tooltip
-                v-if="enrollment.group.type === 'organization'"
-                bottom
-                transition="expand-y-transition"
-                open-delay="200"
-              >
-                <template v-slot:activator="{ on }">
-                  <v-btn
-                    v-on="on"
-                    @click="
-                      $emit('openModal', {
-                        organization: enrollment.group.name,
-                        uuid: uuid
-                      })
-                    "
-                    icon
-                  >
-                    <v-icon>mdi-account-multiple-plus</v-icon>
-                  </v-btn>
-                </template>
-                <span>Add to team</span>
-              </v-tooltip>
-
-              <v-tooltip
-                bottom
-                transition="expand-y-transition"
-                open-delay="200"
-              >
-                <template v-slot:activator="{ on }">
-                  <v-btn
-                    icon
-                    v-on="on"
-                    :disabled="isLocked"
-                    @click="
-                      $emit('withdraw', {
-                        name: enrollment.group.name,
-                        fromDate: enrollment.start,
-                        toDate: enrollment.end,
-                        parentOrg: enrollment.group.parentOrg
-                          ? enrollment.group.parentOrg.name
-                          : null
-                      })
-                    "
-                  >
-                    <v-icon>
-                      mdi-delete
-                    </v-icon>
-                  </v-btn>
-                </template>
-                <span>Remove affiliation</span>
-              </v-tooltip>
-            </v-col>
-          </v-row>
-        </v-list-item-content>
-      </v-list-item>
-    </v-list>
+    <enrollment-list
+      :enrollments="enrollments"
+      :compact="compact"
+      :is-locked="isLocked"
+      @openModal="$emit('openModal', { uuid, organization: $event })"
+      @updateEnrollment="
+        $emit('updateEnrollment', Object.assign($event, { uuid: uuid }))
+      "
+      @withdraw="$emit('withdraw', $event)"
+    />
 
     <v-card class="dragged-identity" color="primary" dark>
       <v-card-subtitle> Moving 1 identity</v-card-subtitle>
@@ -398,11 +180,13 @@
 
 <script>
 import Identity from "./Identity.vue";
+import EnrollmentList from "./EnrollmentList.vue";
 
 export default {
   name: "ExpandedIndividual",
   components: {
-    Identity
+    Identity,
+    EnrollmentList
   },
   props: {
     gender: {
@@ -455,9 +239,6 @@ export default {
     };
   },
   methods: {
-    formatDate(dateTime) {
-      return dateTime.split("T")[0];
-    },
     sortSources(identities, property) {
       return identities.slice().sort((a, b) => {
         const sourceA = a[property].toLowerCase();
@@ -486,28 +267,6 @@ export default {
     splitAll() {
       const uuids = this.flatIdentities.map(identity => identity.uuid);
       this.$emit("unmerge", uuids);
-    },
-    withdrawAll() {
-      this.enrollments.forEach(enrollment => {
-        this.$emit("withdraw", {
-          name: enrollment.group.name,
-          fromDate: enrollment.start,
-          toDate: enrollment.end,
-          parentOrg: enrollment.group.parentOrg
-            ? enrollment.group.parentOrg.name
-            : null
-        });
-      });
-    },
-    createForm() {
-      this.enrollmentsForm = this.enrollments.map(enrollment => {
-        return {
-          fromDate: this.formatDate(enrollment.start),
-          fromDateMenu: false,
-          toDate: this.formatDate(enrollment.end),
-          toDateMenu: false
-        };
-      });
     }
   },
   computed: {
@@ -526,14 +285,6 @@ export default {
         )
         .flat();
     }
-  },
-  watch: {
-    enrollments() {
-      this.createForm();
-    }
-  },
-  created() {
-    this.createForm();
   }
 };
 </script>

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -364,7 +364,10 @@
                       $emit('withdraw', {
                         name: enrollment.group.name,
                         fromDate: enrollment.start,
-                        toDate: enrollment.end
+                        toDate: enrollment.end,
+                        parentOrg: enrollment.group.parentOrg
+                          ? enrollment.group.parentOrg.name
+                          : null
                       })
                     "
                   >
@@ -481,7 +484,10 @@ export default {
         this.$emit("withdraw", {
           name: enrollment.group.name,
           fromDate: enrollment.start,
-          toDate: enrollment.end
+          toDate: enrollment.end,
+          parentOrg: enrollment.group.parentOrg
+            ? enrollment.group.parentOrg.name
+            : null
         });
       });
     },

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -328,6 +328,29 @@
             </v-col>
             <v-col class="text-end col-2">
               <v-tooltip
+                v-if="enrollment.group.type === 'organization'"
+                bottom
+                transition="expand-y-transition"
+                open-delay="200"
+              >
+                <template v-slot:activator="{ on }">
+                  <v-btn
+                    v-on="on"
+                    @click="
+                      $emit('openModal', {
+                        organization: enrollment.group.name,
+                        uuid: uuid
+                      })
+                    "
+                    icon
+                  >
+                    <v-icon>mdi-account-multiple-plus</v-icon>
+                  </v-btn>
+                </template>
+                <span>Add to team</span>
+              </v-tooltip>
+
+              <v-tooltip
                 bottom
                 transition="expand-y-transition"
                 open-delay="200"
@@ -366,7 +389,6 @@
 
 <script>
 import Identity from "./Identity.vue";
-
 export default {
   name: "ExpandedIndividual",
   components: {
@@ -430,7 +452,6 @@ export default {
       return identities.slice().sort((a, b) => {
         const sourceA = a[property].toLowerCase();
         const sourceB = b[property].toLowerCase();
-
         return sourceA.localeCompare(sourceB);
       });
     },
@@ -463,6 +484,16 @@ export default {
           toDate: enrollment.end
         });
       });
+    },
+    createForm() {
+      this.enrollmentsForm = this.enrollments.map(enrollment => {
+        return {
+          fromDate: this.formatDate(enrollment.start),
+          fromDateMenu: false,
+          toDate: this.formatDate(enrollment.end),
+          toDateMenu: false
+        };
+      });
     }
   },
   computed: {
@@ -482,15 +513,13 @@ export default {
         .flat();
     }
   },
+  watch: {
+    enrollments() {
+      this.createForm();
+    }
+  },
   created() {
-    this.enrollments.forEach(enrollment => {
-      this.enrollmentsForm.push({
-        fromDate: this.formatDate(enrollment.start),
-        fromDateMenu: false,
-        toDate: this.formatDate(enrollment.end),
-        toDateMenu: false
-      });
-    });
+    this.createForm();
   }
 };
 </script>
@@ -500,54 +529,44 @@ export default {
   margin-left: 40px;
   background-color: transparent;
 }
-
 .draggable {
   cursor: pointer;
-
   &:hover {
     background: #eeeeee;
   }
 }
-
 .dragged-identity {
   max-width: 300px;
   position: absolute;
   top: -300px;
 }
-
 .compact {
   border-bottom: 0;
   background-color: #ffffff;
   font-size: 0.9rem;
   line-height: 1rem;
   padding: 0.5rem;
-
   .v-list-item__content,
   .v-sheet--tile {
     padding: 0;
   }
-
   ::v-deep .uuid {
     display: none;
   }
-
   ::v-deep .indented {
     padding: 0;
     margin: 0;
     text-align: center;
   }
-
   .row-border:not(:last-child) {
     border: 0;
   }
 }
-
 .v-small-dialog__activator {
   .v-icon {
     opacity: 0;
     padding-bottom: 2px;
   }
-
   &:hover {
     .v-icon {
       opacity: 1;

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -255,7 +255,10 @@
                           enrollmentsForm[index].fromDate
                         ).toISOString(),
                         group: enrollment.group.name,
-                        uuid: uuid
+                        uuid: uuid,
+                        parentOrg: enrollment.group.parentOrg
+                          ? enrollment.group.parentOrg.name
+                          : null
                       });
                       enrollmentsForm[index].fromDateMenu = false;
                     "
@@ -316,7 +319,10 @@
                           enrollmentsForm[index].toDate
                         ).toISOString(),
                         group: enrollment.group.name,
-                        uuid: uuid
+                        uuid: uuid,
+                        parentOrg: enrollment.group.parentOrg
+                          ? enrollment.group.parentOrg.name
+                          : null
                       });
                       enrollmentsForm[index].toDateMenu = false;
                     "
@@ -392,6 +398,7 @@
 
 <script>
 import Identity from "./Identity.vue";
+
 export default {
   name: "ExpandedIndividual",
   components: {
@@ -455,6 +462,7 @@ export default {
       return identities.slice().sort((a, b) => {
         const sourceA = a[property].toLowerCase();
         const sourceB = b[property].toLowerCase();
+
         return sourceA.localeCompare(sourceB);
       });
     },
@@ -535,44 +543,54 @@ export default {
   margin-left: 40px;
   background-color: transparent;
 }
+
 .draggable {
   cursor: pointer;
+
   &:hover {
     background: #eeeeee;
   }
 }
+
 .dragged-identity {
   max-width: 300px;
   position: absolute;
   top: -300px;
 }
+
 .compact {
   border-bottom: 0;
   background-color: #ffffff;
   font-size: 0.9rem;
   line-height: 1rem;
   padding: 0.5rem;
+
   .v-list-item__content,
   .v-sheet--tile {
     padding: 0;
   }
+
   ::v-deep .uuid {
     display: none;
   }
+
   ::v-deep .indented {
     padding: 0;
     margin: 0;
     text-align: center;
   }
+
   .row-border:not(:last-child) {
     border: 0;
   }
 }
+
 .v-small-dialog__activator {
   .v-icon {
     opacity: 0;
     padding-bottom: 2px;
   }
+
   &:hover {
     .v-icon {
       opacity: 1;

--- a/ui/src/components/IndividualsTable.stories.js
+++ b/ui/src/components/IndividualsTable.stories.js
@@ -95,7 +95,7 @@ export const Default = () => ({
                 ],
                 enrollments: [
                   {
-                    organization: {
+                    group: {
                       name: "Slytherin",
                       id: "2"
                     },
@@ -103,7 +103,7 @@ export const Default = () => ({
                     end: "1998-05-02T00:00:00+00:00"
                   },
                   {
-                    organization: {
+                    group: {
                       name: "Hogwarts School of Witchcraft and Wizardry",
                       id: "1"
                     },
@@ -146,7 +146,7 @@ export const Default = () => ({
                 ],
                 enrollments: [
                   {
-                    organization: {
+                    group: {
                       name: "Griffyndor",
                       id: "2"
                     },
@@ -154,7 +154,7 @@ export const Default = () => ({
                     end: "1997-06-02T00:00:00+00:00"
                   },
                   {
-                    organization: {
+                    group: {
                       name: "Hogwarts School of Witchcraft and Wizardry",
                       id: "1"
                     },
@@ -183,7 +183,7 @@ export const Default = () => ({
                 ],
                 enrollments: [
                   {
-                    organization: {
+                    group: {
                       name: "Death Eaters",
                       id: "1"
                     },
@@ -219,7 +219,7 @@ export const Default = () => ({
                 ],
                 enrollments: [
                   {
-                    organization: {
+                    group: {
                       name: "Griffyndor",
                       id: "2"
                     },
@@ -227,7 +227,7 @@ export const Default = () => ({
                     end: "1997-06-02T00:00:00+00:00"
                   },
                   {
-                    organization: {
+                    group: {
                       name: "Hogwarts School of Witchcraft and Wizardry",
                       id: "1"
                     },
@@ -263,7 +263,7 @@ export const Default = () => ({
                 ],
                 enrollments: [
                   {
-                    organization: {
+                    group: {
                       name: "Griffyndor",
                       id: "2"
                     },
@@ -271,7 +271,7 @@ export const Default = () => ({
                     end: "1997-06-02T00:00:00+00:00"
                   },
                   {
-                    organization: {
+                    group: {
                       name: "Hogwarts School of Witchcraft and Wizardry",
                       id: "1"
                     },
@@ -328,7 +328,7 @@ export const Default = () => ({
                 ],
                 enrollments: [
                   {
-                    organization: {
+                    group: {
                       name: "Order of the Phoenix",
                       id: "1"
                     },
@@ -336,7 +336,7 @@ export const Default = () => ({
                     end: "1981-06-02T00:00:00+00:00"
                   },
                   {
-                    organization: {
+                    group: {
                       name: "Hogwarts School of Witchcraft and Wizardry",
                       id: "2"
                     },
@@ -344,7 +344,7 @@ export const Default = () => ({
                     end: "1899-06-02T00:00:00+00:00"
                   },
                   {
-                    organization: {
+                    group: {
                       name: "Griffyndor House",
                       id: "3"
                     },

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -146,6 +146,7 @@
           @unmerge="unmerge($event)"
           @withdraw="removeAffiliation($event, item.uuid)"
           @updateEnrollment="updateEnrollmentDate"
+          @openModal="openTeamModal"
         />
       </template>
     </v-data-table>
@@ -228,6 +229,15 @@
       @updateOrganizations="$emit('updateOrganizations')"
     />
 
+    <team-enroll-modal
+      v-if="teamModal.isOpen"
+      :is-open.sync="teamModal.isOpen"
+      :organization="teamModal.organization"
+      :uuid="teamModal.uuid"
+      :enroll="enroll"
+      @updateTable="queryIndividuals"
+    />
+
     <v-card class="dragged-item" color="primary" dark>
       <v-card-subtitle>
         Moving
@@ -249,6 +259,7 @@ import IndividualEntry from "./IndividualEntry.vue";
 import ExpandedIndividual from "./ExpandedIndividual.vue";
 import ProfileModal from "./ProfileModal.vue";
 import Search from "./Search.vue";
+import TeamEnrollModal from "./TeamEnrollModal.vue";
 
 export default {
   name: "IndividualsTable",
@@ -256,7 +267,8 @@ export default {
     IndividualEntry,
     ExpandedIndividual,
     ProfileModal,
-    Search
+    Search,
+    TeamEnrollModal
   },
   mixins: [enrollMixin],
   props: {
@@ -347,7 +359,12 @@ export default {
       totalResults: 0,
       itemsPerPage: 10,
       allSelected: false,
-      orderBy: null
+      orderBy: null,
+      teamModal: {
+        isOpen: false,
+        organization: null,
+        uuid: null
+      }
     };
   },
   computed: {
@@ -656,6 +673,14 @@ export default {
         dateFrom: null,
         dateTo: null
       });
+    },
+    openTeamModal(data) {
+      const { organization, uuid } = data;
+      Object.assign(this.teamModal, {
+        isOpen: true,
+        organization,
+        uuid
+      });
     }
   }
 };
@@ -669,7 +694,6 @@ export default {
   ::v-deep .v-label {
     font-size: 0.9rem;
   }
-
   ::v-deep .v-input--checkbox {
     padding-top: 6px;
     margin-left: -1px;

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -598,21 +598,24 @@ export default {
         }
       }
     },
-    async removeAffiliation(organization, uuid) {
+    async removeAffiliation(group, uuid) {
       try {
         const response = await this.withdraw(
           uuid,
-          organization.name,
-          organization.fromDate,
-          organization.toDate
+          group.name,
+          group.fromDate,
+          group.toDate,
+          group.parentOrg
         );
         if (response && response.data.withdraw) {
           this.queryIndividuals();
           this.$emit("updateWorkspace", {
             update: formatIndividuals([response.data.withdraw.individual])
           });
-          this.$emit("updateOrganizations");
-          this.$logger.debug("Removed affiliation", { uuid, ...organization });
+          this.$logger.debug("Removed affiliation", { uuid, ...group });
+          if (!group.parentOrg) {
+            this.$emit("updateOrganizations");
+          }
         }
       } catch (error) {
         Object.assign(this.dialog, {
@@ -623,7 +626,7 @@ export default {
         });
         this.$logger.error(`Error removing affiliation: ${error}`, {
           uuid,
-          ...organization
+          ...group
         });
       }
     },

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -3,7 +3,7 @@
     <v-row class="header">
       <h3 class="title">
         <v-icon color="black" left dense>
-          mdi-account-multiple
+          mdi-account
         </v-icon>
         Individuals
         <v-chip pill small class="ml-2">{{ totalResults }}</v-chip>
@@ -697,6 +697,7 @@ export default {
   ::v-deep .v-label {
     font-size: 0.9rem;
   }
+
   ::v-deep .v-input--checkbox {
     padding-top: 6px;
     margin-left: -1px;

--- a/ui/src/components/TeamEnrollModal.stories.js
+++ b/ui/src/components/TeamEnrollModal.stories.js
@@ -1,0 +1,41 @@
+import TeamEnrollModal from "./TeamEnrollModal.vue";
+
+export default {
+  title: "TeamEnrollModal",
+  excludeStories: /.*Data$/
+};
+
+const template = `<team-enroll-modal
+    :is-open='isOpen'
+    :organization='organization'
+    :enroll='enroll'
+    uuid="123"
+  />`;
+
+export const Default = () => ({
+  components: { TeamEnrollModal },
+  template: template,
+  data: () => ({
+    isOpen: true,
+    organization: "Hogwarts"
+  }),
+  methods: {
+    enroll() {
+      return true;
+    }
+  }
+});
+
+export const ErrorOnSave = () => ({
+  components: { TeamEnrollModal },
+  template: template,
+  data: () => ({
+    isOpen: true,
+    organization: "Hogwarts"
+  }),
+  methods: {
+    enroll() {
+      throw "Example error";
+    }
+  }
+});

--- a/ui/src/components/TeamEnrollModal.stories.js
+++ b/ui/src/components/TeamEnrollModal.stories.js
@@ -5,18 +5,25 @@ export default {
   excludeStories: /.*Data$/
 };
 
-const template = `<team-enroll-modal
-    :is-open='isOpen'
-    :organization='organization'
-    :enroll='enroll'
-    uuid="123"
-  />`;
+const template = `
+  <div data-app="true" class="ma-auto">
+    <v-btn color="primary" dark @click.stop="isOpen = true">
+      Open Dialog
+    </v-btn>
+    <team-enroll-modal
+      :is-open.sync='isOpen'
+      :organization='organization'
+      :enroll='enroll'
+      uuid="123"
+    />
+  </div>
+`;
 
 export const Default = () => ({
   components: { TeamEnrollModal },
   template: template,
   data: () => ({
-    isOpen: true,
+    isOpen: false,
     organization: "Hogwarts"
   }),
   methods: {
@@ -30,7 +37,7 @@ export const ErrorOnSave = () => ({
   components: { TeamEnrollModal },
   template: template,
   data: () => ({
-    isOpen: true,
+    isOpen: false,
     organization: "Hogwarts"
   }),
   methods: {

--- a/ui/src/components/TeamEnrollModal.vue
+++ b/ui/src/components/TeamEnrollModal.vue
@@ -1,0 +1,148 @@
+<template>
+  <v-dialog v-model="isOpen" persistent max-width="650">
+    <v-card class="section">
+      <v-card-title class="header">
+        <span class="title">Add to {{ organization }} team</span>
+      </v-card-title>
+      <v-card-text class="mt-3">
+        <v-form ref="form">
+          <v-row>
+            <v-col cols="4">
+              <v-text-field
+                v-model="form.team"
+                :rules="validations.required"
+                label="Team"
+                outlined
+                dense
+              />
+            </v-col>
+            <v-col cols="4">
+              <date-input
+                v-model="form.dateFrom"
+                :max="form.dateTo"
+                label="Date from"
+                outlined
+              />
+            </v-col>
+            <v-col cols="4">
+              <date-input
+                v-model="form.dateTo"
+                :min="form.dateFrom"
+                label="Date to"
+                outlined
+              />
+            </v-col>
+          </v-row>
+        </v-form>
+
+        <v-alert v-if="errorMessage" text type="error">
+          {{ errorMessage }}
+        </v-alert>
+
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="primary darken-1" text @click.prevent="closeModal">
+            Cancel
+          </v-btn>
+          <v-btn
+            depressed
+            color="primary"
+            :disabled="!form.team"
+            @click.prevent="onSave"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import DateInput from "./DateInput.vue";
+
+export default {
+  name: "TeamEnrollModal",
+  components: { DateInput },
+  props: {
+    isOpen: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    uuid: {
+      type: String,
+      required: true
+    },
+    organization: {
+      type: String,
+      required: false
+    },
+    enroll: {
+      type: Function,
+      required: true
+    }
+  },
+  data() {
+    return {
+      form: {
+        team: null,
+        dateFrom: null,
+        dateTo: null
+      },
+      validations: {
+        required: [value => !!value || "Required"]
+      },
+      errorMessage: null
+    };
+  },
+  methods: {
+    closeModal() {
+      this.$emit("update:isOpen", false);
+      this.$emit("updateTable");
+      this.$refs.form.reset();
+      this.form = [
+        {
+          team: null,
+          dateFrom: null,
+          dateTo: null
+        }
+      ];
+      this.errorMessage = null;
+    },
+    async onSave() {
+      const isValid = this.$refs.form.validate();
+      if (!isValid) {
+        return;
+      }
+
+      try {
+        const response = await this.enroll(
+          this.uuid,
+          this.form.team,
+          this.form.dateFrom,
+          this.form.dateTo,
+          this.organization
+        );
+
+        if (response && !response.errors) {
+          this.$logger.debug(`Enrolled individual ${this.uuid}`, {
+            uuid: this.uuid,
+            group: this.form.team,
+            parentOrg: this.organization,
+            fromDate: this.form.dateFrom,
+            toDate: this.form.dateTo
+          });
+          this.closeModal();
+        }
+      } catch (error) {
+        this.errorMessage = this.$getErrorMessage(error);
+        this.$logger.error(
+          `Error enrolling individual ${this.uuid}: ${error}`,
+          this.form
+        );
+      }
+    }
+  }
+};
+</script>

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -284,13 +284,14 @@ export default {
       const response = await unlockIndividual(this.$apollo, uuid);
       return response;
     },
-    async withdraw(uuid, group, fromDate, toDate) {
+    async withdraw(uuid, group, fromDate, toDate, parentOrg) {
       const response = await withdraw(
         this.$apollo,
         uuid,
         group,
         fromDate,
-        toDate
+        toDate,
+        parentOrg
       );
       return response;
     },

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -223,13 +223,14 @@ export default {
     deselectIndividuals() {
       this.$refs.table.deselectIndividuals();
     },
-    async enroll(uuid, group, fromDate, toDate) {
+    async enroll(uuid, group, fromDate, toDate, parentOrg) {
       const response = await enroll(
         this.$apollo,
         uuid,
         group,
         fromDate,
-        toDate
+        toDate,
+        parentOrg
       );
       return response;
     },

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -182,7 +182,7 @@ export default {
       return response;
     },
     updateOrganizations() {
-      this.$refs.organizations.getOrganizations();
+      this.$refs.organizations.getTableItems();
     },
     updateTable() {
       this.$refs.table.queryIndividuals();

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -17,7 +17,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -340,6 +340,8 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
     getcountries="() => {}"
     updateprofile="() => {}"
   />
+   
+  <!---->
    
   <v-card-stub
     class="dragged-item"
@@ -376,7 +378,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -699,6 +701,8 @@ exports[`IndividualsTable Mock query for merge 1`] = `
     getcountries="() => {}"
     updateprofile="() => {}"
   />
+   
+  <!---->
    
   <v-card-stub
     class="dragged-item"
@@ -735,7 +739,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -1058,6 +1062,8 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
     getcountries="() => {}"
     updateprofile="() => {}"
   />
+   
+  <!---->
    
   <v-card-stub
     class="dragged-item"
@@ -1094,7 +1100,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -1417,6 +1423,8 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
     getcountries="() => {}"
     updateprofile="() => {}"
   />
+   
+  <!---->
    
   <v-card-stub
     class="dragged-item"
@@ -1453,7 +1461,7 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -1776,6 +1784,8 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
     getcountries="() => {}"
     updateprofile="() => {}"
   />
+   
+  <!---->
    
   <v-card-stub
     class="dragged-item"
@@ -1812,7 +1822,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -2135,6 +2145,8 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
     getcountries="() => {}"
     updateprofile="() => {}"
   />
+   
+  <!---->
    
   <v-card-stub
     class="dragged-item"

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -24,7 +24,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -350,6 +350,8 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
     updateprofile="() => {}"
   />
    
+  <!---->
+   
   <v-card-stub
     class="dragged-item"
     color="primary"
@@ -385,7 +387,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
         left=""
       >
         
-        mdi-account-multiple
+        mdi-account
       
       </v-icon-stub>
       
@@ -708,6 +710,8 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
     getcountries="() => {}"
     updateprofile="() => {}"
   />
+   
+  <!---->
    
   <v-card-stub
     class="dragged-item"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -363,6 +363,722 @@ exports[`Storyshots DateInput Outlined 1`] = `
 </div>
 `;
 
+exports[`Storyshots EnrollmentList Compact 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div>
+      <div
+        class="v-subheader d-flex justify-space-between theme--light"
+      >
+        
+    Organizations (3)
+    
+        <!---->
+      </div>
+       
+      <div
+        class="v-data-table v-data-table--dense theme--light"
+      >
+        <div
+          class="v-data-table__wrapper"
+        >
+          <table>
+            <thead>
+              <tr>
+                <th
+                  class="text-left"
+                >
+                  Name
+                </th>
+                 
+                <th
+                  class="text-left"
+                >
+                  From
+                </th>
+                 
+                <th
+                  class="text-left"
+                >
+                  To
+                </th>
+              </tr>
+            </thead>
+             
+            <tbody>
+              <tr>
+                <td>
+                  Hogwarts
+                </td>
+                 
+                <td>
+                  1892-09-01
+                </td>
+                 
+                <td>
+                  1997-06-30
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Gryffindor
+                </td>
+                 
+                <td>
+                  1892-09-01
+                </td>
+                 
+                <td>
+                  1899-06-02
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Transfiguration department
+                </td>
+                 
+                <td>
+                  1910-09-01
+                </td>
+                 
+                <td>
+                  1969-06-01
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Order of the Phoenix
+                </td>
+                 
+                <td>
+                  1970-10-01
+                </td>
+                 
+                <td>
+                  1997-06-30
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  International Confederation of Wizards
+                </td>
+                 
+                <td>
+                  1991-01-01
+                </td>
+                 
+                <td>
+                  1995-04-02
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots EnrollmentList Default 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div>
+      <div
+        class="v-subheader d-flex justify-space-between theme--light"
+      >
+        
+    Organizations (3)
+    
+        <button
+          class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+              style="font-size: 16px;"
+            />
+            
+      Remove all
+    
+          </span>
+        </button>
+      </div>
+       
+      <div
+        class="indented mt-2 mb-4"
+      >
+        <div
+          class="mb-2 d-flex justify-space-between align-center"
+        >
+          <div>
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+              />
+            </span>
+            
+        Hogwarts
+
+        
+            <div
+              class="v-menu"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="v-small-dialog__activator"
+                role="button"
+              >
+                <span
+                  class="grey--text text--darken-2 ml-6"
+                >
+                  
+                1892-09-01
+              
+                </span>
+                 
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                  style="font-size: 16px;"
+                />
+              </button>
+              <!---->
+            </div>
+            
+        -
+        
+            <div
+              class="v-menu"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="v-small-dialog__activator ml-5"
+                role="button"
+              >
+                <span
+                  class="grey--text text--darken-2 ml-2"
+                >
+                  
+                1997-06-30
+              
+                </span>
+                 
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                  style="font-size: 16px;"
+                />
+              </button>
+              <!---->
+            </div>
+          </div>
+           
+          <div>
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-account-multiple-plus theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-delete theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+          </div>
+        </div>
+         
+        <ul
+          class="ma-2 mr-0"
+        >
+          <li
+            class="d-flex justify-space-between pr-0"
+          >
+            <div
+              class="d-flex align-center"
+            >
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-account-multiple theme--light"
+                />
+              </span>
+               
+              <span
+                class="mr-4"
+              >
+                Gryffindor
+              </span>
+               
+              <div
+                class="v-menu"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator"
+                  role="button"
+                >
+                  <span
+                    class="grey--text text--darken-2 ml-6"
+                  >
+                    
+                  1892-09-01
+                
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
+              </div>
+              
+          -
+          
+              <div
+                class="v-menu"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator ml-5"
+                  role="button"
+                >
+                  <span
+                    class="grey--text text--darken-2 ml-2"
+                  >
+                    
+                  1899-06-02
+                
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
+              </div>
+            </div>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-delete theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+          </li>
+          <li
+            class="d-flex justify-space-between pr-0"
+          >
+            <div
+              class="d-flex align-center"
+            >
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-account-multiple theme--light"
+                />
+              </span>
+               
+              <span
+                class="mr-4"
+              >
+                Transfiguration department
+              </span>
+               
+              <div
+                class="v-menu"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator"
+                  role="button"
+                >
+                  <span
+                    class="grey--text text--darken-2 ml-6"
+                  >
+                    
+                  1910-09-01
+                
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
+              </div>
+              
+          -
+          
+              <div
+                class="v-menu"
+              >
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator ml-5"
+                  role="button"
+                >
+                  <span
+                    class="grey--text text--darken-2 ml-2"
+                  >
+                    
+                  1969-06-01
+                
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
+              </div>
+            </div>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-delete theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+          </li>
+        </ul>
+      </div>
+      <div
+        class="indented mt-2 mb-4"
+      >
+        <div
+          class="mb-2 d-flex justify-space-between align-center"
+        >
+          <div>
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+              />
+            </span>
+            
+        Order of the Phoenix
+
+        
+            <div
+              class="v-menu"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="v-small-dialog__activator"
+                role="button"
+              >
+                <span
+                  class="grey--text text--darken-2 ml-6"
+                >
+                  
+                1970-10-01
+              
+                </span>
+                 
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                  style="font-size: 16px;"
+                />
+              </button>
+              <!---->
+            </div>
+            
+        -
+        
+            <div
+              class="v-menu"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="v-small-dialog__activator ml-5"
+                role="button"
+              >
+                <span
+                  class="grey--text text--darken-2 ml-2"
+                >
+                  
+                1997-06-30
+              
+                </span>
+                 
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                  style="font-size: 16px;"
+                />
+              </button>
+              <!---->
+            </div>
+          </div>
+           
+          <div>
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-account-multiple-plus theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-delete theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+          </div>
+        </div>
+         
+        <ul
+          class="ma-2 mr-0"
+        />
+      </div>
+      <div
+        class="indented mt-2 mb-4"
+      >
+        <div
+          class="mb-2 d-flex justify-space-between align-center"
+        >
+          <div>
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+              />
+            </span>
+            
+        International Confederation of Wizards
+
+        
+            <div
+              class="v-menu"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="v-small-dialog__activator"
+                role="button"
+              >
+                <span
+                  class="grey--text text--darken-2 ml-6"
+                >
+                  
+                1991-01-01
+              
+                </span>
+                 
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                  style="font-size: 16px;"
+                />
+              </button>
+              <!---->
+            </div>
+            
+        -
+        
+            <div
+              class="v-menu"
+            >
+              <button
+                aria-expanded="false"
+                aria-haspopup="true"
+                class="v-small-dialog__activator ml-5"
+                role="button"
+              >
+                <span
+                  class="grey--text text--darken-2 ml-2"
+                >
+                  
+                1995-04-02
+              
+                </span>
+                 
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                  style="font-size: 16px;"
+                />
+              </button>
+              <!---->
+            </div>
+          </div>
+           
+          <div>
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-account-multiple-plus theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-delete theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+          </div>
+        </div>
+         
+        <ul
+          class="ma-2 mr-0"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots ExpandedIndividual Compact 1`] = `
 <div
   class="v-application v-application--is-ltr theme--light"
@@ -535,73 +1251,75 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
         </div>
       </div>
        
-      <div
-        class="v-subheader d-flex justify-space-between theme--light"
-      >
-        
+      <div>
+        <div
+          class="v-subheader d-flex justify-space-between theme--light"
+        >
+          
     Organizations (2)
     
-        <!---->
-      </div>
-       
-      <div
-        class="v-data-table v-data-table--dense theme--light"
-      >
+          <!---->
+        </div>
+         
         <div
-          class="v-data-table__wrapper"
+          class="v-data-table v-data-table--dense theme--light"
         >
-          <table>
-            <thead>
-              <tr>
-                <th
-                  class="text-left"
-                >
-                  Name
-                </th>
-                 
-                <th
-                  class="text-left"
-                >
-                  From
-                </th>
-                 
-                <th
-                  class="text-left"
-                >
-                  To
-                </th>
-              </tr>
-            </thead>
-             
-            <tbody>
-              <tr>
-                <td>
-                  Slytherin
-                </td>
-                 
-                <td>
-                  1938-09-01
-                </td>
-                 
-                <td>
-                  1998-05-02
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Hogwarts School of Witchcraft and Wizardry
-                </td>
-                 
-                <td>
-                  1938-09-01
-                </td>
-                 
-                <td>
-                  1945-06-02
-                </td>
-              </tr>
-            </tbody>
-          </table>
+          <div
+            class="v-data-table__wrapper"
+          >
+            <table>
+              <thead>
+                <tr>
+                  <th
+                    class="text-left"
+                  >
+                    Name
+                  </th>
+                   
+                  <th
+                    class="text-left"
+                  >
+                    From
+                  </th>
+                   
+                  <th
+                    class="text-left"
+                  >
+                    To
+                  </th>
+                </tr>
+              </thead>
+               
+              <tbody>
+                <tr>
+                  <td>
+                    Slytherin
+                  </td>
+                   
+                  <td>
+                    1938-09-01
+                  </td>
+                   
+                  <td>
+                    1998-05-02
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    Hogwarts School of Witchcraft and Wizardry
+                  </td>
+                   
+                  <td>
+                    1938-09-01
+                  </td>
+                   
+                  <td>
+                    1945-06-02
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
        
@@ -1186,222 +1904,271 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
         </div>
       </div>
        
-      <div
-        class="v-subheader d-flex justify-space-between theme--light"
-      >
-        
+      <div>
+        <div
+          class="v-subheader d-flex justify-space-between theme--light"
+        >
+          
     Organizations (2)
     
-        <button
-          class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
-          type="button"
-        >
-          <span
-            class="v-btn__content"
+          <button
+            class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            type="button"
           >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
-              style="font-size: 16px;"
-            />
-            
+            <span
+              class="v-btn__content"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+                style="font-size: 16px;"
+              />
+              
       Remove all
     
-          </span>
-        </button>
-      </div>
-       
-      <div
-        class="v-list indented v-sheet theme--light v-list--dense"
-        role="list"
-      >
+            </span>
+          </button>
+        </div>
+         
         <div
-          class="row-border v-list-item theme--light"
-          role="listitem"
-          tabindex="-1"
+          class="indented mt-2 mb-4"
         >
           <div
-            class="v-list-item__content"
+            class="mb-2 d-flex justify-space-between align-center"
           >
-            <div
-              class="row flex align-center no-gutters"
-            >
-              <div
-                class="col"
+            <div>
+              <span
+                class="v-tooltip v-tooltip--bottom"
               >
-                <span>
-                  Slytherin
-                </span>
-              </div>
-               
+                <!---->
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+                />
+              </span>
+              
+        Slytherin
+
+        
               <div
-                class="col-3 ma-2 text-center col"
+                class="v-menu"
               >
-                <div
-                  class="v-menu"
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator"
+                  role="button"
                 >
-                  <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="v-small-dialog__activator"
-                    role="button"
+                  <span
+                    class="grey--text text--darken-2 ml-6"
                   >
                     
-                  1938-09-01
-                  
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </button>
-                  <!---->
-                </div>
+                1938-09-01
+              
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
               </div>
-               
+              
+        -
+        
               <div
-                class="col-3 ma-2 text-center col"
+                class="v-menu"
               >
-                <div
-                  class="v-menu"
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator ml-5"
+                  role="button"
                 >
-                  <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="v-small-dialog__activator"
-                    role="button"
+                  <span
+                    class="grey--text text--darken-2 ml-2"
                   >
                     
-                  1998-05-02
-                  
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </button>
-                  <!---->
-                </div>
-              </div>
-               
-              <div
-                class="text-end col-2 col"
-              >
-                <span
-                  class="v-tooltip v-tooltip--bottom"
-                >
-                  <!---->
-                  <button
-                    class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-                    type="button"
-                  >
-                    <span
-                      class="v-btn__content"
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-delete theme--light"
-                      />
-                    </span>
-                  </button>
-                </span>
+                1998-05-02
+              
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
               </div>
             </div>
+             
+            <div>
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <button
+                  class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                  type="button"
+                >
+                  <span
+                    class="v-btn__content"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate mdi mdi-account-multiple-plus theme--light"
+                    />
+                  </span>
+                </button>
+              </span>
+               
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <button
+                  class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                  type="button"
+                >
+                  <span
+                    class="v-btn__content"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate mdi mdi-delete theme--light"
+                    />
+                  </span>
+                </button>
+              </span>
+            </div>
           </div>
+           
+          <ul
+            class="ma-2 mr-0"
+          />
         </div>
         <div
-          class="row-border v-list-item theme--light"
-          role="listitem"
-          tabindex="-1"
+          class="indented mt-2 mb-4"
         >
           <div
-            class="v-list-item__content"
+            class="mb-2 d-flex justify-space-between align-center"
           >
-            <div
-              class="row flex align-center no-gutters"
-            >
-              <div
-                class="col"
+            <div>
+              <span
+                class="v-tooltip v-tooltip--bottom"
               >
-                <span>
-                  Hogwarts School of Witchcraft and Wizardry
-                </span>
-              </div>
-               
+                <!---->
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+                />
+              </span>
+              
+        Hogwarts School of Witchcraft and Wizardry
+
+        
               <div
-                class="col-3 ma-2 text-center col"
+                class="v-menu"
               >
-                <div
-                  class="v-menu"
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator"
+                  role="button"
                 >
-                  <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="v-small-dialog__activator"
-                    role="button"
+                  <span
+                    class="grey--text text--darken-2 ml-6"
                   >
                     
-                  1938-09-01
-                  
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </button>
-                  <!---->
-                </div>
+                1938-09-01
+              
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
               </div>
-               
+              
+        -
+        
               <div
-                class="col-3 ma-2 text-center col"
+                class="v-menu"
               >
-                <div
-                  class="v-menu"
+                <button
+                  aria-expanded="false"
+                  aria-haspopup="true"
+                  class="v-small-dialog__activator ml-5"
+                  role="button"
                 >
-                  <button
-                    aria-expanded="false"
-                    aria-haspopup="true"
-                    class="v-small-dialog__activator"
-                    role="button"
+                  <span
+                    class="grey--text text--darken-2 ml-2"
                   >
                     
-                  1945-06-02
-                  
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </button>
-                  <!---->
-                </div>
-              </div>
-               
-              <div
-                class="text-end col-2 col"
-              >
-                <span
-                  class="v-tooltip v-tooltip--bottom"
-                >
-                  <!---->
-                  <button
-                    class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-                    type="button"
-                  >
-                    <span
-                      class="v-btn__content"
-                    >
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate mdi mdi-delete theme--light"
-                      />
-                    </span>
-                  </button>
-                </span>
+                1945-06-02
+              
+                  </span>
+                   
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
+                    style="font-size: 16px;"
+                  />
+                </button>
+                <!---->
               </div>
             </div>
+             
+            <div>
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <button
+                  class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                  type="button"
+                >
+                  <span
+                    class="v-btn__content"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate mdi mdi-account-multiple-plus theme--light"
+                    />
+                  </span>
+                </button>
+              </span>
+               
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <button
+                  class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                  type="button"
+                >
+                  <span
+                    class="v-btn__content"
+                  >
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate mdi mdi-delete theme--light"
+                    />
+                  </span>
+                </button>
+              </span>
+            </div>
           </div>
+           
+          <ul
+            class="ma-2 mr-0"
+          />
         </div>
       </div>
        
@@ -1654,36 +2421,34 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
         </div>
       </div>
        
-      <div
-        class="v-subheader d-flex justify-space-between theme--light"
-      >
-        
+      <div>
+        <div
+          class="v-subheader d-flex justify-space-between theme--light"
+        >
+          
     Organizations (0)
     
-        <button
-          class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
-          disabled="disabled"
-          type="button"
-        >
-          <span
-            class="v-btn__content"
+          <button
+            class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            disabled="disabled"
+            type="button"
           >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
-              style="font-size: 16px;"
-            />
-            
+            <span
+              class="v-btn__content"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+                style="font-size: 16px;"
+              />
+              
       Remove all
     
-          </span>
-        </button>
+            </span>
+          </button>
+        </div>
+         
       </div>
-       
-      <div
-        class="v-list indented v-sheet theme--light v-list--dense"
-        role="list"
-      />
        
       <div
         class="dragged-identity v-card v-sheet theme--dark primary"
@@ -6008,7 +6773,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
         >
           <i
             aria-hidden="true"
-            class="v-icon notranslate v-icon--left v-icon--dense mdi mdi-account-multiple theme--light black--text"
+            class="v-icon notranslate v-icon--left v-icon--dense mdi mdi-account theme--light black--text"
           />
           
       Individuals
@@ -6060,7 +6825,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 />
                 <input
                   aria-checked="false"
-                  id="input-801"
+                  id="input-879"
                   role="checkbox"
                   type="checkbox"
                   value=""
@@ -6071,7 +6836,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               </div>
               <label
                 class="v-label theme--light"
-                for="input-801"
+                for="input-879"
                 style="left: 0px; position: relative;"
               >
                 Select all
@@ -6157,13 +6922,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-806"
+                    for="input-884"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-806"
+                    id="input-884"
                     type="text"
                   />
                 </div>
@@ -6235,7 +7000,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-owns="list-814"
+                aria-owns="list-892"
                 class="v-input__slot"
                 role="button"
               >
@@ -6253,7 +7018,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-814"
+                    for="input-892"
                     style="left: 0px; position: absolute;"
                   >
                     Order by
@@ -6264,7 +7029,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                     <input
                       aria-readonly="false"
                       autocomplete="off"
-                      id="input-814"
+                      id="input-892"
                       readonly="readonly"
                       type="text"
                     />
@@ -6451,13 +7216,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label v-label--active theme--light"
-                    for="input-834"
+                    for="input-912"
                     style="left: 0px; position: absolute;"
                   >
                     Items per page
                   </label>
                   <input
-                    id="input-834"
+                    id="input-912"
                     max="0"
                     min="1"
                     type="number"
@@ -6493,6 +7258,8 @@ exports[`Storyshots IndividualsTable Default 1`] = `
       >
         <!---->
       </div>
+       
+      <!---->
        
       <div
         class="dragged-item v-card v-sheet theme--dark primary"
@@ -6994,13 +7761,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-986"
+                    for="input-1188"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-986"
+                    id="input-1188"
                     type="text"
                   />
                 </div>
@@ -7127,13 +7894,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-997"
+                  for="input-1199"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-997"
+                  id="input-1199"
                   max="0"
                   min="1"
                   type="number"
@@ -7282,13 +8049,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-927"
+                    for="input-1129"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-927"
+                    id="input-1129"
                     type="text"
                   />
                 </div>
@@ -7415,13 +8182,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-938"
+                  for="input-1140"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-938"
+                  id="input-1140"
                   max="0"
                   min="1"
                   type="number"
@@ -7754,13 +8521,13 @@ exports[`Storyshots Search Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1067"
+                  for="input-1269"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1067"
+                  id="input-1269"
                   type="text"
                 />
               </div>
@@ -7888,13 +8655,13 @@ exports[`Storyshots Search Filter Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1077"
+                  for="input-1279"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1077"
+                  id="input-1279"
                   type="text"
                 />
               </div>
@@ -7992,13 +8759,13 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1090"
+                  for="input-1292"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1090"
+                  id="input-1292"
                   type="text"
                 />
               </div>
@@ -8070,7 +8837,7 @@ exports[`Storyshots Search Order Selector 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="list-1095"
+              aria-owns="list-1297"
               class="v-input__slot"
               role="button"
             >
@@ -8088,7 +8855,7 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1095"
+                  for="input-1297"
                   style="left: 0px; position: absolute;"
                 >
                   Order by
@@ -8099,7 +8866,7 @@ exports[`Storyshots Search Order Selector 1`] = `
                   <input
                     aria-readonly="false"
                     autocomplete="off"
-                    id="input-1095"
+                    id="input-1297"
                     readonly="readonly"
                     type="text"
                   />
@@ -8139,6 +8906,80 @@ exports[`Storyshots Search Order Selector 1`] = `
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TeamEnrollModal Default 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="ma-auto"
+      data-app="true"
+    >
+      <button
+        class="v-btn v-btn--contained theme--dark v-size--default primary"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          
+      Open Dialog
+    
+        </span>
+      </button>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots TeamEnrollModal Error On Save 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="ma-auto"
+      data-app="true"
+    >
+      <button
+        class="v-btn v-btn--contained theme--dark v-size--default primary"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          
+      Open Dialog
+    
+        </span>
+      </button>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
       </div>
     </div>
   </div>
@@ -8645,7 +9486,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           >
             <i
               aria-hidden="true"
-              class="v-icon notranslate v-icon--left v-icon--dense mdi mdi-account-multiple theme--light black--text"
+              class="v-icon notranslate v-icon--left v-icon--dense mdi mdi-account theme--light black--text"
             />
             
       Individuals
@@ -8697,7 +9538,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1189"
+                    id="input-1405"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -8708,7 +9549,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1189"
+                  for="input-1405"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -8794,13 +9635,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1194"
+                      for="input-1410"
                       style="left: 0px; position: absolute;"
                     >
                       Search
                     </label>
                     <input
-                      id="input-1194"
+                      id="input-1410"
                       type="text"
                     />
                   </div>
@@ -8872,7 +9713,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-owns="list-1202"
+                  aria-owns="list-1418"
                   class="v-input__slot"
                   role="button"
                 >
@@ -8890,7 +9731,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1202"
+                      for="input-1418"
                       style="left: 0px; position: absolute;"
                     >
                       Order by
@@ -8901,7 +9742,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       <input
                         aria-readonly="false"
                         autocomplete="off"
-                        id="input-1202"
+                        id="input-1418"
                         readonly="readonly"
                         type="text"
                       />
@@ -9088,13 +9929,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label v-label--active theme--light"
-                      for="input-1222"
+                      for="input-1438"
                       style="left: 0px; position: absolute;"
                     >
                       Items per page
                     </label>
                     <input
-                      id="input-1222"
+                      id="input-1438"
                       max="0"
                       min="1"
                       type="number"
@@ -9130,6 +9971,8 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
         >
           <!---->
         </div>
+         
+        <!---->
          
         <div
           class="dragged-item v-card v-sheet theme--dark primary"

--- a/ui/tests/unit/enrollmentList.spec.js
+++ b/ui/tests/unit/enrollmentList.spec.js
@@ -1,0 +1,151 @@
+import { shallowMount } from "@vue/test-utils";
+import Vue from "vue";
+import Vuetify from "vuetify";
+import EnrollmentList from "@/components/EnrollmentList";
+
+Vue.use(Vuetify);
+
+describe("EnrollmentList component", () => {
+  const vuetify = new Vuetify();
+  const mountFunction = options => {
+    return shallowMount(EnrollmentList, {
+      Vue,
+      vuetify,
+      propsData: { enrollments: [] },
+      ...options
+    });
+  };
+
+  test("Groups enrollments by organization", () => {
+    const wrapper = mountFunction();
+    const enrollments = [
+      {
+        start: "2000-01-01T00:00:00+00:00",
+        end: "2004-01-02T00:00:00+00:00",
+        group: {
+          name: "Organization 1",
+          type: "organization"
+        }
+      },
+      {
+        start: "2006-01-01T00:00:00+00:00",
+        end: "2008-01-02T00:00:00+00:00",
+        group: {
+          name: "Organization 1",
+          type: "organization"
+        }
+      },
+      {
+        start: "2010-01-01T00:00:00+00:00",
+        end: "2012-01-02T00:00:00+00:00",
+        group: {
+          name: "Organization 1",
+          type: "organization"
+        }
+      },
+      {
+        start: "2004-01-01T00:00:00+00:00",
+        end: "2006-01-02T00:00:00+00:00",
+        group: {
+          name: "Organization 2",
+          type: "organization",
+          parentOrg: null
+        }
+      }
+    ];
+
+    const groupedEnrollments = wrapper.vm.groupEnrollments(enrollments);
+    expect(Object.keys(groupedEnrollments).length).toBe(2);
+
+    const organization1 = groupedEnrollments["Organization 1"];
+    expect(organization1.enrollments.length).toBe(3);
+
+    const organization2 = groupedEnrollments["Organization 2"];
+    expect(organization2.enrollments.length).toBe(1);
+  });
+
+  test("Groups team enrollments by their parent organization", () => {
+    const wrapper = mountFunction();
+    const enrollments = [
+      {
+        start: "2000-01-01T00:00:00+00:00",
+        end: "2004-01-02T00:00:00+00:00",
+        group: {
+          name: "Organization 1",
+          type: "organization",
+          parentOrg: null
+        }
+      },
+      {
+        start: "2000-01-01T00:00:00+00:00",
+        end: "2002-01-01T00:00:00+00:00",
+        group: {
+          name: "Team 1",
+          type: "team",
+          parentOrg: { name: "Organization 1" }
+        }
+      },
+      {
+        start: "2002-01-01T00:00:00+00:00",
+        end: "2004-01-01T00:00:00+00:00",
+        group: {
+          name: "Team 2",
+          type: "team",
+          parentOrg: { name: "Organization 1" }
+        }
+      },
+      {
+        start: "2005-01-01T00:00:00+00:00",
+        end: "2007-01-02T00:00:00+00:00",
+        group: {
+          name: "Organization 2",
+          type: "organization",
+          parentOrg: null
+        }
+      },
+      {
+        start: "2005-01-01T00:00:00+00:00",
+        end: "2007-01-01T00:00:00+00:00",
+        group: {
+          name: "Team 3",
+          type: "team",
+          parentOrg: { name: "Organization 2" }
+        }
+      }
+    ];
+
+    const groupedEnrollments = wrapper.vm.groupEnrollments(enrollments);
+    expect(Object.keys(groupedEnrollments).length).toBe(2);
+
+    const organization1 = groupedEnrollments["Organization 1"];
+    expect(organization1.enrollments.length).toBe(1);
+    expect(organization1.enrollments[0].start).toBe(
+      "2000-01-01T00:00:00+00:00"
+    );
+    expect(organization1.enrollments[0].end).toBe("2004-01-02T00:00:00+00:00");
+    expect(organization1.teams.length).toBe(2);
+
+    const team1 = organization1.teams[0];
+    expect(team1.group.name).toBe("Team 1");
+    expect(team1.start).toBe("2000-01-01T00:00:00+00:00");
+    expect(team1.end).toBe("2002-01-01T00:00:00+00:00");
+
+    const team2 = organization1.teams[1];
+    expect(team2.group.name).toBe("Team 2");
+    expect(team2.start).toBe("2002-01-01T00:00:00+00:00");
+    expect(team2.end).toBe("2004-01-01T00:00:00+00:00");
+
+    const organization2 = groupedEnrollments["Organization 2"];
+    expect(organization2.enrollments.length).toBe(1);
+    expect(organization2.enrollments[0].start).toBe(
+      "2005-01-01T00:00:00+00:00"
+    );
+    expect(organization2.enrollments[0].end).toBe("2007-01-02T00:00:00+00:00");
+    expect(organization2.teams.length).toBe(1);
+
+    const team3 = organization2.teams[0];
+    expect(team3.group.name).toBe("Team 3");
+    expect(team3.start).toBe("2005-01-01T00:00:00+00:00");
+    expect(team3.end).toBe("2007-01-01T00:00:00+00:00");
+  });
+});


### PR DESCRIPTION
This PR updates the user interface to allow individuals to be enrolled in teams. 
Users can click on a button next to an individual's enrollment to add a team for that organization. This opens the `TeamEnrollModal`, which shows a form to enter the team name and optional dates.
The enrollments are grouped by organization, with the teams indented below their parent. There is also an icon next to their names to make it clearer if it is an organization or a team.
The template and logic to show an individual's enrollments is moved to a new component `EnrollmentList` to prevent `ExpandedIndividual` from becoming too complex.
The mutations to withdraw and update the enrollment dates are also updated to account for teams.