### PR TITLE
[ui] Show number of individuals affiliated to teams

### DIFF
--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -199,6 +199,11 @@ const GET_TEAMS = gql`
         name
         numchild
         id
+        enrollments {
+          individual {
+            mk
+          }
+        }
       }
     }
   }

--- a/ui/src/components/ExpandedOrganization.stories.js
+++ b/ui/src/components/ExpandedOrganization.stories.js
@@ -29,11 +29,21 @@ export const Default = () => ({
             entities: [
               {
                 name: "Committee on Experimental Charms",
-                numchild: 0
+                numchild: 0,
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } },
+                  { id: 4, individual: { mk: 4 } },
+                  { id: 5, individual: { mk: 5 } }
+                ],
               },
               {
                 name: "Department of Magical Law Enforcement",
-                numchild: 2
+                numchild: 2,
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } }
+                ],
               },
               {
                 name: "Department of Magical Accidents and Catastrophes",
@@ -42,23 +52,45 @@ export const Default = () => ({
               {
                 name:
                   "Department for the Regulation and Control of Magical Creatures",
-                numchild: 1
+                numchild: 1,
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } }
+                ],
               },
               {
                 name: "Auror Office",
                 parent: "Department of Magical Law Enforcement",
-                numchild: 0
+                numchild: 0,
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } },
+                  { id: 4, individual: { mk: 4 } },
+                  { id: 5, individual: { mk: 5 } }
+                ],
               },
               {
                 name: "Improper Use of Magic Office",
                 parent: "Department of Magical Law Enforcement",
-                numchild: 0
+                numchild: 0,
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } },
+                  { id: 3, individual: { mk: 3 } },
+                  { id: 4, individual: { mk: 4 } }
+                ],
               },
               {
                 name: "Beast Division",
                 parent:
                   "Department for the Regulation and Control of Magical Creatures",
-                numchild: 0
+                numchild: 0,
+                enrollments: [
+                  { id: 1, individual: { mk: 1 } },
+                  { id: 2, individual: { mk: 2 } }
+                ],
               }
             ]
           }
@@ -123,7 +155,14 @@ export const Group = () => ({
           entities: [
             {
               name: "Witches' League",
-              numchild: 0
+              numchild: 0,
+              enrollments: [
+                { id: 1, individual: { mk: 1 } },
+                { id: 2, individual: { mk: 2 } },
+                { id: 3, individual: { mk: 3 } },
+                { id: 4, individual: { mk: 4 } },
+                { id: 5, individual: { mk: 5 } }
+              ],
             }
           ]
         }

--- a/ui/src/components/ExpandedOrganization.vue
+++ b/ui/src/components/ExpandedOrganization.vue
@@ -17,7 +17,31 @@
       </v-subheader>
       <v-list-item v-for="(item, index) in teams" :key="index">
         <v-list-item-content>
-          <v-list-item-title>{{ item.name }}</v-list-item-title>
+          <v-list-item-title class="team">
+            <span class="team__name">{{ item.name }}</span>
+            <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+              <template v-slot:activator="{ on }">
+                <v-btn
+                  small
+                  depressed
+                  color="transparent"
+                  v-on="on"
+                  @click.stop="
+                    $emit('getEnrollments', {
+                      enrollment: item.name,
+                      parentOrg: organization
+                    })
+                  "
+                >
+                  {{ getEnrolledIndividuals(item.enrollments) }}
+                  <v-icon small right>
+                    mdi-account-multiple
+                  </v-icon>
+                </v-btn>
+              </template>
+              <span>Enrollments</span>
+            </v-tooltip>
+          </v-list-item-title>
         </v-list-item-content>
       </v-list-item>
     </v-list>
@@ -92,6 +116,16 @@ export default {
       }
       const response = await this.fetchTeams(filters);
       this.teams = response.data.teams.entities;
+    },
+    getEnrolledIndividuals(enrollments) {
+      if (!enrollments) {
+        return 0;
+      }
+      const uniqueIndividuals = new Set(
+        enrollments.map(item => item.individual.mk)
+      );
+
+      return uniqueIndividuals.size;
     }
   },
   async created() {
@@ -99,3 +133,14 @@ export default {
   }
 };
 </script>
+<style lang="scss" scoped>
+.team {
+  display: inline-flex;
+  align-items: center;
+
+  &__name {
+    width: 44%;
+    white-space: break-spaces;
+  }
+}
+</style>

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -76,7 +76,7 @@
           @enroll="confirmEnroll"
           @edit="openModal(item)"
           @delete="confirmDelete(item.name)"
-          @getEnrollments="$emit('getEnrollments', item.name)"
+          @getEnrollments="$emit('getEnrollments', { enrollment: item.name })"
         />
       </template>
       <template v-slot:expanded-item="{ item }">
@@ -87,6 +87,7 @@
           :add-team="addTeam"
           :delete-team="deleteTeam"
           :fetch-teams="fetchTeams"
+          @getEnrollments="$emit('getEnrollments', $event)"
         />
       </template>
     </v-data-table>

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -150,6 +150,10 @@ export default {
           type: "string"
         },
         {
+          filter: "enrollmentParentOrg",
+          type: "string"
+        },
+        {
           filter: "enrollmentDate",
           type: "date"
         },

--- a/ui/src/views/Dashboard.vue
+++ b/ui/src/views/Dashboard.vue
@@ -71,6 +71,7 @@
           :delete-team="deleteTeam"
           :fetch-teams="fetchTeams"
           is-group
+          @getEnrollments="getEnrollments"
           ref="teams"
         />
       </v-col>
@@ -312,9 +313,15 @@ export default {
       this.emptyWorkspace();
       this.savedIndividuals = [];
     },
-    getEnrollments(group) {
-      this.filters = "";
-      this.$nextTick(() => (this.filters = `enrollment:"${group}"`));
+    getEnrollments({ enrollment, parentOrg }) {
+      let newFilters = `enrollment:"${enrollment}"`;
+      if (parentOrg) {
+        newFilters = newFilters.concat(` enrollmentParentOrg:"${parentOrg}"`);
+      }
+      if (this.filters === newFilters) {
+        this.filters = "";
+      }
+      this.$nextTick(() => (this.filters = newFilters));
     }
   },
   async mounted() {

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -102,7 +102,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -463,7 +463,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -824,7 +824,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1185,7 +1185,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1546,7 +1546,7 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -1907,7 +1907,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -109,7 +109,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub
@@ -472,7 +472,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
-      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
+      validfilters="[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object],[object Object]"
     />
      
     <v-tooltip-stub

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -6818,7 +6818,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 />
                 <input
                   aria-checked="false"
-                  id="input-879"
+                  id="input-894"
                   role="checkbox"
                   type="checkbox"
                   value=""
@@ -6829,7 +6829,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               </div>
               <label
                 class="v-label theme--light"
-                for="input-879"
+                for="input-894"
                 style="left: 0px; position: relative;"
               >
                 Select all
@@ -6915,13 +6915,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-884"
+                    for="input-899"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-884"
+                    id="input-899"
                     type="text"
                   />
                 </div>
@@ -6993,7 +6993,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-owns="list-892"
+                aria-owns="list-907"
                 class="v-input__slot"
                 role="button"
               >
@@ -7011,7 +7011,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-892"
+                    for="input-907"
                     style="left: 0px; position: absolute;"
                   >
                     Order by
@@ -7022,7 +7022,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                     <input
                       aria-readonly="false"
                       autocomplete="off"
-                      id="input-892"
+                      id="input-907"
                       readonly="readonly"
                       type="text"
                     />
@@ -7209,13 +7209,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label v-label--active theme--light"
-                    for="input-912"
+                    for="input-927"
                     style="left: 0px; position: absolute;"
                   >
                     Items per page
                   </label>
                   <input
-                    id="input-912"
+                    id="input-927"
                     max="0"
                     min="1"
                     type="number"
@@ -7754,13 +7754,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1186"
+                    for="input-1201"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1186"
+                    id="input-1201"
                     type="text"
                   />
                 </div>
@@ -7891,13 +7891,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1197"
+                  for="input-1212"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1197"
+                  id="input-1212"
                   max="0"
                   min="1"
                   type="number"
@@ -8035,13 +8035,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1129"
+                    for="input-1144"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1129"
+                    id="input-1144"
                     type="text"
                   />
                 </div>
@@ -8172,13 +8172,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1140"
+                  for="input-1155"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1140"
+                  id="input-1155"
                   max="0"
                   min="1"
                   type="number"
@@ -8500,13 +8500,13 @@ exports[`Storyshots Search Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1265"
+                  for="input-1280"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1265"
+                  id="input-1280"
                   type="text"
                 />
               </div>
