### PR TITLE
[ui] Improve date inputs

### DIFF
--- a/ui/src/components/ProfileModal.vue
+++ b/ui/src/components/ProfileModal.vue
@@ -78,87 +78,50 @@
               </v-checkbox>
             </v-col>
           </v-row>
-        </v-form>
 
-        <v-row class="pl-4">
-          <span class="subheader">Organizations</span>
-        </v-row>
-        <v-row v-for="(enrollment, index) in enrollmentsForm" :key="index">
-          <v-col cols="4">
-            <v-text-field
-              label="Organization"
-              v-model="enrollmentsForm[index].organization"
-              outlined
-              dense
-            />
-          </v-col>
-          <v-col cols="3">
-            <v-menu
-              v-model="enrollmentsForm[index].fromDateMenu"
-              :close-on-content-click="false"
-              transition="scale-transition"
-              offset-y
-              min-width="290px"
-            >
-              <template v-slot:activator="{ on }">
-                <v-text-field
-                  v-model="enrollmentsForm[index].fromDate"
-                  label="Date from"
-                  outlined
-                  dense
-                  readonly
-                  v-on="on"
-                ></v-text-field>
-              </template>
-              <v-date-picker
+          <v-row class="pl-4">
+            <span class="subheader">Organizations</span>
+          </v-row>
+          <v-row v-for="(enrollment, index) in enrollmentsForm" :key="index">
+            <v-col cols="4">
+              <v-text-field
+                label="Organization"
+                v-model="enrollmentsForm[index].organization"
+                outlined
+                dense
+              />
+            </v-col>
+            <v-col cols="3">
+              <date-input
                 v-model="enrollmentsForm[index].fromDate"
-                @input="enrollmentsForm[index].fromDateMenu = false"
-                no-title
-                scrollable
-              >
-              </v-date-picker>
-            </v-menu>
-          </v-col>
-          <v-col cols="3">
-            <v-menu
-              v-model="enrollmentsForm[index].toDateMenu"
-              :close-on-content-click="false"
-              transition="scale-transition"
-              offset-y
-              min-width="290px"
-            >
-              <template v-slot:activator="{ on }">
-                <v-text-field
-                  v-model="enrollmentsForm[index].toDate"
-                  label="Date to"
-                  outlined
-                  dense
-                  readonly
-                  v-on="on"
-                ></v-text-field>
-              </template>
-              <v-date-picker
+                :max="enrollmentsForm[index].toDate"
+                label="Date from"
+                outlined
+              />
+            </v-col>
+            <v-col cols="3">
+              <date-input
                 v-model="enrollmentsForm[index].toDate"
                 :min="enrollmentsForm[index].fromDate"
-                @input="enrollmentsForm[index].toDateMenu = false"
-                no-title
-                scrollable
+                label="Date to"
+                outlined
+              />
+            </v-col>
+            <v-col cols="1" class="pt-3">
+              <v-btn icon color="primary" @click="removeEnrollment(index)">
+                <v-icon color="primary">mdi-delete</v-icon>
+              </v-btn>
+            </v-col>
+          </v-row>
+          <v-row class="pl-3">
+            <v-btn text small outlined color="primary" @click="addInput">
+              <v-icon left small color="primary"
+                >mdi-plus-circle-outline</v-icon
               >
-              </v-date-picker>
-            </v-menu>
-          </v-col>
-          <v-col cols="1" class="pt-3">
-            <v-btn icon color="primary" @click="removeEnrollment(index)">
-              <v-icon color="primary">mdi-delete</v-icon>
+              Add organization
             </v-btn>
-          </v-col>
-        </v-row>
-        <v-row class="pl-3">
-          <v-btn text small outlined color="primary" @click="addInput">
-            <v-icon left small color="primary">mdi-plus-circle-outline</v-icon>
-            Add organization
-          </v-btn>
-        </v-row>
+          </v-row>
+        </v-form>
       </v-card-text>
 
       <v-alert v-if="errorMessage" text type="error" class="ma-5">
@@ -184,8 +147,11 @@
 </template>
 
 <script>
