### PR TITLE
[gitdm] The '#' character in the middle is a valid line

### DIFF
--- a/releases/unreleased/[gitdm]-the-#-character-in-the-middle-is-a-valid-line.yml
+++ b/releases/unreleased/[gitdm]-the-#-character-in-the-middle-is-a-valid-line.yml
@@ -1,0 +1,13 @@
+---
+title: '[gitdm] The # character in the middle is a valid line'
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Accepts the `#` character in the middle of the line,
+    but it will be skipped.
+
+    For example:
+    - user@domain.com #Chaoss
+    - user@domain.com Chaos#s
+    - user@domain.com Chaoss < 2015-03-01#

--- a/sortinghat/parsing/gitdm.py
+++ b/sortinghat/parsing/gitdm.py
@@ -60,7 +60,7 @@ class GitdmParser(object):
     """
 
     # Common Gitdm patterns
-    VALID_LINE_REGEX = r"^(\S+)[ \t]+([^#\n\r\f\v]+[^#\s]*)(?:([ \t]+#.*)?|\s*)$"
+    VALID_LINE_REGEX = r"^(\S+)[ \t]+([^\n\r\f\v]+[^#\s]*)(?:([ \t]+#.*)?|\s*)$"
     LINES_TO_IGNORE_REGEX = r"^\s*(?:#.*)?\s*$"
     EMAIL_ADDRESS_REGEX = r"^(?P<email>[^\s@]+@[^\s@.]+\.[^\s@]+)$"
     ORGANIZATION_REGEX = r"^(?P<organization>[^#<\t\n\r\f\v]*[^#<\t\n\r\f\v\s])?$"


### PR DESCRIPTION
This change accepts the `#` character in the middle of the line,
but it will be skipped.

For example:
- user@domain.com #Chaoss
- user@domain.com Chaos#s
- user@domain.com Chaoss < 2015-03-01#

Signed-off-by: Quan Zhou <quan@bitergia.com>