### PR TITLE
Remove duplicates when filtering individuals

### DIFF
--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1260,11 +1260,17 @@ class SortingHatQuery:
                                                          Q(country__alpha3=country))
                                                  .values_list('individual__mk')))
         if filters and 'source' in filters:
-            query = query.filter(identities__source=filters['source'])
+            query = query.filter(mk__in=Subquery(Identity.objects
+                                                 .filter(source=filters['source'])
+                                                 .values_list('individual__mk')))
         if filters and 'enrollment' in filters:
-            query = query.filter(enrollments__group__name__icontains=filters['enrollment'])
+            query = query.filter(mk__in=Subquery(Enrollment.objects
+                                                 .filter(group__name__icontains=filters['enrollment'])
+                                                 .values_list('individual__mk')))
             if 'enrollment_parent_org' in filters:
-                query = query.filter(enrollments__group__parent_org__name=filters['enrollment_parent_org'])
+                query = query.filter(mk__in=Subquery(Enrollment.objects
+                                                     .filter(group__parent_org__name=filters['enrollment_parent_org'])
+                                                     .values_list('individual__mk')))
         if filters and 'enrollment_date' in filters:
             # Accepted date format is ISO 8601, YYYY-MM-DDTHH:MM:SS
             try:
@@ -1299,7 +1305,10 @@ class SortingHatQuery:
                                                                  end__gte=date1)
                                                          .values_list('individual__mk')))
         if filters and 'is_enrolled' in filters:
-            query = query.filter(enrollments__isnull=not filters['is_enrolled'])
+            query = query.filter(mk__in=Subquery(Individual.objects
+                                                 .filter(enrollments__isnull=not filters['is_enrolled'])
+                                                 .values_list('mk')))
+
         if filters and 'last_updated' in filters:
             # Accepted date format is ISO 8601, YYYY-MM-DDTHH:MM:SS
             try:

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -163,6 +163,9 @@ const GET_PAGINATED_ORGANIZATIONS = gql`
         name
         enrollments {
           id
+          individual {
+            mk
+          }
         }
         domains {
           domain

--- a/ui/src/components/OrganizationsTable.stories.js
+++ b/ui/src/components/OrganizationsTable.stories.js
@@ -96,24 +96,30 @@ export const Organizations = () => ({
                 id: 1,
                 name: "Griffyndor",
                 enrollments: [
-                  { id: 1 },
-                  { id: 2 },
-                  { id: 3 },
-                  { id: 4 },
-                  { id: 5 }
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } },
+                  { id: 4, individual: { mk: 4 } },
+                  { id: 5, individual: { mk: 5 } }
                 ],
                 domains: [{ domain: "griffyndor.hogwarts.edu" }]
               },
               {
                 id: 2,
                 name: "Slytherin",
-                enrollments: [{ id: 1 }, { id: 2 }],
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } }],
                 domains: [{ domain: "slytherin.hogwarts.edu" }]
               },
               {
                 id: 3,
                 name: "Ravenclaw",
-                enrollments: [{ id: 1 }, { id: 2 }, { id: 3 }],
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } }
+                ],
                 domains: [{ domain: "ravenclaw.hogwarts.edu" }]
               }
             ],
@@ -133,7 +139,12 @@ export const Organizations = () => ({
               {
                 id: 4,
                 name: "Hufflepuff",
-                enrollments: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }],
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } },
+                  { id: 4, individual: { mk: 4 } }
+                ],
                 domains: [{ domain: "hufflepuff.hogwarts.edu" }]
               }
             ],
@@ -227,22 +238,29 @@ export const Groups = () => ({
                 id: 1,
                 name: "Dark Force Defence League",
                 enrollments: [
-                  { id: 1 },
-                  { id: 2 },
-                  { id: 3 },
-                  { id: 4 },
-                  { id: 5 }
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } },
+                  { id: 4, individual: { mk: 4 } },
+                  { id: 5, individual: { mk: 5 } }
                 ]
               },
               {
                 id: 2,
                 name: "Extraordinary Society of Potioneers",
-                enrollments: [{ id: 1 }, { id: 2 }]
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } }
+                ]
               },
               {
                 id: 3,
                 name: "Society for the Tolerance of Vampires",
-                enrollments: [{ id: 1 }, { id: 2 }, { id: 3 }]
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } }
+                ]
               }
             ],
             pageInfo: {
@@ -261,17 +279,29 @@ export const Groups = () => ({
               {
                 id: 4,
                 name: "Frog Choir",
-                enrollments: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } },
+                  { id: 4, individual: { mk: 4 } }
+                ]
               },
               {
                 id: 5,
                 name: "Celestial Ball decorating committee",
-                enrollments: [{ id: 1 }, { id: 2 }, { id: 3 }]
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } }
+                ]
               },
               {
                 id: 6,
                 name: "Duelling Club",
-                enrollments: [{ id: 1 }, { id: 2 }]
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } }
+                ]
               }
             ],
             pageInfo: {

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -65,7 +65,7 @@
       <template v-slot:item="{ item, expand, isExpanded }">
         <organization-entry
           :name="item.name"
-          :enrollments="item.enrollments ? item.enrollments.length : 0"
+          :enrollments="getEnrolledIndividuals(item.enrollments)"
           :domains="item.domains"
           :is-expanded="isExpanded"
           :is-editable="!isGroup"
@@ -423,6 +423,16 @@ export default {
           `Error adding team ${this.forms.teamName}: ${error}`
         );
       }
+    },
+    getEnrolledIndividuals(enrollments) {
+      if (!enrollments) {
+        return 0;
+      }
+      const uniqueIndividuals = new Set(
+        enrollments.map(item => item.individual.mk)
+      );
+
+      return uniqueIndividuals.size;
     }
   }
 };


### PR DESCRIPTION
This PR fixes the `enrollment`, `isEnrolled` and `source` filters returning duplicates in the individuals query.
It also changes the UI to show the number of individuals enrolled in an organization instead of the total number of enrollments.
Fixes #624