@@ -8634,13 +8634,13 @@ exports[`Storyshots Search Filter Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1275"
+                  for="input-1290"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1275"
+                  id="input-1290"
                   type="text"
                 />
               </div>
@@ -8738,13 +8738,13 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1288"
+                  for="input-1303"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1288"
+                  id="input-1303"
                   type="text"
                 />
               </div>
@@ -8816,7 +8816,7 @@ exports[`Storyshots Search Order Selector 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="list-1293"
+              aria-owns="list-1308"
               class="v-input__slot"
               role="button"
             >
@@ -8834,7 +8834,7 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1293"
+                  for="input-1308"
                   style="left: 0px; position: absolute;"
                 >
                   Order by
@@ -8845,7 +8845,7 @@ exports[`Storyshots Search Order Selector 1`] = `
                   <input
                     aria-readonly="false"
                     autocomplete="off"
-                    id="input-1293"
+                    id="input-1308"
                     readonly="readonly"
                     type="text"
                   />
@@ -9517,7 +9517,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1401"
+                    id="input-1416"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -9528,7 +9528,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1401"
+                  for="input-1416"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -9614,13 +9614,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1406"
+                      for="input-1421"
                       style="left: 0px; position: absolute;"
                     >
                       Search
                     </label>
                     <input
-                      id="input-1406"
+                      id="input-1421"
                       type="text"
                     />
                   </div>
@@ -9692,7 +9692,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-owns="list-1414"
+                  aria-owns="list-1429"
                   class="v-input__slot"
                   role="button"
                 >
@@ -9710,7 +9710,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1414"
+                      for="input-1429"
                       style="left: 0px; position: absolute;"
                     >
                       Order by
@@ -9721,7 +9721,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       <input
                         aria-readonly="false"
                         autocomplete="off"
-                        id="input-1414"
+                        id="input-1429"
                         readonly="readonly"
                         type="text"
                       />
@@ -9908,13 +9908,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label v-label--active theme--light"
-                      for="input-1434"
+                      for="input-1449"
                       style="left: 0px; position: absolute;"
                     >
                       Items per page
                     </label>
                     <input
-                      id="input-1434"
+                      id="input-1449"
                       max="0"
                       min="1"
                       type="number"


### PR DESCRIPTION
This PR adds the number of individuals affiliated to each team on the expanded organization view. When the number is clicked,
it adds the filter to the search bar automatically, and shows the list of individuals affiliated to that team.