### PR TITLE
[ui] Fix filtering individuals by organization

### DIFF
--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -304,7 +304,8 @@ export default {
       this.savedIndividuals = [];
     },
     getEnrollments(group) {
-      this.filters = `enrollment:"${group}"`;
+      this.filters = "";
+      this.$nextTick(() => (this.filters = `enrollment:"${group}"`));
     }
   },
   async mounted() {


### PR DESCRIPTION
This PR fixes #617. When you click an organization to see the list of enrolled individuals, it clears the previous enrollment filter and waits for Vue to update it before setting the new one.