### PR TITLE
Bump numpy to 1.21.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ sqlalchemy>=1.2,<1.4
 jinja2>=3.0.3,<3.1.0
 python-dateutil>=2.6.0
 pandas>=0.22.0,<=0.25.3
-numpy<=1.18.3
+numpy<1.21.1
 pyyaml>=3.12
 requests>=2.9
 urllib3>=1.22

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(name="sortinghat",
         'jinja2>=3.0.3,<3.1.0',
         'python-dateutil>=2.6.0',
         'pandas>=0.22.0,<=0.25.3',
-        'numpy<=1.18.3',
+        'numpy<1.21.1',
         'pyyaml>=3.12',
         'requests>=2.9',
         'urllib3>=1.22'


### PR DESCRIPTION
This PR updates the version of numpy to <1.21.0 in requirements.txt file and setup.py.