+import DateInput from "./DateInput.vue";
+
 export default {
   name: "ProfileModal",
+  components: { DateInput },
   props: {
     isOpen: {
       type: Boolean,
@@ -224,10 +190,8 @@ export default {
       enrollmentsForm: [
         {
           organization: "",
-          fromDate: "",
-          fromDateMenu: false,
-          toDate: "",
-          toDateMenu: false
+          fromDate: "01-10-2010",
+          toDate: ""
         }
       ],
       savedData: {
@@ -260,8 +224,7 @@ export default {
       this.enrollmentsForm.push({
         organization: "",
         fromDate: "",
-        toDate: "",
-        menu: false
+        toDate: ""
       });
     },
     removeEnrollment(index) {
@@ -361,25 +324,19 @@ export default {
         const response = await Promise.all(
           this.enrollmentsForm.map(enrollment => {
             if (enrollment.organization) {
-              const fromDate = enrollment.fromDate
-                ? new Date(enrollment.fromDate).toISOString()
-                : null;
-              const toDate = enrollment.toDate
-                ? new Date(enrollment.toDate).toISOString()
-                : null;
               const response = this.enroll(
                 this.savedData.individual,
                 enrollment.organization,
-                fromDate,
-                toDate
+                enrollment.fromDate,
+                enrollment.toDate
               );
               this.$logger.debug(
                 `Enrolled individual ${this.savedData.individual}`,
                 {
                   uuid: this.savedData.individual,
                   organization: enrollment.organization,
-                  fromDate,
-                  toDate
+                  fromDate: enrollment.fromDate,
+                  toDate: enrollment.toDate
                 }
               );
               return response;

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -3857,178 +3857,113 @@ exports[`ProfileModal Mock mutation for addIdentity 1`] = `
             />
           </v-col-stub>
         </v-row-stub>
-      </v-form-stub>
-       
-      <v-row-stub
-        class="pl-4"
-        tag="div"
-      >
-        <span
-          class="subheader"
-        >
-          Organizations
-        </span>
-      </v-row-stub>
-       
-      <v-row-stub
-        tag="div"
-      >
-        <v-col-stub
-          cols="4"
-          tag="div"
-        >
-          <v-text-field-stub
-            backgroundcolor=""
-            clearicon="$clear"
-            dense="true"
-            errorcount="1"
-            errormessages=""
-            label="Organization"
-            loaderheight="2"
-            messages=""
-            outlined="true"
-            rules=""
-            successmessages=""
-            type="text"
-            value=""
-          />
-        </v-col-stub>
          
-        <v-col-stub
-          cols="3"
+        <v-row-stub
+          class="pl-4"
           tag="div"
         >
-          <v-menu-stub
-            closedelay="0"
-            closeonclick="true"
-            contentclass=""
-            maxheight="auto"
-            maxwidth="auto"
-            minwidth="290px"
-            nudgebottom="0"
-            nudgeleft="0"
-            nudgeright="0"
-            nudgetop="0"
-            nudgewidth="0"
-            offsety="true"
-            opendelay="0"
-            openonclick="true"
-            origin="top left"
-            transition="scale-transition"
+          <span
+            class="subheader"
           >
-             
-            <v-date-picker-stub
-              eventcolor="warning"
-              firstdayofweek="0"
-              localefirstdayofyear="0"
-              nexticon="$next"
-              nextmontharialabel="$vuetify.datePicker.nextMonthAriaLabel"
-              nextyeararialabel="$vuetify.datePicker.nextYearAriaLabel"
-              notitle="true"
-              previcon="$prev"
-              prevmontharialabel="$vuetify.datePicker.prevMonthAriaLabel"
-              prevyeararialabel="$vuetify.datePicker.prevYearAriaLabel"
-              scrollable="true"
-              selecteditemstext="$vuetify.datePicker.itemsSelected"
-              showcurrent="true"
-              type="date"
-              value=""
-              width="290"
-            />
-          </v-menu-stub>
-        </v-col-stub>
+            Organizations
+          </span>
+        </v-row-stub>
          
-        <v-col-stub
-          cols="3"
+        <v-row-stub
           tag="div"
         >
-          <v-menu-stub
-            closedelay="0"
-            closeonclick="true"
-            contentclass=""
-            maxheight="auto"
-            maxwidth="auto"
-            minwidth="290px"
-            nudgebottom="0"
-            nudgeleft="0"
-            nudgeright="0"
-            nudgetop="0"
-            nudgewidth="0"
-            offsety="true"
-            opendelay="0"
-            openonclick="true"
-            origin="top left"
-            transition="scale-transition"
+          <v-col-stub
+            cols="4"
+            tag="div"
           >
-             
-            <v-date-picker-stub
-              eventcolor="warning"
-              firstdayofweek="0"
-              localefirstdayofyear="0"
-              min=""
-              nexticon="$next"
-              nextmontharialabel="$vuetify.datePicker.nextMonthAriaLabel"
-              nextyeararialabel="$vuetify.datePicker.nextYearAriaLabel"
-              notitle="true"
-              previcon="$prev"
-              prevmontharialabel="$vuetify.datePicker.prevMonthAriaLabel"
-              prevyeararialabel="$vuetify.datePicker.prevYearAriaLabel"
-              scrollable="true"
-              selecteditemstext="$vuetify.datePicker.itemsSelected"
-              showcurrent="true"
-              type="date"
+            <v-text-field-stub
+              backgroundcolor=""
+              clearicon="$clear"
+              dense="true"
+              errorcount="1"
+              errormessages=""
+              label="Organization"
+              loaderheight="2"
+              messages=""
+              outlined="true"
+              rules=""
+              successmessages=""
+              type="text"
               value=""
-              width="290"
             />
-          </v-menu-stub>
-        </v-col-stub>
+          </v-col-stub>
+           
+          <v-col-stub
+            cols="3"
+            tag="div"
+          >
+            <date-input-stub
+              label="Date from"
+              max=""
+              outlined="true"
+              value="01-10-2010"
+            />
+          </v-col-stub>
+           
+          <v-col-stub
+            cols="3"
+            tag="div"
+          >
+            <date-input-stub
+              label="Date to"
+              min="01-10-2010"
+              outlined="true"
+              value=""
+            />
+          </v-col-stub>
+           
+          <v-col-stub
+            class="pt-3"
+            cols="1"
+            tag="div"
+          >
+            <v-btn-stub
+              activeclass=""
+              color="primary"
+              icon="true"
+              tag="button"
+              type="button"
+            >
+              <v-icon-stub
+                color="primary"
+              >
+                mdi-delete
+              </v-icon-stub>
+            </v-btn-stub>
+          </v-col-stub>
+        </v-row-stub>
          
-        <v-col-stub
-          class="pt-3"
-          cols="1"
+        <v-row-stub
+          class="pl-3"
           tag="div"
         >
           <v-btn-stub
             activeclass=""
             color="primary"
-            icon="true"
+            outlined="true"
+            small="true"
             tag="button"
+            text="true"
             type="button"
           >
             <v-icon-stub
               color="primary"
+              left=""
+              small=""
             >
-              mdi-delete
+              mdi-plus-circle-outline
             </v-icon-stub>
-          </v-btn-stub>
-        </v-col-stub>
-      </v-row-stub>
-       
-      <v-row-stub
-        class="pl-3"
-        tag="div"
-      >
-        <v-btn-stub
-          activeclass=""
-          color="primary"
-          outlined="true"
-          small="true"
-          tag="button"
-          text="true"
-          type="button"
-        >
-          <v-icon-stub
-            color="primary"
-            left=""
-            small=""
-          >
-            mdi-plus-circle-outline
-          </v-icon-stub>
+            
+            Add organization
           
-          Add organization
-        
-        </v-btn-stub>
-      </v-row-stub>
+          </v-btn-stub>
+        </v-row-stub>
+      </v-form-stub>
     </v-card-text-stub>
      
     <!---->
@@ -4319,178 +4254,113 @@ exports[`ProfileModal Mock mutation for updateProfile 1`] = `
             />
           </v-col-stub>
         </v-row-stub>
-      </v-form-stub>
-       
-      <v-row-stub
-        class="pl-4"
-        tag="div"
-      >
-        <span
-          class="subheader"
-        >
-          Organizations
-        </span>
-      </v-row-stub>
-       
-      <v-row-stub
-        tag="div"
-      >
-        <v-col-stub
-          cols="4"
-          tag="div"
-        >
-          <v-text-field-stub
-            backgroundcolor=""
-            clearicon="$clear"
-            dense="true"
-            errorcount="1"
-            errormessages=""
-            label="Organization"
-            loaderheight="2"
-            messages=""
-            outlined="true"
-            rules=""
-            successmessages=""
-            type="text"
-            value=""
-          />
-        </v-col-stub>
          
-        <v-col-stub
-          cols="3"
+        <v-row-stub
+          class="pl-4"
           tag="div"
         >
-          <v-menu-stub
-            closedelay="0"
-            closeonclick="true"
-            contentclass=""
-            maxheight="auto"
-            maxwidth="auto"
-            minwidth="290px"
-            nudgebottom="0"
-            nudgeleft="0"
-            nudgeright="0"
-            nudgetop="0"
-            nudgewidth="0"
-            offsety="true"
-            opendelay="0"
-            openonclick="true"
-            origin="top left"
-            transition="scale-transition"
+          <span
+            class="subheader"
           >
-             
-            <v-date-picker-stub
-              eventcolor="warning"
-              firstdayofweek="0"
-              localefirstdayofyear="0"
-              nexticon="$next"
-              nextmontharialabel="$vuetify.datePicker.nextMonthAriaLabel"
-              nextyeararialabel="$vuetify.datePicker.nextYearAriaLabel"
-              notitle="true"
-              previcon="$prev"
-              prevmontharialabel="$vuetify.datePicker.prevMonthAriaLabel"
-              prevyeararialabel="$vuetify.datePicker.prevYearAriaLabel"
-              scrollable="true"
-              selecteditemstext="$vuetify.datePicker.itemsSelected"
-              showcurrent="true"
-              type="date"
-              value=""
-              width="290"
-            />
-          </v-menu-stub>
-        </v-col-stub>
+            Organizations
+          </span>
+        </v-row-stub>
          
-        <v-col-stub
-          cols="3"
+        <v-row-stub
           tag="div"
         >
-          <v-menu-stub
-            closedelay="0"
-            closeonclick="true"
-            contentclass=""
-            maxheight="auto"
-            maxwidth="auto"
-            minwidth="290px"
-            nudgebottom="0"
-            nudgeleft="0"
-            nudgeright="0"
-            nudgetop="0"
-            nudgewidth="0"
-            offsety="true"
-            opendelay="0"
-            openonclick="true"
-            origin="top left"
-            transition="scale-transition"
+          <v-col-stub
+            cols="4"
+            tag="div"
           >
-             
-            <v-date-picker-stub
-              eventcolor="warning"
-              firstdayofweek="0"
-              localefirstdayofyear="0"
-              min=""
-              nexticon="$next"
-              nextmontharialabel="$vuetify.datePicker.nextMonthAriaLabel"
-              nextyeararialabel="$vuetify.datePicker.nextYearAriaLabel"
-              notitle="true"
-              previcon="$prev"
-              prevmontharialabel="$vuetify.datePicker.prevMonthAriaLabel"
-              prevyeararialabel="$vuetify.datePicker.prevYearAriaLabel"
-              scrollable="true"
-              selecteditemstext="$vuetify.datePicker.itemsSelected"
-              showcurrent="true"
-              type="date"
+            <v-text-field-stub
+              backgroundcolor=""
+              clearicon="$clear"
+              dense="true"
+              errorcount="1"
+              errormessages=""
+              label="Organization"
+              loaderheight="2"
+              messages=""
+              outlined="true"
+              rules=""
+              successmessages=""
+              type="text"
               value=""
-              width="290"
             />
-          </v-menu-stub>
-        </v-col-stub>
+          </v-col-stub>
+           
+          <v-col-stub
+            cols="3"
+            tag="div"
+          >
+            <date-input-stub
+              label="Date from"
+              max=""
+              outlined="true"
+              value="01-10-2010"
+            />
+          </v-col-stub>
+           
+          <v-col-stub
+            cols="3"
+            tag="div"
+          >
+            <date-input-stub
+              label="Date to"
+              min="01-10-2010"
+              outlined="true"
+              value=""
+            />
+          </v-col-stub>
+           
+          <v-col-stub
+            class="pt-3"
+            cols="1"
+            tag="div"
+          >
+            <v-btn-stub
+              activeclass=""
+              color="primary"
+              icon="true"
+              tag="button"
+              type="button"
+            >
+              <v-icon-stub
+                color="primary"
+              >
+                mdi-delete
+              </v-icon-stub>
+            </v-btn-stub>
+          </v-col-stub>
+        </v-row-stub>
          
-        <v-col-stub
-          class="pt-3"
-          cols="1"
+        <v-row-stub
+          class="pl-3"
           tag="div"
         >
           <v-btn-stub
             activeclass=""
             color="primary"
-            icon="true"
+            outlined="true"
+            small="true"
             tag="button"
+            text="true"
             type="button"
           >
             <v-icon-stub
               color="primary"
+              left=""
+              small=""
             >
-              mdi-delete
+              mdi-plus-circle-outline
             </v-icon-stub>
-          </v-btn-stub>
-        </v-col-stub>
-      </v-row-stub>
-       
-      <v-row-stub
-        class="pl-3"
-        tag="div"
-      >
-        <v-btn-stub
-          activeclass=""
-          color="primary"
-          outlined="true"
-          small="true"
-          tag="button"
-          text="true"
-          type="button"
-        >
-          <v-icon-stub
-            color="primary"
-            left=""
-            small=""
-          >
-            mdi-plus-circle-outline
-          </v-icon-stub>
+            
+            Add organization
           
-          Add organization
-        
-        </v-btn-stub>
-      </v-row-stub>
+          </v-btn-stub>
+        </v-row-stub>
+      </v-form-stub>
     </v-card-text-stub>
      
     <!---->

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -159,7 +159,7 @@ exports[`Storyshots DateInput Error 1`] = `
         class="v-menu"
       >
         <div
-          class="v-input v-input--has-state v-input--is-label-active v-input--is-dirty v-input--dense theme--light v-text-field v-text-field--single-line v-text-field--enclosed v-text-field--outlined error--text"
+          class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty v-input--dense theme--light v-text-field v-text-field--enclosed v-text-field--outlined"
         >
           <div
             class="v-input__control"
@@ -171,7 +171,9 @@ exports[`Storyshots DateInput Error 1`] = `
               <fieldset
                 aria-hidden="true"
               >
-                <legend>
+                <legend
+                  style="width: 0px;"
+                >
                   <span>
                     ​
                   </span>
@@ -180,6 +182,13 @@ exports[`Storyshots DateInput Error 1`] = `
               <div
                 class="v-text-field__slot"
               >
+                <label
+                  class="v-label v-label--active theme--light"
+                  for="input-49"
+                  style="left: 0px; position: absolute;"
+                >
+                  Label
+                </label>
                 <input
                   id="input-49"
                   type="text"
@@ -193,27 +202,9 @@ exports[`Storyshots DateInput Error 1`] = `
                 >
                   <button
                     aria-label="clear icon"
-                    class="v-icon notranslate v-icon--link mdi mdi-close theme--light error--text"
+                    class="v-icon notranslate v-icon--link mdi mdi-close theme--light"
                     type="button"
                   />
-                </div>
-              </div>
-            </div>
-            <div
-              class="v-text-field__details"
-            >
-              <div
-                class="v-messages theme--light error--text"
-                role="alert"
-              >
-                <div
-                  class="v-messages__wrapper"
-                >
-                  <div
-                    class="v-messages__message"
-                  >
-                    Invalid date
-                  </div>
                 </div>
               </div>
             </div>
@@ -306,7 +297,7 @@ exports[`Storyshots DateInput Outlined 1`] = `
         class="v-menu"
       >
         <div
-          class="v-input v-input--hide-details v-input--dense theme--light v-text-field v-text-field--single-line v-text-field--enclosed v-text-field--outlined"
+          class="v-input v-input--hide-details v-input--dense theme--light v-text-field v-text-field--enclosed v-text-field--outlined"
         >
           <div
             class="v-input__control"
@@ -318,7 +309,9 @@ exports[`Storyshots DateInput Outlined 1`] = `
               <fieldset
                 aria-hidden="true"
               >
-                <legend>
+                <legend
+                  style="width: 0px;"
+                >
                   <span>
                     ​
                   </span>

--- a/ui/tests/unit/dateInput.spec.js
+++ b/ui/tests/unit/dateInput.spec.js
@@ -18,20 +18,21 @@ describe("DateInput", () => {
     });
   };
 
-  test("Sets date in the right formats", async() => {
+  test("Sets date in the right formats", async () => {
     const wrapper = mountFunction();
-    await wrapper.setProps({value: "2020"});
-
-    // Internal date in YYYYYY-MM-DDTHH:mm:ss.sssZ format
-    expect(wrapper.vm.date).toBe("2020-01-01T00:00:00.000Z");
+    await wrapper.setProps({ value: "2020" });
 
     // YYYYYY-MM-DD format in the UI
     expect(wrapper.vm.inputDate).toBe("2020-01-01");
+    expect(wrapper.vm.pickerDate).toBe("2020-01-01");
+
+    // Emit ISO date for the v-model
+    expect(wrapper.emitted().input[1]).toEqual(["2020-01-01T00:00:00.000Z"]);
   });
 
-  test("Shows an error for an invalid date", async() => {
+  test("Shows an error for an invalid date", async () => {
     const wrapper = mountFunction();
-    await wrapper.setProps({value: "invalid date"});
+    await wrapper.setProps({ value: "invalid date" });
 
     expect(wrapper.vm.error).toBe("Invalid date");
     expect(wrapper.find(".error--text").exists()).toBe(true);


### PR DESCRIPTION
This PR replaces the date pickers in `ProfileModal` with the `DateInput` component, which allows the user to type a date. The component is also improved:
- Sets the date for the Vuetify picker in a YYYY-MM-DD format. This was preventing the date picker from highlighting the chosen date.
- Adds a help text with the right date format.
- Adds validation rules used by `ProfileModal`.
- Adds a `single-line` prop to match the input style in the modal.

Fixes #618.