### PR TITLE
[gitdm] Skip invalid format lines

### DIFF
--- a/releases/unreleased/[gitdm]-skip-invalid-format-lines.yml
+++ b/releases/unreleased/[gitdm]-skip-invalid-format-lines.yml
@@ -1,0 +1,8 @@
+---
+title: '[gitdm] Skip invalid format lines'
+category: fixed
+author: Quan Zhou <quan@bitergia.com>
+issue: null
+notes: >
+    Gitdm parser won't fail reading files with an invalid format. Instead,
+    it will ignore invalid content.

--- a/sortinghat/parsing/gitdm.py
+++ b/sortinghat/parsing/gitdm.py
@@ -296,8 +296,9 @@ class GitdmParser(object):
 
             m = re.match(self.VALID_LINE_REGEX, line, re.UNICODE)
             if not m:
-                cause = "line %s: invalid format" % str(nline)
-                raise InvalidFormatError(cause=cause)
+                cause = "Skip: '%s' -> line %s: invalid line format" % (line, str(nline))
+                logger.warning(cause)
+                continue
 
             try:
                 result = parse_line(m.group(1), m.group(2))

--- a/tests/data/gitdm_email_invalid_lines.txt
+++ b/tests/data/gitdm_email_invalid_lines.txt
@@ -1,0 +1,6 @@
+#
+# Gitdm invalid lines example
+#
+
+jsmith.example.com  Example Company < 2010-01-01#
+jsmith.example.com  Example#

--- a/tests/data/gitdm_orgs_invalid_lines.txt
+++ b/tests/data/gitdm_orgs_invalid_lines.txt
@@ -1,0 +1,6 @@
+#
+# Gitdm invalid lines example
+#
+
+bitergia.com	B#itergia
+bitergia.com	B# Bitergia


### PR DESCRIPTION
This change skips invalid formatting lines instead of raising an
error. This way it will keep executing the file.

Example of invalid lines:
- bitergia.com	B#itergia
- jsmith.example.com  Example#
- jsmith.example.com  Example Company < 2010-01-01#

Test updated accordingly.

Signed-off-by: Quan Zhou <quan@bitergia.com>