### PR TITLE
[ui] Create view to show an individual's info

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -164,6 +164,12 @@ const ENROLL = gql`
           name
           email
           id
+          isBot
+          gender
+          country {
+            code
+            name
+          }
         }
         enrollments {
           start

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -176,6 +176,10 @@ const ENROLL = gql`
           end
           group {
             name
+            type
+            parentOrg {
+              name
+            }
           }
         }
       }

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -81,6 +81,11 @@ const UNMERGE = gql`
           email
           id
           isBot
+          gender
+          country {
+            code
+            name
+          }
         }
         identities {
           name
@@ -236,6 +241,7 @@ const UPDATE_PROFILE = gql`
     updateProfile(data: $data, uuid: $uuid) {
       uuid
       individual {
+        mk
         isLocked
         identities {
           uuid
@@ -366,6 +372,7 @@ const UPDATE_ENROLLMENT = gql`
       uuid
       individual {
         isLocked
+        mk
         identities {
           uuid
           name
@@ -388,6 +395,10 @@ const UPDATE_ENROLLMENT = gql`
           end
           group {
             name
+            type
+            parentOrg {
+              name
+            }
           }
         }
       }

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -30,6 +30,9 @@ const GET_INDIVIDUAL_BYUUID = gql`
           group {
             name
             type
+            parentOrg {
+              name
+            }
           }
         }
       }

--- a/ui/src/components/DateInput.vue
+++ b/ui/src/components/DateInput.vue
@@ -19,7 +19,6 @@
         :rules="isValid"
         height="30"
         clearable
-        hide-details="auto"
         hint="YYYY-MM-DD"
         v-on="on"
         @change="formatDate($event)"

--- a/ui/src/components/EnrollModal.stories.js
+++ b/ui/src/components/EnrollModal.stories.js
@@ -1,0 +1,51 @@
+import EnrollModal from "./EnrollModal.vue";
+
+export default {
+  title: "EnrollModal",
+  excludeStories: /.*Data$/
+};
+
+const template = `
+  <div data-app="true" class="ma-auto">
+    <v-btn color="primary" dark @click.stop="isOpen = true">
+      Open Dialog
+    </v-btn>
+    <enroll-modal
+      :is-open.sync='isOpen'
+      :organization='organization'
+      :enroll='enroll'
+      :title='title'
+      uuid="123"
+    />
+  </div>
+`;
+
+export const Default = () => ({
+  components: { EnrollModal },
+  template: template,
+  data: () => ({
+    isOpen: false,
+    organization: null,
+    title: "Enroll individual to an organization"
+  }),
+  methods: {
+    enroll() {
+      return true;
+    }
+  }
+});
+
+export const WithOrganization = () => ({
+  components: { EnrollModal },
+  template: template,
+  data: () => ({
+    isOpen: false,
+    organization: "Hogwarts",
+    title: "Enroll individual to Hogwarts?"
+  }),
+  methods: {
+    enroll() {
+      return true;
+    }
+  }
+});

--- a/ui/src/components/EnrollModal.vue
+++ b/ui/src/components/EnrollModal.vue
@@ -1,0 +1,128 @@
+<template>
+  <v-dialog v-model="isOpen" max-width="550px">
+    <v-card class="pa-3">
+      <v-card-title class="headline">{{ title }}</v-card-title>
+      <v-card-text>
+        <p v-if="text" class="pt-2 pb-2 text-body-2">
+          {{ text }}
+        </p>
+        <h6 v-if="organization" class="subheader">
+          Enrollment dates (optional)
+        </h6>
+        <v-row>
+          <v-col v-if="!organization" cols="4">
+            <v-text-field
+              v-model="form.organization"
+              label="Organization"
+              outlined
+              dense
+            />
+          </v-col>
+          <v-col :cols="organization ? 6 : 4">
+            <date-input v-model="form.dateFrom" label="Date from" outlined />
+          </v-col>
+          <v-col :cols="organization ? 6 : 4">
+            <date-input v-model="form.dateTo" label="Date to" outlined />
+          </v-col>
+        </v-row>
+        <v-alert v-if="errorMessage" text type="error">
+          {{ errorMessage }}
+        </v-alert>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text @click="onClose">
+          Cancel
+        </v-btn>
+        <v-btn
+          :disabled="!organization && !form.organization"
+          color="primary"
+          id="confirm"
+          depressed
+          @click="onSave"
+        >
+          Confirm
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+import DateInput from "./DateInput.vue";
+
+export default {
+  name: "EnrollModal",
+  components: { DateInput },
+  props: {
+    isOpen: {
+      type: Boolean,
+      required: true
+    },
+    enroll: {
+      type: Function,
+      required: true
+    },
+    uuid: {
+      type: String,
+      required: false
+    },
+    title: {
+      type: String,
+      required: false
+    },
+    text: {
+      type: String,
+      required: false
+    },
+    organization: {
+      type: String,
+      required: false
+    }
+  },
+  data() {
+    return {
+      form: {
+        organization: this.organization,
+        dateFrom: "",
+        dateTo: ""
+      },
+      errorMessage: ""
+    };
+  },
+  methods: {
+    async onSave() {
+      try {
+        await this.enroll(
+          this.uuid,
+          this.form.organization,
+          this.form.dateFrom,
+          this.form.dateTo
+        );
+        this.onClose();
+      } catch (error) {
+        this.errorMessage = this.$getErrorMessage(error);
+        this.$logger.error(`Error enrolling individual: ${error}`, this.form);
+      }
+    },
+    onClose() {
+      this.$emit("update:isOpen", false);
+      this.form = {
+        organization: this.organization,
+        dateFrom: "",
+        dateTo: ""
+      };
+      this.errorMessage = "";
+    }
+  },
+  watch: {
+    organization(value) {
+      this.form.organization = value;
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/index.scss";
+</style>

--- a/ui/src/components/EnrollmentList.vue
+++ b/ui/src/components/EnrollmentList.vue
@@ -2,17 +2,29 @@
   <div>
     <v-subheader class="d-flex justify-space-between">
       Organizations ({{ Object.keys(items).length }})
-      <v-btn
-        v-if="!compact"
-        text
-        small
-        outlined
-        :disabled="enrollments.length < 1 || isLocked"
-        @click="withdrawAll"
-      >
-        <v-icon small left>mdi-delete</v-icon>
-        Remove all
-      </v-btn>
+      <div v-if="!compact">
+        <v-btn
+          class="mr-4"
+          text
+          small
+          outlined
+          :disabled="isLocked"
+          @click="$emit('openEnrollmentModal')"
+        >
+          <v-icon small left>mdi-plus</v-icon>
+          Add
+        </v-btn>
+        <v-btn
+          text
+          small
+          outlined
+          :disabled="enrollments.length < 1 || isLocked"
+          @click="withdrawAll"
+        >
+          <v-icon small left>mdi-delete</v-icon>
+          Remove all
+        </v-btn>
+      </div>
     </v-subheader>
     <v-simple-table v-if="compact" dense>
       <template v-slot:default>
@@ -170,7 +182,7 @@
                 :disabled="isLocked"
                 icon
                 v-on="on"
-                @click="$emit('openModal', enrollment.group.name)"
+                @click="$emit('openTeamModal', enrollment.group.name)"
               >
                 <v-icon>
                   mdi-account-multiple-plus

--- a/ui/src/components/EnrollmentList.vue
+++ b/ui/src/components/EnrollmentList.vue
@@ -32,12 +32,7 @@
         </tbody>
       </template>
     </v-simple-table>
-    <div
-      v-else
-      v-for="(item, name) in items"
-      :key="name"
-      class="indented mt-2 mb-4"
-    >
+    <div v-else v-for="(item, name) in items" :key="name" class="ma-4">
       <div
         v-for="(enrollment, index) in item.enrollments"
         :key="index"
@@ -46,7 +41,7 @@
         <div>
           <v-tooltip bottom>
             <template v-slot:activator="{ on }">
-              <v-icon v-on="on" class="mr-5" left>
+              <v-icon v-on="on" class="mr-8" left>
                 mdi-sitemap
               </v-icon>
             </template>
@@ -64,6 +59,7 @@
           >
             <template v-slot:activator="{ on, attrs }">
               <button
+                :disabled="isLocked"
                 v-on="on"
                 v-bind="attrs"
                 class="v-small-dialog__activator"
@@ -121,6 +117,7 @@
           >
             <template v-slot:activator="{ on, attrs }">
               <button
+                :disabled="isLocked"
                 v-on="on"
                 v-bind="attrs"
                 class="v-small-dialog__activator ml-5"
@@ -170,6 +167,7 @@
           <v-tooltip bottom transition="expand-y-transition" open-delay="200">
             <template v-slot:activator="{ on }">
               <v-btn
+                :disabled="isLocked"
                 icon
                 v-on="on"
                 @click="$emit('openModal', enrollment.group.name)"
@@ -186,6 +184,7 @@
               <v-btn
                 icon
                 v-on="on"
+                :disabled="isLocked"
                 @click="
                   $emit('withdraw', {
                     name: enrollment.group.name,
@@ -211,15 +210,7 @@
           class="d-flex justify-space-between pr-0"
         >
           <div class="d-flex align-center">
-            <v-tooltip bottom>
-              <template v-slot:activator="{ on }">
-                <v-icon v-on="on" class="mr-5" left>
-                  mdi-account-multiple
-                </v-icon>
-              </template>
-              <span>Team</span>
-            </v-tooltip>
-            <span class="mr-4">{{ team.group.name }}</span>
+            <span class="ml-3 mr-4">{{ team.group.name }}</span>
 
             <v-menu
               v-model="team.form.fromDateMenu"
@@ -231,6 +222,7 @@
             >
               <template v-slot:activator="{ on, attrs }">
                 <button
+                  :disabled="isLocked"
                   v-on="on"
                   v-bind="attrs"
                   class="v-small-dialog__activator"
@@ -287,6 +279,7 @@
             >
               <template v-slot:activator="{ on, attrs }">
                 <button
+                  :disabled="isLocked"
                   v-on="on"
                   v-bind="attrs"
                   class="v-small-dialog__activator ml-5"
@@ -337,6 +330,7 @@
           <v-tooltip bottom transition="expand-y-transition" open-delay="200">
             <template v-slot:activator="{ on }">
               <v-btn
+                :disabled="isLocked"
                 icon
                 v-on="on"
                 @click="
@@ -461,7 +455,6 @@ li {
   list-style-type: none;
   padding: 8px;
   padding-left: 16px;
-  border-left: 1px solid #e5e5e5;
 }
 
 .v-small-dialog__activator {

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -47,119 +47,14 @@
         </v-edit-dialog>
       </div>
     </v-row>
-    <v-subheader class="d-flex justify-space-between">
-      <span>Identities ({{ identitiesCount }})</span>
-      <v-btn
-        v-if="!compact"
-        text
-        small
-        outlined
-        :disabled="identitiesCount === 1 || isLocked"
-        @click="splitAll"
-      >
-        <v-icon small left>mdi-call-split</v-icon>
-        Split all
-      </v-btn>
-    </v-subheader>
-    <v-simple-table v-if="compact" dense>
-      <template v-slot:default>
-        <thead v-if="identitiesCount > 0">
-          <tr>
-            <th class="text-left">Name</th>
-            <th class="text-left">Email</th>
-            <th class="text-left">Username</th>
-            <th class="text-left">Source</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr v-for="item in flatIdentities" :key="item.uuid">
-            <td>{{ item.name || "-" }}</td>
-            <td>{{ item.email || "-" }}</td>
-            <td>{{ item.username || "-" }}</td>
-            <td>
-              <v-tooltip
-                bottom
-                transition="expand-y-transition"
-                open-delay="300"
-              >
-                <template v-slot:activator="{ on }">
-                  <v-icon v-on="on" v-text="item.icon" small left />
-                </template>
-                <span>{{ item.source.toLowerCase() }}</span>
-              </v-tooltip>
-            </td>
-          </tr>
-        </tbody>
-      </template>
-    </v-simple-table>
-    <v-list
-      v-else
-      v-for="(source, sourceIndex) in identities"
-      :key="source.name"
-      :class="{
-        'row-border': sourceIndex !== identities.length - 1
-      }"
-      class="indented"
-      dense
-    >
-      <v-list-item
-        v-for="(identity, index) in sortSources(source.identities, 'source')"
-        :class="{ draggable: identity.uuid !== uuid }"
-        :key="identity.uuid"
-        :draggable="identity.uuid !== uuid"
-        @dragstart.native="startDrag(identity, $event)"
-        @dragend.native="dragEnd($event)"
-      >
-        <v-list-item-icon v-if="index === 0">
-          <v-tooltip bottom transition="expand-y-transition" open-delay="300">
-            <template v-slot:activator="{ on }">
-              <v-icon v-on="on">
-                {{ source.icon }}
-              </v-icon>
-            </template>
-            <span>
-              {{ source.name }}
-            </span>
-          </v-tooltip>
-        </v-list-item-icon>
-
-        <v-list-item-action v-else></v-list-item-action>
-
-        <v-list-item-content>
-          <identity
-            :uuid="identity.uuid"
-            :name="identity.name"
-            :email="identity.email"
-            :username="identity.username"
-            :source="identity.source || source.name"
-          />
-        </v-list-item-content>
-
-        <v-tooltip bottom transition="expand-y-transition" open-delay="200">
-          <template v-slot:activator="{ on }">
-            <v-btn
-              icon
-              :disabled="identity.uuid === uuid || isLocked"
-              v-on="on"
-              @click="$emit('unmerge', [identity.uuid, uuid])"
-            >
-              <v-icon>
-                mdi-call-split
-              </v-icon>
-            </v-btn>
-          </template>
-          <span>Split identity</span>
-        </v-tooltip>
-        <v-tooltip bottom transition="expand-y-transition" open-delay="200">
-          <template v-slot:activator="{ on }">
-            <v-icon :disabled="identity.uuid === uuid" v-on="on">
-              mdi-drag-vertical
-            </v-icon>
-          </template>
-          <span>Move identity</span>
-        </v-tooltip>
-      </v-list-item>
-    </v-list>
+    <identities-list
+      :identities="identities"
+      :uuid="uuid"
+      :compact="compact"
+      :is-locked="isLocked"
+      draggable
+      @unmerge="$emit('unmerge', $event)"
+    />
 
     <enrollment-list
       :enrollments="enrollments"
@@ -171,21 +66,17 @@
       "
       @withdraw="$emit('withdraw', $event)"
     />
-
-    <v-card class="dragged-identity" color="primary" dark>
-      <v-card-subtitle> Moving 1 identity</v-card-subtitle>
-    </v-card>
   </td>
 </template>
 
 <script>
-import Identity from "./Identity.vue";
+import IdentitiesList from "./IdentitiesList.vue";
 import EnrollmentList from "./EnrollmentList.vue";
 
 export default {
   name: "ExpandedIndividual",
   components: {
-    Identity,
+    IdentitiesList,
     EnrollmentList
   },
   props: {
@@ -239,51 +130,11 @@ export default {
     };
   },
   methods: {
-    sortSources(identities, property) {
-      return identities.slice().sort((a, b) => {
-        const sourceA = a[property].toLowerCase();
-        const sourceB = b[property].toLowerCase();
-
-        return sourceA.localeCompare(sourceB);
-      });
-    },
-    startDrag(identity, event) {
-      const dragImage = document.querySelector(".dragged-identity");
-      event.dataTransfer.setDragImage(dragImage, 0, 0);
-      event.dataTransfer.effectAllowed = "move";
-      event.dataTransfer.setData("type", "move");
-      event.dataTransfer.setData("uuid", identity.uuid);
-      event.target.classList.add("dragging");
-    },
-    dragEnd(event) {
-      event.target.classList.remove("dragging");
-    },
     async getCountryList() {
       const response = await this.getCountries();
       if (response) {
         this.countries = response;
       }
-    },
-    splitAll() {
-      const uuids = this.flatIdentities.map(identity => identity.uuid);
-      this.$emit("unmerge", uuids);
-    }
-  },
-  computed: {
-    identitiesCount() {
-      return this.identities.reduce((a, b) => a + b.identities.length, 0);
-    },
-    sources() {
-      return this.identities.map(identity => identity.name);
-    },
-    flatIdentities() {
-      return this.identities
-        .map(source =>
-          source.identities.map(identity =>
-            Object.assign({ icon: source.icon }, identity)
-          )
-        )
-        .flat();
     }
   }
 };
@@ -293,20 +144,6 @@ export default {
 .indented {
   margin-left: 40px;
   background-color: transparent;
-}
-
-.draggable {
-  cursor: pointer;
-
-  &:hover {
-    background: #eeeeee;
-  }
-}
-
-.dragged-identity {
-  max-width: 300px;
-  position: absolute;
-  top: -300px;
 }
 
 .compact {

--- a/ui/src/components/ExpandedIndividual.vue
+++ b/ui/src/components/ExpandedIndividual.vue
@@ -60,7 +60,8 @@
       :enrollments="enrollments"
       :compact="compact"
       :is-locked="isLocked"
-      @openModal="$emit('openModal', { uuid, organization: $event })"
+      @openEnrollmentModal="$emit('openEnrollmentModal', uuid)"
+      @openTeamModal="$emit('openTeamModal', { uuid, organization: $event })"
       @updateEnrollment="
         $emit('updateEnrollment', Object.assign($event, { uuid: uuid }))
       "

--- a/ui/src/components/IdentitiesList.stories.js
+++ b/ui/src/components/IdentitiesList.stories.js
@@ -1,0 +1,80 @@
+import IdentitiesList from "./IdentitiesList.vue";
+
+export default {
+  title: "IdentitiesList",
+  excludeStories: /.*Data$/
+};
+
+const template = `
+  <identities-list
+    :compact="compact"
+    :identities="identities"
+    uuid="123"
+  />`;
+
+const identities = [
+  {
+    name: "GitHub",
+    icon: "mdi-github",
+    identities: [
+      {
+        uuid: "06e6903c91180835b6ee91dd56782c6ca72bc562",
+        name: "Tom Marvolo Riddle",
+        email: "triddle@example.net",
+        username: "triddle",
+        source: "GitHub"
+      },
+      {
+        uuid: "164e41c60c28698ac30b0d17176d3e720e036918",
+        name: "Voldemort",
+        email: "-",
+        username: "voldemort",
+        source: "GitHub"
+      }
+    ]
+  },
+  {
+    name: "Git",
+    icon: "mdi-git",
+    identities: [
+      {
+        uuid: "10982379421b80e13266db011d6e5131dd519016",
+        name: "voldemort",
+        email: "voldemort@example.net",
+        username: "-",
+        source: "git"
+      }
+    ]
+  },
+  {
+    name: "Others",
+    icon: "mdi-account-multiple",
+    identities: [
+      {
+        uuid: "1f1a9e56dedb45f5969413eeb4442d982e33f0f6",
+        name: "-",
+        email: "-",
+        username: "voldemort",
+        source: "irc"
+      }
+    ]
+  }
+];
+
+export const Default = () => ({
+  components: { IdentitiesList },
+  template: template,
+  data: () => ({
+    identities: identities,
+    compact: false
+  })
+});
+
+export const Compact = () => ({
+  components: { IdentitiesList },
+  template: template,
+  data: () => ({
+    identities: identities,
+    compact: true
+  })
+});

--- a/ui/src/components/IdentitiesList.vue
+++ b/ui/src/components/IdentitiesList.vue
@@ -1,0 +1,220 @@
+<template>
+  <div>
+    <v-subheader class="d-flex justify-space-between">
+      <span>Identities ({{ identitiesCount }})</span>
+      <v-btn
+        v-if="!compact"
+        text
+        small
+        outlined
+        :disabled="identitiesCount === 1 || isLocked"
+        @click="splitAll"
+      >
+        <v-icon small left>mdi-call-split</v-icon>
+        Split all
+      </v-btn>
+    </v-subheader>
+    <v-simple-table v-if="compact" dense>
+      <template v-slot:default>
+        <thead v-if="identitiesCount > 0">
+          <tr>
+            <th class="text-left">Name</th>
+            <th class="text-left">Email</th>
+            <th class="text-left">Username</th>
+            <th class="text-left">Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="item in flatIdentities" :key="item.uuid">
+            <td>{{ item.name || "-" }}</td>
+            <td>{{ item.email || "-" }}</td>
+            <td>{{ item.username || "-" }}</td>
+            <td>
+              <v-tooltip
+                bottom
+                transition="expand-y-transition"
+                open-delay="300"
+              >
+                <template v-slot:activator="{ on }">
+                  <v-icon v-on="on" v-text="item.icon" small left />
+                </template>
+                <span>{{ item.source.toLowerCase() }}</span>
+              </v-tooltip>
+            </td>
+          </tr>
+        </tbody>
+      </template>
+    </v-simple-table>
+    <v-list
+      v-else
+      v-for="(source, sourceIndex) in identities"
+      :key="source.name"
+      :class="{
+        'row-border': sourceIndex !== identities.length - 1
+      }"
+      class="indented"
+      dense
+    >
+      <v-list-item
+        v-for="(identity, index) in sortSources(source.identities, 'source')"
+        :class="{ draggable: draggable && identity.uuid !== uuid }"
+        :key="identity.uuid"
+        :draggable="draggable && !isLocked && identity.uuid !== uuid"
+        @dragstart.native="startDrag(identity, $event)"
+        @dragend.native="dragEnd($event)"
+      >
+        <v-list-item-icon v-if="index === 0">
+          <v-tooltip bottom transition="expand-y-transition" open-delay="300">
+            <template v-slot:activator="{ on }">
+              <v-icon v-on="on">
+                {{ source.icon }}
+              </v-icon>
+            </template>
+            <span>
+              {{ source.name }}
+            </span>
+          </v-tooltip>
+        </v-list-item-icon>
+
+        <v-list-item-action v-else></v-list-item-action>
+
+        <v-list-item-content>
+          <identity
+            :uuid="identity.uuid"
+            :name="identity.name"
+            :email="identity.email"
+            :username="identity.username"
+            :source="identity.source || source.name"
+          />
+        </v-list-item-content>
+
+        <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+          <template v-slot:activator="{ on }">
+            <v-btn
+              icon
+              :disabled="identity.uuid === uuid || isLocked"
+              v-on="on"
+              @click="$emit('unmerge', [identity.uuid, uuid])"
+            >
+              <v-icon>
+                mdi-call-split
+              </v-icon>
+            </v-btn>
+          </template>
+          <span>Split identity</span>
+        </v-tooltip>
+        <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+          <template v-slot:activator="{ on }">
+            <v-icon
+              v-if="draggable"
+              :disabled="identity.uuid === uuid || isLocked"
+              v-on="on"
+            >
+              mdi-drag-vertical
+            </v-icon>
+          </template>
+          <span>Move identity</span>
+        </v-tooltip>
+      </v-list-item>
+    </v-list>
+    <v-card class="dragged-identity" color="primary" dark>
+      <v-card-subtitle> Moving 1 identity</v-card-subtitle>
+    </v-card>
+  </div>
+</template>
+
+<script>
+import Identity from "./Identity.vue";
+
+export default {
+  name: "IdentitiesList",
+  components: {
+    Identity
+  },
+  props: {
+    identities: {
+      type: Array,
+      required: true
+    },
+    isLocked: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    compact: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    uuid: {
+      type: String,
+      required: true
+    },
+    draggable: {
+      type: Boolean,
+      required: false,
+      default: false
+    }
+  },
+  methods: {
+    sortSources(identities, property) {
+      return identities.slice().sort((a, b) => {
+        const sourceA = a[property].toLowerCase();
+        const sourceB = b[property].toLowerCase();
+
+        return sourceA.localeCompare(sourceB);
+      });
+    },
+    startDrag(identity, event) {
+      const dragImage = document.querySelector(".dragged-identity");
+      event.dataTransfer.setDragImage(dragImage, 0, 0);
+      event.dataTransfer.effectAllowed = "move";
+      event.dataTransfer.setData("type", "move");
+      event.dataTransfer.setData("uuid", identity.uuid);
+      event.target.classList.add("dragging");
+    },
+    dragEnd(event) {
+      event.target.classList.remove("dragging");
+    },
+    splitAll() {
+      const uuids = this.flatIdentities.map(identity => identity.uuid);
+      this.$emit("unmerge", uuids);
+    }
+  },
+  computed: {
+    identitiesCount() {
+      return this.identities.reduce((a, b) => a + b.identities.length, 0);
+    },
+    sources() {
+      return this.identities.map(identity => identity.name);
+    },
+    flatIdentities() {
+      return this.identities
+        .map(source =>
+          source.identities.map(identity =>
+            Object.assign({ icon: source.icon }, identity)
+          )
+        )
+        .flat();
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/index.scss";
+
+.draggable {
+  cursor: pointer;
+
+  &:hover {
+    background: #eeeeee;
+  }
+}
+
+.dragged-identity {
+  max-width: 300px;
+  position: absolute;
+  top: -300px;
+}
+</style>

--- a/ui/src/components/IndividualEntry.vue
+++ b/ui/src/components/IndividualEntry.vue
@@ -22,21 +22,9 @@
 
         <v-list-item-content>
           <v-list-item-title class="font-weight-medium">
-            <span v-if="isLocked">{{ name }}</span>
-            <v-edit-dialog v-else @save="$emit('edit', { name: form.name })">
+            <a :href="`individual/${uuid}`" target="_blank" @click.stop>
               {{ name }}
-              <v-icon class="icon--hidden" small>
-                mdi-lead-pencil
-              </v-icon>
-              <template v-slot:input>
-                <v-text-field
-                  v-model="form.name"
-                  label="Edit name"
-                  maxlength="30"
-                  single-line
-                ></v-text-field>
-              </template>
-            </v-edit-dialog>
+            </a>
 
             <v-tooltip bottom transition="expand-y-transition" open-delay="200">
               <template v-slot:activator="{ on }">
@@ -79,22 +67,6 @@
               </template>
               <span>{{ isLocked ? "Unlock profile" : "Lock profile" }}</span>
             </v-tooltip>
-            <v-tooltip bottom transition="expand-y-transition" open-delay="200">
-              <template v-slot:activator="{ on }">
-                <v-btn
-                  :href="`individual/${uuid}`"
-                  class="icon--hidden ml-1"
-                  v-on="on"
-                  small
-                  icon
-                  target="_blank"
-                  @click.stop
-                >
-                  <v-icon small>mdi-open-in-new</v-icon>
-                </v-btn>
-              </template>
-              <span>View full profile</span>
-            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>{{ organization }}</v-list-item-subtitle>
         </v-list-item-content>
@@ -102,21 +74,7 @@
     </td>
 
     <td class="text-center">
-      <span v-if="isLocked" class="mr-7">{{ email }}</span>
-      <v-edit-dialog v-else @save="$emit('edit', { email: form.email })">
-        {{ email }}
-        <v-icon small right>
-          mdi-lead-pencil
-        </v-icon>
-        <template v-slot:input>
-          <v-text-field
-            v-model="form.email"
-            label="Edit email"
-            maxlength="30"
-            single-line
-          ></v-text-field>
-        </template>
-      </v-edit-dialog>
+      <span>{{ email }}</span>
     </td>
 
     <td class="text-right">
@@ -342,6 +300,14 @@ tr {
   }
 }
 .v-list-item__title {
+  a {
+    color: rgba(0, 0, 0, 0.87);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
   ::v-deep .icon--hidden {
     opacity: 0;
     padding-bottom: 2px;

--- a/ui/src/components/IndividualEntry.vue
+++ b/ui/src/components/IndividualEntry.vue
@@ -79,6 +79,22 @@
               </template>
               <span>{{ isLocked ? "Unlock profile" : "Lock profile" }}</span>
             </v-tooltip>
+            <v-tooltip bottom transition="expand-y-transition" open-delay="200">
+              <template v-slot:activator="{ on }">
+                <v-btn
+                  :href="`individual/${uuid}`"
+                  class="icon--hidden ml-1"
+                  v-on="on"
+                  small
+                  icon
+                  target="_blank"
+                  @click.stop
+                >
+                  <v-icon small>mdi-open-in-new</v-icon>
+                </v-btn>
+              </template>
+              <span>View full profile</span>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>{{ organization }}</v-list-item-subtitle>
         </v-list-item-content>
@@ -131,6 +147,11 @@
           </v-btn>
         </template>
         <v-list>
+          <v-list-item :href="`individual/${uuid}`" target="_blank">
+            <v-list-item-title>
+              View full profile
+            </v-list-item-title>
+          </v-list-item>
           <v-list-item @click="$emit('select', $event)">
             <v-list-item-title>
               {{ isSelected ? "Deselect individual" : "Select individual" }}

--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -146,7 +146,8 @@
           @unmerge="unmerge($event)"
           @withdraw="removeAffiliation($event, item.uuid)"
           @updateEnrollment="updateEnrollmentDate"
-          @openModal="openTeamModal"
+          @openEnrollmentModal="confirmEnroll"
+          @openTeamModal="openTeamModal"
         />
       </template>
     </v-data-table>
@@ -229,6 +230,15 @@
       @updateOrganizations="$emit('updateOrganizations')"
     />
 
+    <enroll-modal
+      :is-open.sync="enrollmentModal.open"
+      :title="enrollmentModal.title"
+      :text="enrollmentModal.text"
+      :organization="enrollmentModal.organization"
+      :uuid="enrollmentModal.uuid"
+      :enroll="enrollIndividual"
+    />
+
     <team-enroll-modal
       v-if="teamModal.isOpen"
       :is-open.sync="teamModal.isOpen"
@@ -259,6 +269,7 @@ import IndividualEntry from "./IndividualEntry.vue";
 import ExpandedIndividual from "./ExpandedIndividual.vue";
 import ProfileModal from "./ProfileModal.vue";
 import Search from "./Search.vue";
+import EnrollModal from "./EnrollModal.vue";
 import TeamEnrollModal from "./TeamEnrollModal.vue";
 
 export default {
@@ -268,6 +279,7 @@ export default {
     ExpandedIndividual,
     ProfileModal,
     Search,
+    EnrollModal,
     TeamEnrollModal
   },
   mixins: [enrollMixin],
@@ -350,10 +362,7 @@ export default {
         open: false,
         title: "",
         text: "",
-        action: "",
-        showDates: false,
-        dateFrom: null,
-        dateTo: null
+        action: ""
       },
       openModal: false,
       totalResults: 0,

--- a/ui/src/components/TeamEnrollModal.vue
+++ b/ui/src/components/TeamEnrollModal.vue
@@ -133,6 +133,7 @@ export default {
             fromDate: this.form.dateFrom,
             toDate: this.form.dateTo
           });
+          this.$emit("updateIndividual", response.data.enroll.individual);
           this.closeModal();
         }
       } catch (error) {

--- a/ui/src/components/WorkSpace.vue
+++ b/ui/src/components/WorkSpace.vue
@@ -106,21 +106,6 @@
           <p v-if="dialog.text" class="pt-2 pb-2 text-body-2">
             {{ dialog.text }}
           </p>
-          <div v-if="dialog.showDates">
-            <h6 class="subheader">Enrollment dates (optional)</h6>
-            <v-row>
-              <v-col cols="6">
-                <date-input
-                  v-model="dialog.dateFrom"
-                  label="Date from"
-                  outlined
-                />
-              </v-col>
-              <v-col cols="6">
-                <date-input v-model="dialog.dateTo" label="Date to" outlined />
-              </v-col>
-            </v-row>
-          </div>
         </v-card-text>
         <v-card-actions v-if="dialog.action">
           <v-spacer></v-spacer>
@@ -139,6 +124,15 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <enroll-modal
+      :is-open.sync="enrollmentModal.open"
+      :title="enrollmentModal.title"
+      :text="enrollmentModal.text"
+      :organization="enrollmentModal.organization"
+      :uuid="enrollmentModal.uuid"
+      :enroll="enrollIndividual"
+    />
   </v-sheet>
 </template>
 
@@ -150,10 +144,12 @@ import {
 } from "../utils/actions";
 import { enrollMixin } from "../mixins/enroll";
 import IndividualCard from "./IndividualCard.vue";
+import EnrollModal from "./EnrollModal.vue";
 export default {
   name: "WorkSpace",
   components: {
-    IndividualCard
+    IndividualCard,
+    EnrollModal
   },
   mixins: [enrollMixin],
   props: {
@@ -186,10 +182,7 @@ export default {
         open: false,
         title: "",
         text: "",
-        action: "",
-        showDates: false,
-        dateFrom: null,
-        dateTo: null
+        action: ""
       }
     };
   },
@@ -315,10 +308,7 @@ export default {
         open: false,
         title: "",
         text: "",
-        action: "",
-        showDates: false,
-        dateFrom: null,
-        dateTo: null
+        action: ""
       });
     }
   },

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -9,6 +9,12 @@ const routes = [
     meta: { requiresAuth: true, title: "Sorting Hat" }
   },
   {
+    path: "/individual/:mk",
+    name: "Individual",
+    component: () => import("../views/Individual"),
+    meta: { requiresAuth: true, title: "Sorting Hat" }
+  },
+  {
     path: "/login",
     name: "Login",
     component: () => import("../views/Login"),

--- a/ui/src/styles/index.scss
+++ b/ui/src/styles/index.scss
@@ -123,7 +123,8 @@ button.v-pagination__item {
 }
 
 .theme--light.v-icon,
-.v-btn--round .v-btn__content .v-icon {
+.v-btn--round .v-btn__content .v-icon,
+.theme--light.v-btn--outlined .v-btn__content .v-icon{
   color: rgba(0, 0, 0, 0.62);
 }
 

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -293,7 +293,7 @@
       :organization="teamModal.organization"
       :uuid="mk"
       :enroll="enroll"
-      @updateTable="fetchIndividual"
+      @updateIndividual="updateIndividual($event)"
     />
 
     <v-dialog v-model="dialog.open" max-width="500px">
@@ -401,9 +401,7 @@ export default {
           return;
         }
 
-        this.individual = formatIndividuals(
-          response.data.individuals.entities
-        )[0];
+        this.updateIndividual(response.data.individuals.entities);
 
         Object.assign(this.form, {
           name: this.individual.name,
@@ -420,9 +418,7 @@ export default {
     async updateProfile(data) {
       try {
         const response = await updateProfile(this.$apollo, data, this.mk);
-        this.individual = formatIndividuals([
-          response.data.updateProfile.individual
-        ])[0];
+        this.updateIndividual(response.data.updateProfile.individual);
         this.$logger.debug(`Updated profile ${this.mk}`, data);
       } catch (error) {
         this.dialog = {
@@ -483,7 +479,7 @@ export default {
         const updatedIndividual = response.data.unmergeIdentities.individuals.find(
           individual => individual.mk === this.mk
         );
-        this.individual = formatIndividuals([updatedIndividual])[0];
+        this.updateIndividual(updatedIndividual);
         this.$logger.debug("Unmerged identities", uuids);
       } catch (error) {
         this.dialog = {
@@ -510,9 +506,7 @@ export default {
       Object.assign(data, { uuid: this.mk });
       try {
         const response = await updateEnrollment(this.$apollo, data);
-        this.individual = formatIndividuals([
-          response.data.updateEnrollment.individual
-        ])[0];
+        this.updateIndividual(response.data.updateEnrollment.individual);
         this.$logger.debug("Updated enrollment", data);
       } catch (error) {
         this.dialog = {
@@ -534,9 +528,7 @@ export default {
           toDate,
           parentOrg
         );
-        this.individual = formatIndividuals([
-          response.data.withdraw.individual
-        ])[0];
+        this.updateIndividual(response.data.withdraw.individual);
         this.$logger.debug("Removed affiliation", { uuid: this.mk, ...data });
       } catch (error) {
         this.dialog = {
@@ -584,6 +576,13 @@ export default {
         text: "",
         errorMessage: ""
       };
+    },
+    updateIndividual(newData) {
+      if (!Array.isArray(newData)) {
+        newData = [newData];
+      }
+
+      this.individual = formatIndividuals(newData)[0];
     }
   },
   mounted() {

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -249,7 +249,8 @@
                 v-if="individual.enrollments"
                 :enrollments="individual.enrollments"
                 :is-locked="individual.isLocked"
-                @openModal="openTeamModal"
+                @openEnrollmentModal="confirmEnroll"
+                @openTeamModal="openTeamModal"
                 @updateEnrollment="updateEnrollment"
                 @withdraw="withdraw"
               />
@@ -269,6 +270,14 @@
         Go to dashboard
       </v-btn>
     </v-container>
+
+    <enroll-modal
+      :is-open.sync="enrollmentModal.open"
+      :title="enrollmentModal.title"
+      :text="enrollmentModal.text"
+      :uuid="mk"
+      :enroll="enrollIndividual"
+    />
 
     <team-enroll-modal
       v-if="teamModal.open"
@@ -328,9 +337,11 @@ import {
   withdraw
 } from "../apollo/mutations";
 import { formatIndividuals } from "../utils/actions";
+import { enrollMixin } from "../mixins/enroll";
 import Avatar from "../components/Avatar.vue";
 import IdentitiesList from "../components/IdentitiesList.vue";
 import EnrollmentList from "../components/EnrollmentList.vue";
+import EnrollModal from "../components/EnrollModal.vue";
 import TeamEnrollModal from "../components/TeamEnrollModal.vue";
 
 export default {
@@ -339,8 +350,10 @@ export default {
     Avatar,
     IdentitiesList,
     EnrollmentList,
+    EnrollModal,
     TeamEnrollModal
   },
+  mixins: [enrollMixin],
   data() {
     return {
       individual: {},

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -227,6 +227,14 @@
                   </v-edit-dialog>
                 </v-col>
               </v-row>
+              <v-row class="ml-9">
+                <v-col cols="1" class="ml-6">
+                  <span>UUID:</span>
+                </v-col>
+                <v-col>
+                  <span>{{ individual.uuid }}</span>
+                </v-col>
+              </v-row>
             </v-container>
           </v-row>
 

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -1,0 +1,620 @@
+<template>
+  <v-main>
+    <v-container v-if="individual" class="ml-auto mr-auto mb-8">
+      <v-row>
+        <v-col :cols="recommendations.length === 0 ? 12 : 9">
+          <v-row class="section pa-3 mb-4">
+            <v-col>
+              <v-list-item class="pl-1">
+                <avatar :name="individual.name" :email="individual.email" />
+
+                <v-list-item-content>
+                  <v-list-item-title class="font-weight-medium text-h6">
+                    <span v-if="individual.isLocked">{{
+                      individual.name
+                    }}</span>
+                    <v-edit-dialog
+                      v-else
+                      large
+                      @save="updateProfile({ name: form.name })"
+                      @cancel="form.name = individual.name"
+                    >
+                      <button>
+                        {{ individual.name || "no name" }}
+                        <v-icon
+                          class="icon--hidden aligned"
+                          aria-label="Edit name"
+                          small
+                        >
+                          mdi-lead-pencil
+                        </v-icon>
+                      </button>
+                      <template v-slot:input>
+                        <v-text-field
+                          v-model="form.name"
+                          label="Edit name"
+                          maxlength="30"
+                          single-line
+                        ></v-text-field>
+                      </template>
+                    </v-edit-dialog>
+
+                    <v-tooltip
+                      bottom
+                      transition="expand-y-transition"
+                      open-delay="200"
+                    >
+                      <template v-slot:activator="{ on }">
+                        <v-btn
+                          v-show="!individual.isLocked"
+                          v-on="on"
+                          class="aligned focusable"
+                          icon
+                          small
+                          @click="updateProfile({ isBot: !individual.isBot })"
+                        >
+                          <v-icon
+                            :class="{ 'icon--hidden': !individual.isBot }"
+                            small
+                          >
+                            mdi-robot
+                          </v-icon>
+                        </v-btn>
+                      </template>
+                      <span>{{
+                        individual.isBot ? "Unmark as bot" : "Mark as bot"
+                      }}</span>
+                    </v-tooltip>
+                    <v-icon
+                      v-show="individual.isLocked && individual.isBot"
+                      class="aligned"
+                      small
+                      right
+                    >
+                      mdi-robot
+                    </v-icon>
+                  </v-list-item-title>
+                  <v-list-item-subtitle>{{
+                    individual.organization
+                  }}</v-list-item-subtitle>
+                </v-list-item-content>
+              </v-list-item>
+            </v-col>
+
+            <v-col cols="2" class="d-flex justify-end align-center mr-1">
+              <v-btn
+                v-if="individual.isLocked"
+                class="mr-4"
+                text
+                small
+                outlined
+                @click="unlock"
+              >
+                <v-icon small left>mdi-lock-open</v-icon>
+                Unlock
+              </v-btn>
+              <v-btn v-else class="mr-4" text small outlined @click="lock">
+                <v-icon small left>mdi-lock</v-icon>
+                Lock
+              </v-btn>
+              <v-btn
+                text
+                small
+                outlined
+                :disabled="individual.isLocked"
+                @click="confirmDelete"
+              >
+                <v-icon small left>mdi-delete</v-icon>
+                Delete
+              </v-btn>
+            </v-col>
+          </v-row>
+
+          <v-row class="section mb-4">
+            <v-container fluid>
+              <v-subheader>Profile</v-subheader>
+              <v-row class="ml-9">
+                <v-col cols="1" class="ml-6">
+                  Email:
+                </v-col>
+                <v-col>
+                  <span v-if="individual.isLocked">{{
+                    individual.email || "none"
+                  }}</span>
+                  <v-edit-dialog
+                    v-else
+                    large
+                    @save="updateProfile({ email: form.email })"
+                    @cancel="form.email = individual.email"
+                  >
+                    <button>
+                      {{ individual.email || "none" }}
+                      <v-icon
+                        class="icon--hidden aligned"
+                        aria-label="Edit name"
+                        small
+                      >
+                        mdi-lead-pencil
+                      </v-icon>
+                    </button>
+                    <template v-slot:input>
+                      <v-text-field
+                        v-model="form.email"
+                        label="Edit email"
+                        maxlength="30"
+                        single-line
+                      ></v-text-field>
+                    </template>
+                  </v-edit-dialog>
+                </v-col>
+              </v-row>
+              <v-row class="ml-9">
+                <v-col cols="1" class="ml-6">
+                  Country:
+                </v-col>
+                <v-col>
+                  <span v-if="individual.isLocked">
+                    {{ individual.country ? individual.country.name : "none" }}
+                  </span>
+                  <v-edit-dialog
+                    v-else
+                    large
+                    @save="
+                      updateProfile({
+                        countryCode: form.country ? form.country.code : ''
+                      })
+                    "
+                    @cancel="form.country = individual.country"
+                  >
+                    <button>
+                      {{
+                        individual.country ? individual.country.name : "none"
+                      }}
+                      <v-icon
+                        class="icon--hidden aligned"
+                        aria-label="Edit country"
+                        small
+                      >
+                        mdi-lead-pencil
+                      </v-icon>
+                    </button>
+                    <template v-slot:input>
+                      <v-combobox
+                        v-model="form.country"
+                        :items="countries"
+                        label="Country"
+                        item-text="name"
+                        single-line
+                        @click.once="getCountryList"
+                        @keypress.once="getCountryList"
+                      />
+                    </template>
+                  </v-edit-dialog>
+                </v-col>
+              </v-row>
+              <v-row class="ml-9">
+                <v-col cols="1" class="ml-6">
+                  Gender:
+                </v-col>
+                <v-col>
+                  <span v-if="individual.isLocked">
+                    {{ individual.gender || "none" }}
+                  </span>
+                  <v-edit-dialog
+                    v-else
+                    large
+                    @save="updateProfile({ gender: form.gender })"
+                    @cancel="form.gender = individual.gender"
+                  >
+                    <button>
+                      {{ individual.gender || "none" }}
+                      <v-icon
+                        class="icon--hidden aligned"
+                        aria-label="Edit gender"
+                        small
+                      >
+                        mdi-lead-pencil
+                      </v-icon>
+                    </button>
+                    <template v-slot:input>
+                      <v-text-field
+                        v-model="form.gender"
+                        label="Edit gender"
+                        maxlength="30"
+                        single-line
+                      ></v-text-field>
+                    </template>
+                  </v-edit-dialog>
+                </v-col>
+              </v-row>
+            </v-container>
+          </v-row>
+
+          <v-row class="section mb-4">
+            <v-container fluid>
+              <identities-list
+                class="mb-8"
+                v-if="individual.identities"
+                :identities="individual.identities"
+                :uuid="individual.uuid"
+                :is-locked="individual.isLocked"
+                @unmerge="unmergeIdentities"
+              />
+            </v-container>
+          </v-row>
+
+          <v-row class="section">
+            <v-container fluid>
+              <enrollment-list
+                v-if="individual.enrollments"
+                :enrollments="individual.enrollments"
+                :is-locked="individual.isLocked"
+                @openModal="openTeamModal"
+                @updateEnrollment="updateEnrollment"
+                @withdraw="withdraw"
+              />
+            </v-container>
+          </v-row>
+        </v-col>
+        <v-col cols="3" v-if="recommendations.length !== 0">
+          <v-container class="section"> </v-container>
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <v-container v-else>
+      <v-alert dense text type="error"> Individual {{ mk }} not found </v-alert>
+      <v-btn to="/" color="primary" depressed>
+        <v-icon left dark>mdi-arrow-left</v-icon>
+        Go to dashboard
+      </v-btn>
+    </v-container>
+
+    <team-enroll-modal
+      v-if="teamModal.open"
+      :is-open.sync="teamModal.open"
+      :organization="teamModal.organization"
+      :uuid="mk"
+      :enroll="enroll"
+      @updateTable="fetchIndividual"
+    />
+
+    <v-dialog v-model="dialog.open" max-width="500px">
+      <v-card class="pa-3">
+        <v-card-title class="headline">{{ dialog.title }}</v-card-title>
+        <v-card-text>
+          <p v-if="dialog.text" class="pt-2 pb-2 text-body-2">
+            {{ dialog.text }}
+          </p>
+          <v-alert v-if="dialog.errorMessage" dense text type="error">
+            {{ dialog.errorMessage }}
+          </v-alert>
+        </v-card-text>
+        <v-card-actions v-if="dialog.action">
+          <v-spacer></v-spacer>
+          <v-btn text @click="closeDialog">
+            Cancel
+          </v-btn>
+          <v-btn
+            color="primary"
+            id="confirm"
+            depressed
+            @click.stop="dialog.action"
+          >
+            Confirm
+          </v-btn>
+        </v-card-actions>
+        <v-card-actions v-else>
+          <v-spacer></v-spacer>
+          <v-btn text color="primary" @click="closeDialog">
+            OK
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-main>
+</template>
+
+<script>
+import { getCountries, getIndividualByUuid } from "../apollo/queries";
+import {
+  deleteIdentity,
+  enroll,
+  lockIndividual,
+  unlockIndividual,
+  unmerge,
+  updateEnrollment,
+  updateProfile,
+  withdraw
+} from "../apollo/mutations";
+import { formatIndividuals } from "../utils/actions";
+import Avatar from "../components/Avatar.vue";
+import IdentitiesList from "../components/IdentitiesList.vue";
+import EnrollmentList from "../components/EnrollmentList.vue";
+import TeamEnrollModal from "../components/TeamEnrollModal.vue";
+
+export default {
+  name: "Individual",
+  components: {
+    Avatar,
+    IdentitiesList,
+    EnrollmentList,
+    TeamEnrollModal
+  },
+  data() {
+    return {
+      individual: {},
+      recommendations: [],
+      form: {
+        name: "",
+        email: "",
+        country: "",
+        gender: ""
+      },
+      dialog: {
+        open: false,
+        title: "",
+        text: "",
+        errorMessage: "",
+        action: null
+      },
+      teamModal: {
+        open: false,
+        organization: ""
+      },
+      countries: []
+    };
+  },
+  computed: {
+    mk() {
+      return this.$route.params.mk;
+    }
+  },
+  methods: {
+    async fetchIndividual() {
+      try {
+        const response = await getIndividualByUuid(this.$apollo, this.mk);
+
+        if (response.data.individuals.entities.length === 0) {
+          this.individual = false;
+          return;
+        }
+
+        this.individual = formatIndividuals(
+          response.data.individuals.entities
+        )[0];
+
+        Object.assign(this.form, {
+          name: this.individual.name,
+          email: this.individual.email,
+          country: this.individual.country,
+          gender: this.individual.gender
+        });
+
+        document.title = `${this.individual.name} - Sorting Hat`;
+      } catch (error) {
+        console.log(error);
+      }
+    },
+    async updateProfile(data) {
+      try {
+        const response = await updateProfile(this.$apollo, data, this.mk);
+        this.individual = formatIndividuals([
+          response.data.updateProfile.individual
+        ])[0];
+        this.$logger.debug(`Updated profile ${this.mk}`, data);
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error updating profile",
+          errorMessage: this.$getErrorMessage(error)
+        };
+        this.$logger.error(`Error updating profile: ${error}`, data);
+      }
+    },
+    async lock() {
+      try {
+        const response = await lockIndividual(this.$apollo, this.mk);
+        Object.assign(this.individual, {
+          isLocked: response.data.lock.individual.isLocked
+        });
+        this.$logger.debug(`Locked individual ${this.mk}`);
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error locking profile",
+          errorMessage: this.$getErrorMessage(error)
+        };
+        this.$logger.error(`Error locking individual ${this.mk}: ${error}`);
+      }
+    },
+    async unlock() {
+      try {
+        const response = await unlockIndividual(this.$apollo, this.mk);
+        Object.assign(this.individual, {
+          isLocked: response.data.unlock.individual.isLocked
+        });
+        this.$logger.debug(`Unlocked individual ${this.mk}`);
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error updating profile",
+          errorMessage: this.$getErrorMessage(error)
+        };
+        this.$logger.error(`Error unlocking individual ${this.mk}: ${error}`);
+      }
+    },
+    async getCountryList() {
+      try {
+        const response = await getCountries(this.$apollo);
+        this.countries = response.data.countries.entities;
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error loading country list",
+          errorMessage: this.$getErrorMessage(error)
+        };
+      }
+    },
+    async unmergeIdentities(uuids) {
+      try {
+        const response = await unmerge(this.$apollo, uuids);
+        const updatedIndividual = response.data.unmergeIdentities.individuals.find(
+          individual => individual.mk === this.mk
+        );
+        this.individual = formatIndividuals([updatedIndividual])[0];
+        this.$logger.debug("Unmerged identities", uuids);
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error updating profile",
+          errorMessage: this.$getErrorMessage(error)
+        };
+        this.$logger.error(`Error unmerging identities ${uuids}: ${error}`);
+      }
+    },
+    async enroll(uuid, group, fromDate, toDate, parentOrg) {
+      const response = await enroll(
+        this.$apollo,
+        uuid,
+        group,
+        fromDate,
+        toDate,
+        parentOrg
+      );
+
+      return response;
+    },
+    async updateEnrollment(data) {
+      Object.assign(data, { uuid: this.mk });
+      try {
+        const response = await updateEnrollment(this.$apollo, data);
+        this.individual = formatIndividuals([
+          response.data.updateEnrollment.individual
+        ])[0];
+        this.$logger.debug("Updated enrollment", data);
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error updating profile",
+          errorMessage: this.$getErrorMessage(error)
+        };
+        this.$logger.error(`Error updating enrollment: ${error}`, data);
+      }
+    },
+    async withdraw(data) {
+      const { name, fromDate, toDate, parentOrg } = data;
+      try {
+        const response = await withdraw(
+          this.$apollo,
+          this.mk,
+          name,
+          fromDate,
+          toDate,
+          parentOrg
+        );
+        this.individual = formatIndividuals([
+          response.data.withdraw.individual
+        ])[0];
+        this.$logger.debug("Removed affiliation", { uuid: this.mk, ...data });
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error updating profile",
+          errorMessage: this.$getErrorMessage(error)
+        };
+        this.$logger.error(`Error removing affiliation: ${error}`, {
+          uuid: this.mk,
+          ...data
+        });
+      }
+    },
+    async deleteIndividual() {
+      try {
+        const response = await deleteIdentity(this.$apollo, this.mk);
+        if (response) {
+          this.$router.push("/");
+        }
+      } catch (error) {
+        this.dialog = {
+          open: true,
+          title: "Error deleting profile",
+          errorMessage: this.$getErrorMessage(error)
+        };
+      }
+    },
+    openTeamModal(organization) {
+      this.teamModal = {
+        open: true,
+        organization: organization
+      };
+    },
+    confirmDelete() {
+      this.dialog = {
+        open: true,
+        title: `Delete ${this.individual.name}?`,
+        action: this.deleteIndividual
+      };
+    },
+    closeDialog() {
+      this.dialog = {
+        open: false,
+        title: "",
+        text: "",
+        errorMessage: ""
+      };
+    }
+  },
+  mounted() {
+    this.fetchIndividual();
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/index.scss";
+
+.section {
+  font-size: 0.875rem;
+}
+
+::v-deep .v-small-dialog__activator,
+.v-small-dialog {
+  display: inline-block;
+}
+.v-small-dialog__activator {
+  .v-icon {
+    opacity: 0;
+    padding-bottom: 2px;
+  }
+
+  button:focus,
+  button:focus-visible {
+    background: #f4f4f4;
+    .v-icon {
+      opacity: 1;
+    }
+  }
+
+  &:hover {
+    .v-icon {
+      opacity: 1;
+    }
+  }
+}
+.v-list-item__title {
+  ::v-deep .icon--hidden {
+    opacity: 0;
+    padding-bottom: 2px;
+  }
+  &:hover {
+    ::v-deep .icon--hidden {
+      opacity: 1;
+    }
+  }
+}
+
+.aligned {
+  margin-bottom: 4px;
+}
+</style>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -341,6 +341,12 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
     updateprofile="() => {}"
   />
    
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
+  />
+   
   <!---->
    
   <v-card-stub
@@ -700,6 +706,12 @@ exports[`IndividualsTable Mock query for merge 1`] = `
     enroll="() => {}"
     getcountries="() => {}"
     updateprofile="() => {}"
+  />
+   
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
   />
    
   <!---->
@@ -1063,6 +1075,12 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
     updateprofile="() => {}"
   />
    
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
+  />
+   
   <!---->
    
   <v-card-stub
@@ -1422,6 +1440,12 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
     enroll="() => {}"
     getcountries="() => {}"
     updateprofile="() => {}"
+  />
+   
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
   />
    
   <!---->
@@ -1785,6 +1809,12 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
     updateprofile="() => {}"
   />
    
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
+  />
+   
   <!---->
    
   <v-card-stub
@@ -2144,6 +2174,12 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
     enroll="() => {}"
     getcountries="() => {}"
     updateprofile="() => {}"
+  />
+   
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
   />
    
   <!---->

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -350,6 +350,12 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
     updateprofile="() => {}"
   />
    
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
+  />
+   
   <!---->
    
   <v-card-stub
@@ -709,6 +715,12 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
     enroll="() => {}"
     getcountries="() => {}"
     updateprofile="() => {}"
+  />
+   
+  <enroll-modal-stub
+    enroll="function () { [native code] }"
+    text=""
+    title=""
   />
    
   <!---->

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -4568,27 +4568,14 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             Tom Marvolo Riddle
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -4617,27 +4604,6 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -4652,27 +4618,9 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      triddle@example.com
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  triddle@example.com
+                </span>
               </td>
                
               <td
@@ -4811,9 +4759,14 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <span>
-                        Tom Marvolo Riddle
-                      </span>
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
+                      >
+                        
+            Tom Marvolo Riddle
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -4842,27 +4795,6 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -4877,9 +4809,7 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
               <td
                 class="text-center"
               >
-                <span
-                  class="mr-7"
-                >
+                <span>
                   triddle@example.com
                 </span>
               </td>
@@ -5020,27 +4950,14 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             Tom Marvolo Riddle
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -5069,27 +4986,6 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -5104,27 +5000,9 @@ exports[`Storyshots IndividualEntry Default 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      triddle@example.com
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  triddle@example.com
+                </span>
               </td>
                
               <td
@@ -5263,27 +5141,14 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             Santiago Dueñas
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -5312,27 +5177,6 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -5347,27 +5191,9 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      sduenas@bitergia.com
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  sduenas@bitergia.com
+                </span>
               </td>
                
               <td
@@ -5506,27 +5332,14 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             Tom Marvolo Riddle
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -5555,27 +5368,6 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -5590,27 +5382,9 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      triddle@example.com
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  triddle@example.com
+                </span>
               </td>
                
               <td
@@ -5749,9 +5523,14 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <span>
-                        Tom Marvolo Riddle
-                      </span>
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
+                      >
+                        
+            Tom Marvolo Riddle
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -5780,27 +5559,6 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -5815,9 +5573,7 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
               <td
                 class="text-center"
               >
-                <span
-                  class="mr-7"
-                >
+                <span>
                   triddle@example.com
                 </span>
               </td>
@@ -5954,27 +5710,14 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             Tom Marvolo Riddle
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -6003,27 +5746,6 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -6038,27 +5760,9 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  
+                </span>
               </td>
                
               <td
@@ -6197,27 +5901,14 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -6246,27 +5937,6 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -6281,27 +5951,9 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      triddle@example.com
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  triddle@example.com
+                </span>
               </td>
                
               <td
@@ -6440,27 +6092,14 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             Tom Marvolo Riddle
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -6489,27 +6128,6 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -6524,27 +6142,9 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      triddle@example.com
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  triddle@example.com
+                </span>
               </td>
                
               <td
@@ -6683,27 +6283,14 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                     <div
                       class="v-list-item__title font-weight-medium"
                     >
-                      <div
-                        class="v-menu v-small-dialog theme--light"
+                      <a
+                        href="individual/03b3428ee"
+                        target="_blank"
                       >
-                        <div
-                          class="v-small-dialog__activator"
-                        >
-                          <span
-                            class="v-small-dialog__activator__content"
-                          >
-                            
+                        
             Voldemort
-            
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate icon--hidden mdi mdi-lead-pencil theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </div>
-                        <!---->
-                      </div>
+          
+                      </a>
                        
                       <span
                         class="v-tooltip v-tooltip--bottom"
@@ -6732,27 +6319,6 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                           type="button"
                         />
                       </span>
-                       
-                      <span
-                        class="v-tooltip v-tooltip--bottom"
-                      >
-                        <!---->
-                        <a
-                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
-                          href="individual/03b3428ee"
-                          target="_blank"
-                        >
-                          <span
-                            class="v-btn__content"
-                          >
-                            <i
-                              aria-hidden="true"
-                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
-                              style="font-size: 16px;"
-                            />
-                          </span>
-                        </a>
-                      </span>
                     </div>
                      
                     <div
@@ -6767,27 +6333,9 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
               <td
                 class="text-center"
               >
-                <div
-                  class="v-menu v-small-dialog theme--light"
-                >
-                  <div
-                    class="v-small-dialog__activator"
-                  >
-                    <span
-                      class="v-small-dialog__activator__content"
-                    >
-                      
-      lord.voldemort@example.com
-      
-                      <i
-                        aria-hidden="true"
-                        class="v-icon notranslate v-icon--right mdi mdi-lead-pencil theme--light"
-                        style="font-size: 16px;"
-                      />
-                    </span>
-                  </div>
-                  <!---->
-                </div>
+                <span>
+                  lord.voldemort@example.com
+                </span>
               </td>
                
               <td
@@ -7855,7 +7403,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 />
                 <input
                   aria-checked="false"
-                  id="input-1015"
+                  id="input-937"
                   role="checkbox"
                   type="checkbox"
                   value=""
@@ -7866,7 +7414,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               </div>
               <label
                 class="v-label theme--light"
-                for="input-1015"
+                for="input-937"
                 style="left: 0px; position: relative;"
               >
                 Select all
@@ -7952,13 +7500,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1020"
+                    for="input-942"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1020"
+                    id="input-942"
                     type="text"
                   />
                 </div>
@@ -8030,7 +7578,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-owns="list-1028"
+                aria-owns="list-950"
                 class="v-input__slot"
                 role="button"
               >
@@ -8048,7 +7596,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1028"
+                    for="input-950"
                     style="left: 0px; position: absolute;"
                   >
                     Order by
@@ -8059,7 +7607,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                     <input
                       aria-readonly="false"
                       autocomplete="off"
-                      id="input-1028"
+                      id="input-950"
                       readonly="readonly"
                       type="text"
                     />
@@ -8246,13 +7794,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label v-label--active theme--light"
-                    for="input-1048"
+                    for="input-970"
                     style="left: 0px; position: absolute;"
                   >
                     Items per page
                   </label>
                   <input
-                    id="input-1048"
+                    id="input-970"
                     max="0"
                     min="1"
                     type="number"
@@ -8798,13 +8346,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1339"
+                    for="input-1222"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1339"
+                    id="input-1222"
                     type="text"
                   />
                 </div>
@@ -8935,13 +8483,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1350"
+                  for="input-1233"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1350"
+                  id="input-1233"
                   max="0"
                   min="1"
                   type="number"
@@ -9079,13 +8627,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1282"
+                    for="input-1165"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1282"
+                    id="input-1165"
                     type="text"
                   />
                 </div>
@@ -9216,13 +8764,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1293"
+                  for="input-1176"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1293"
+                  id="input-1176"
                   max="0"
                   min="1"
                   type="number"
@@ -9544,13 +9092,13 @@ exports[`Storyshots Search Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1418"
+                  for="input-1301"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1418"
+                  id="input-1301"
                   type="text"
                 />
               </div>
@@ -9678,13 +9226,13 @@ exports[`Storyshots Search Filter Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1428"
+                  for="input-1311"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1428"
+                  id="input-1311"
                   type="text"
                 />
               </div>
@@ -9782,13 +9330,13 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1441"
+                  for="input-1324"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1441"
+                  id="input-1324"
                   type="text"
                 />
               </div>
@@ -9860,7 +9408,7 @@ exports[`Storyshots Search Order Selector 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="list-1446"
+              aria-owns="list-1329"
               class="v-input__slot"
               role="button"
             >
@@ -9878,7 +9426,7 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1446"
+                  for="input-1329"
                   style="left: 0px; position: absolute;"
                 >
                   Order by
@@ -9889,7 +9437,7 @@ exports[`Storyshots Search Order Selector 1`] = `
                   <input
                     aria-readonly="false"
                     autocomplete="off"
-                    id="input-1446"
+                    id="input-1329"
                     readonly="readonly"
                     type="text"
                   />
@@ -10575,7 +10123,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1560"
+                    id="input-1443"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -10586,7 +10134,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1560"
+                  for="input-1443"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -10672,13 +10220,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1565"
+                      for="input-1448"
                       style="left: 0px; position: absolute;"
                     >
                       Search
                     </label>
                     <input
-                      id="input-1565"
+                      id="input-1448"
                       type="text"
                     />
                   </div>
@@ -10750,7 +10298,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-owns="list-1573"
+                  aria-owns="list-1456"
                   class="v-input__slot"
                   role="button"
                 >
@@ -10768,7 +10316,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1573"
+                      for="input-1456"
                       style="left: 0px; position: absolute;"
                     >
                       Order by
@@ -10779,7 +10327,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       <input
                         aria-readonly="false"
                         autocomplete="off"
-                        id="input-1573"
+                        id="input-1456"
                         readonly="readonly"
                         type="text"
                       />
@@ -10966,13 +10514,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label v-label--active theme--light"
-                      for="input-1593"
+                      for="input-1476"
                       style="left: 0px; position: absolute;"
                     >
                       Items per page
                     </label>
                     <input
-                      id="input-1593"
+                      id="input-1476"
                       max="0"
                       min="1"
                       type="number"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -515,7 +515,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
       </div>
        
       <div
-        class="indented mt-2 mb-4"
+        class="ma-4"
       >
         <div
           class="mb-2 d-flex justify-space-between align-center"
@@ -527,7 +527,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
               <!---->
               <i
                 aria-hidden="true"
-                class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+                class="v-icon notranslate mr-8 v-icon--left mdi mdi-sitemap theme--light"
               />
             </span>
             
@@ -640,17 +640,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
               class="d-flex align-center"
             >
               <span
-                class="v-tooltip v-tooltip--bottom"
-              >
-                <!---->
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-account-multiple theme--light"
-                />
-              </span>
-               
-              <span
-                class="mr-4"
+                class="ml-3 mr-4"
               >
                 Gryffindor
               </span>
@@ -736,17 +726,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
               class="d-flex align-center"
             >
               <span
-                class="v-tooltip v-tooltip--bottom"
-              >
-                <!---->
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-account-multiple theme--light"
-                />
-              </span>
-               
-              <span
-                class="mr-4"
+                class="ml-3 mr-4"
               >
                 Transfiguration department
               </span>
@@ -828,7 +808,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
         </ul>
       </div>
       <div
-        class="indented mt-2 mb-4"
+        class="ma-4"
       >
         <div
           class="mb-2 d-flex justify-space-between align-center"
@@ -840,7 +820,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
               <!---->
               <i
                 aria-hidden="true"
-                class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+                class="v-icon notranslate mr-8 v-icon--left mdi mdi-sitemap theme--light"
               />
             </span>
             
@@ -948,7 +928,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
         />
       </div>
       <div
-        class="indented mt-2 mb-4"
+        class="ma-4"
       >
         <div
           class="mb-2 d-flex justify-space-between align-center"
@@ -960,7 +940,7 @@ exports[`Storyshots EnrollmentList Default 1`] = `
               <!---->
               <i
                 aria-hidden="true"
-                class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+                class="v-icon notranslate mr-8 v-icon--left mdi mdi-sitemap theme--light"
               />
             </span>
             
@@ -1089,158 +1069,170 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
        
       <!---->
        
-      <div
-        class="v-subheader d-flex justify-space-between theme--light"
-      >
-        <span>
-          Identities (4)
-        </span>
-         
-        <!---->
-      </div>
-       
-      <div
-        class="v-data-table v-data-table--dense theme--light"
-      >
+      <div>
         <div
-          class="v-data-table__wrapper"
+          class="v-subheader d-flex justify-space-between theme--light"
         >
-          <table>
-            <thead>
-              <tr>
-                <th
-                  class="text-left"
-                >
-                  Name
-                </th>
-                 
-                <th
-                  class="text-left"
-                >
-                  Email
-                </th>
-                 
-                <th
-                  class="text-left"
-                >
-                  Username
-                </th>
-                 
-                <th
-                  class="text-left"
-                >
-                  Source
-                </th>
-              </tr>
-            </thead>
-             
-            <tbody>
-              <tr>
-                <td>
-                  Tom Marvolo Riddle
-                </td>
-                 
-                <td>
-                  triddle@example.net
-                </td>
-                 
-                <td>
-                  triddle
-                </td>
-                 
-                <td>
-                  <span
-                    class="v-tooltip v-tooltip--bottom"
+          <span>
+            Identities (4)
+          </span>
+           
+          <!---->
+        </div>
+         
+        <div
+          class="v-data-table v-data-table--dense theme--light"
+        >
+          <div
+            class="v-data-table__wrapper"
+          >
+            <table>
+              <thead>
+                <tr>
+                  <th
+                    class="text-left"
                   >
-                    <!---->
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--left mdi mdi-github theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  Voldemort
-                </td>
-                 
-                <td>
-                  -
-                </td>
-                 
-                <td>
-                  voldemort
-                </td>
-                 
-                <td>
-                  <span
-                    class="v-tooltip v-tooltip--bottom"
+                    Name
+                  </th>
+                   
+                  <th
+                    class="text-left"
                   >
-                    <!---->
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--left mdi mdi-github theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  voldemort
-                </td>
-                 
-                <td>
-                  voldemort@example.net
-                </td>
-                 
-                <td>
-                  -
-                </td>
-                 
-                <td>
-                  <span
-                    class="v-tooltip v-tooltip--bottom"
+                    Email
+                  </th>
+                   
+                  <th
+                    class="text-left"
                   >
-                    <!---->
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--left mdi mdi-git theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </span>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  -
-                </td>
-                 
-                <td>
-                  -
-                </td>
-                 
-                <td>
-                  voldemort
-                </td>
-                 
-                <td>
-                  <span
-                    class="v-tooltip v-tooltip--bottom"
+                    Username
+                  </th>
+                   
+                  <th
+                    class="text-left"
                   >
-                    <!---->
-                    <i
-                      aria-hidden="true"
-                      class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light"
-                      style="font-size: 16px;"
-                    />
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                    Source
+                  </th>
+                </tr>
+              </thead>
+               
+              <tbody>
+                <tr>
+                  <td>
+                    Tom Marvolo Riddle
+                  </td>
+                   
+                  <td>
+                    triddle@example.net
+                  </td>
+                   
+                  <td>
+                    triddle
+                  </td>
+                   
+                  <td>
+                    <span
+                      class="v-tooltip v-tooltip--bottom"
+                    >
+                      <!---->
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--left mdi mdi-github theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    Voldemort
+                  </td>
+                   
+                  <td>
+                    -
+                  </td>
+                   
+                  <td>
+                    voldemort
+                  </td>
+                   
+                  <td>
+                    <span
+                      class="v-tooltip v-tooltip--bottom"
+                    >
+                      <!---->
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--left mdi mdi-github theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    voldemort
+                  </td>
+                   
+                  <td>
+                    voldemort@example.net
+                  </td>
+                   
+                  <td>
+                    -
+                  </td>
+                   
+                  <td>
+                    <span
+                      class="v-tooltip v-tooltip--bottom"
+                    >
+                      <!---->
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--left mdi mdi-git theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    -
+                  </td>
+                   
+                  <td>
+                    -
+                  </td>
+                   
+                  <td>
+                    voldemort
+                  </td>
+                   
+                  <td>
+                    <span
+                      class="v-tooltip v-tooltip--bottom"
+                    >
+                      <!---->
+                      <i
+                        aria-hidden="true"
+                        class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light"
+                        style="font-size: 16px;"
+                      />
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+         
+        <div
+          class="dragged-identity v-card v-sheet theme--dark primary"
+        >
+          <div
+            class="v-card__subtitle"
+          >
+             Moving 1 identity
+          </div>
         </div>
       </div>
        
@@ -1313,16 +1305,6 @@ exports[`Storyshots ExpandedIndividual Compact 1`] = `
               </tbody>
             </table>
           </div>
-        </div>
-      </div>
-       
-      <div
-        class="dragged-identity v-card v-sheet theme--dark primary"
-      >
-        <div
-          class="v-card__subtitle"
-        >
-           Moving 1 identity
         </div>
       </div>
     </td>
@@ -1420,480 +1402,492 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
         </div>
       </div>
        
-      <div
-        class="v-subheader d-flex justify-space-between theme--light"
-      >
-        <span>
-          Identities (4)
-        </span>
-         
-        <button
-          class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
-          type="button"
+      <div>
+        <div
+          class="v-subheader d-flex justify-space-between theme--light"
         >
-          <span
-            class="v-btn__content"
+          <span>
+            Identities (4)
+          </span>
+           
+          <button
+            class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            type="button"
           >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
-              style="font-size: 16px;"
-            />
-            
+            <span
+              class="v-btn__content"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
+                style="font-size: 16px;"
+              />
+              
       Split all
     
-          </span>
-        </button>
-      </div>
-       
-      <div
-        class="v-list indented v-sheet theme--light v-list--dense row-border"
-        role="list"
-      >
+            </span>
+          </button>
+        </div>
+         
         <div
-          class="v-list-item theme--light"
-          draggable="false"
-          role="listitem"
-          tabindex="-1"
+          class="v-list indented v-sheet theme--light v-list--dense row-border"
+          role="list"
         >
           <div
-            class="v-list-item__icon"
-          >
-            <span
-              class="v-tooltip v-tooltip--bottom"
-            >
-              <!---->
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate mdi mdi-github theme--light"
-              />
-            </span>
-          </div>
-           
-          <div
-            class="v-list-item__content"
+            class="v-list-item theme--light"
+            draggable="false"
+            role="listitem"
+            tabindex="-1"
           >
             <div
-              class="row no-gutters"
+              class="v-list-item__icon"
+            >
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-github theme--light"
+                />
+              </span>
+            </div>
+             
+            <div
+              class="v-list-item__content"
             >
               <div
-                class="uuid col"
+                class="row no-gutters"
               >
-                <span
-                  class="v-tooltip v-tooltip--bottom"
+                <div
+                  class="uuid col"
                 >
-                  <!---->
                   <span
-                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
+                    class="v-tooltip v-tooltip--bottom"
                   >
+                    <!---->
                     <span
-                      class="v-chip__content"
+                      class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                      tile=""
                     >
-                      
+                      <span
+                        class="v-chip__content"
+                      >
+                        
           06e6903c91180835b6ee91dd56782c6ca72bc562
         
+                      </span>
                     </span>
                   </span>
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  Tom Marvolo Riddle
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  triddle@example.net
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  triddle
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  GitHub
-                </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    Tom Marvolo Riddle
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    triddle@example.net
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    triddle
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    GitHub
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <button
-              class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-              disabled="disabled"
-              type="button"
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
             >
-              <span
-                class="v-btn__content"
-              >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-call-split theme--light"
-                />
-              </span>
-            </button>
-          </span>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate v-icon--disabled mdi mdi-drag-vertical theme--light"
-            />
-          </span>
-        </div>
-        <div
-          class="v-list-item theme--light draggable"
-          draggable="true"
-          role="listitem"
-          tabindex="-1"
-        >
-          <div
-            class="v-list-item__action"
-          />
-           
-          <div
-            class="v-list-item__content"
-          >
-            <div
-              class="row no-gutters"
-            >
-              <div
-                class="uuid col"
+              <!---->
+              <button
+                class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                disabled="disabled"
+                type="button"
               >
                 <span
-                  class="v-tooltip v-tooltip--bottom"
+                  class="v-btn__content"
                 >
-                  <!---->
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-icon--disabled mdi mdi-drag-vertical theme--light"
+              />
+            </span>
+          </div>
+          <div
+            class="v-list-item theme--light draggable"
+            draggable="true"
+            role="listitem"
+            tabindex="-1"
+          >
+            <div
+              class="v-list-item__action"
+            />
+             
+            <div
+              class="v-list-item__content"
+            >
+              <div
+                class="row no-gutters"
+              >
+                <div
+                  class="uuid col"
+                >
                   <span
-                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
+                    class="v-tooltip v-tooltip--bottom"
                   >
+                    <!---->
                     <span
-                      class="v-chip__content"
+                      class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                      tile=""
                     >
-                      
+                      <span
+                        class="v-chip__content"
+                      >
+                        
           164e41c60c28698ac30b0d17176d3e720e036918
         
+                      </span>
                     </span>
                   </span>
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  Voldemort
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  -
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  voldemort
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  GitHub
-                </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    Voldemort
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    -
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    voldemort
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    GitHub
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <button
-              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-              type="button"
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
             >
-              <span
-                class="v-btn__content"
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
               >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-call-split theme--light"
-                />
-              </span>
-            </button>
-          </span>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-drag-vertical theme--light"
-            />
-          </span>
-        </div>
-      </div>
-      <div
-        class="v-list indented v-sheet theme--light v-list--dense row-border"
-        role="list"
-      >
-        <div
-          class="v-list-item theme--light draggable"
-          draggable="true"
-          role="listitem"
-          tabindex="-1"
-        >
-          <div
-            class="v-list-item__icon"
-          >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
             <span
               class="v-tooltip v-tooltip--bottom"
             >
               <!---->
               <i
                 aria-hidden="true"
-                class="v-icon notranslate mdi mdi-git theme--light"
+                class="v-icon notranslate mdi mdi-drag-vertical theme--light"
               />
             </span>
           </div>
-           
+        </div>
+        <div
+          class="v-list indented v-sheet theme--light v-list--dense row-border"
+          role="list"
+        >
           <div
-            class="v-list-item__content"
+            class="v-list-item theme--light draggable"
+            draggable="true"
+            role="listitem"
+            tabindex="-1"
           >
             <div
-              class="row no-gutters"
+              class="v-list-item__icon"
+            >
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-git theme--light"
+                />
+              </span>
+            </div>
+             
+            <div
+              class="v-list-item__content"
             >
               <div
-                class="uuid col"
+                class="row no-gutters"
               >
-                <span
-                  class="v-tooltip v-tooltip--bottom"
+                <div
+                  class="uuid col"
                 >
-                  <!---->
                   <span
-                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
+                    class="v-tooltip v-tooltip--bottom"
                   >
+                    <!---->
                     <span
-                      class="v-chip__content"
+                      class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                      tile=""
                     >
-                      
+                      <span
+                        class="v-chip__content"
+                      >
+                        
           10982379421b80e13266db011d6e5131dd519016
         
+                      </span>
                     </span>
                   </span>
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  voldemort
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  voldemort@example.net
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  -
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  git
-                </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    voldemort
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    voldemort@example.net
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    -
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    git
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <button
-              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-              type="button"
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
             >
-              <span
-                class="v-btn__content"
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
               >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-call-split theme--light"
-                />
-              </span>
-            </button>
-          </span>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-drag-vertical theme--light"
-            />
-          </span>
-        </div>
-      </div>
-      <div
-        class="v-list indented v-sheet theme--light v-list--dense"
-        role="list"
-      >
-        <div
-          class="v-list-item theme--light draggable"
-          draggable="true"
-          role="listitem"
-          tabindex="-1"
-        >
-          <div
-            class="v-list-item__icon"
-          >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
             <span
               class="v-tooltip v-tooltip--bottom"
             >
               <!---->
               <i
                 aria-hidden="true"
-                class="v-icon notranslate mdi mdi-account-multiple theme--light"
+                class="v-icon notranslate mdi mdi-drag-vertical theme--light"
               />
             </span>
           </div>
-           
+        </div>
+        <div
+          class="v-list indented v-sheet theme--light v-list--dense"
+          role="list"
+        >
           <div
-            class="v-list-item__content"
+            class="v-list-item theme--light draggable"
+            draggable="true"
+            role="listitem"
+            tabindex="-1"
           >
             <div
-              class="row no-gutters"
-            >
-              <div
-                class="uuid col"
-              >
-                <span
-                  class="v-tooltip v-tooltip--bottom"
-                >
-                  <!---->
-                  <span
-                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
-                  >
-                    <span
-                      class="v-chip__content"
-                    >
-                      
-          1f1a9e56dedb45f5969413eeb4442d982e33f0f6
-        
-                    </span>
-                  </span>
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  -
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  -
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  voldemort
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  irc
-                </span>
-              </div>
-            </div>
-          </div>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <button
-              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-              type="button"
+              class="v-list-item__icon"
             >
               <span
-                class="v-btn__content"
+                class="v-tooltip v-tooltip--bottom"
               >
+                <!---->
                 <i
                   aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-call-split theme--light"
+                  class="v-icon notranslate mdi mdi-account-multiple theme--light"
                 />
               </span>
-            </button>
-          </span>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
+            </div>
+             
+            <div
+              class="v-list-item__content"
+            >
+              <div
+                class="row no-gutters"
+              >
+                <div
+                  class="uuid col"
+                >
+                  <span
+                    class="v-tooltip v-tooltip--bottom"
+                  >
+                    <!---->
+                    <span
+                      class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                      tile=""
+                    >
+                      <span
+                        class="v-chip__content"
+                      >
+                        
+          1f1a9e56dedb45f5969413eeb4442d982e33f0f6
+        
+                      </span>
+                    </span>
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    -
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    -
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    voldemort
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    irc
+                  </span>
+                </div>
+              </div>
+            </div>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-drag-vertical theme--light"
+              />
+            </span>
+          </div>
+        </div>
+         
+        <div
+          class="dragged-identity v-card v-sheet theme--dark primary"
+        >
+          <div
+            class="v-card__subtitle"
           >
-            <!---->
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate mdi mdi-drag-vertical theme--light"
-            />
-          </span>
+             Moving 1 identity
+          </div>
         </div>
       </div>
        
@@ -1924,7 +1918,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
         </div>
          
         <div
-          class="indented mt-2 mb-4"
+          class="ma-4"
         >
           <div
             class="mb-2 d-flex justify-space-between align-center"
@@ -1936,7 +1930,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                 <!---->
                 <i
                   aria-hidden="true"
-                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+                  class="v-icon notranslate mr-8 v-icon--left mdi mdi-sitemap theme--light"
                 />
               </span>
               
@@ -2044,7 +2038,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           />
         </div>
         <div
-          class="indented mt-2 mb-4"
+          class="ma-4"
         >
           <div
             class="mb-2 d-flex justify-space-between align-center"
@@ -2056,7 +2050,7 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
                 <!---->
                 <i
                   aria-hidden="true"
-                  class="v-icon notranslate mr-5 v-icon--left mdi mdi-sitemap theme--light"
+                  class="v-icon notranslate mr-8 v-icon--left mdi mdi-sitemap theme--light"
                 />
               </span>
               
@@ -2164,16 +2158,6 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           />
         </div>
       </div>
-       
-      <div
-        class="dragged-identity v-card v-sheet theme--dark primary"
-      >
-        <div
-          class="v-card__subtitle"
-        >
-           Moving 1 identity
-        </div>
-      </div>
     </td>
   </div>
 </div>
@@ -2269,148 +2253,160 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
         </div>
       </div>
        
-      <div
-        class="v-subheader d-flex justify-space-between theme--light"
-      >
-        <span>
-          Identities (1)
-        </span>
-         
-        <button
-          class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
-          disabled="disabled"
-          type="button"
+      <div>
+        <div
+          class="v-subheader d-flex justify-space-between theme--light"
         >
-          <span
-            class="v-btn__content"
+          <span>
+            Identities (1)
+          </span>
+           
+          <button
+            class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            disabled="disabled"
+            type="button"
           >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
-              style="font-size: 16px;"
-            />
-            
+            <span
+              class="v-btn__content"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
+                style="font-size: 16px;"
+              />
+              
       Split all
     
-          </span>
-        </button>
-      </div>
-       
-      <div
-        class="v-list indented v-sheet theme--light v-list--dense"
-        role="list"
-      >
+            </span>
+          </button>
+        </div>
+         
         <div
-          class="v-list-item theme--light"
-          draggable="false"
-          role="listitem"
-          tabindex="-1"
+          class="v-list indented v-sheet theme--light v-list--dense"
+          role="list"
         >
           <div
-            class="v-list-item__icon"
+            class="v-list-item theme--light"
+            draggable="false"
+            role="listitem"
+            tabindex="-1"
           >
+            <div
+              class="v-list-item__icon"
+            >
+              <span
+                class="v-tooltip v-tooltip--bottom"
+              >
+                <!---->
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-github theme--light"
+                />
+              </span>
+            </div>
+             
+            <div
+              class="v-list-item__content"
+            >
+              <div
+                class="row no-gutters"
+              >
+                <div
+                  class="uuid col"
+                >
+                  <span
+                    class="v-tooltip v-tooltip--bottom"
+                  >
+                    <!---->
+                    <span
+                      class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                      tile=""
+                    >
+                      <span
+                        class="v-chip__content"
+                      >
+                        
+          164e41c60c28698ac30b0d17176d3e720e036918
+        
+                      </span>
+                    </span>
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    Hagrid
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    hagrid@example.com
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    hagrid
+                  </span>
+                </div>
+                 
+                <div
+                  class="ma-2 text-center col"
+                >
+                  <span>
+                    Git
+                  </span>
+                </div>
+              </div>
+            </div>
+             
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <button
+                class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+                disabled="disabled"
+                type="button"
+              >
+                <span
+                  class="v-btn__content"
+                >
+                  <i
+                    aria-hidden="true"
+                    class="v-icon notranslate mdi mdi-call-split theme--light"
+                  />
+                </span>
+              </button>
+            </span>
+             
             <span
               class="v-tooltip v-tooltip--bottom"
             >
               <!---->
               <i
                 aria-hidden="true"
-                class="v-icon notranslate mdi mdi-github theme--light"
+                class="v-icon notranslate v-icon--disabled mdi mdi-drag-vertical theme--light"
               />
             </span>
           </div>
-           
+        </div>
+         
+        <div
+          class="dragged-identity v-card v-sheet theme--dark primary"
+        >
           <div
-            class="v-list-item__content"
+            class="v-card__subtitle"
           >
-            <div
-              class="row no-gutters"
-            >
-              <div
-                class="uuid col"
-              >
-                <span
-                  class="v-tooltip v-tooltip--bottom"
-                >
-                  <!---->
-                  <span
-                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
-                    tile=""
-                  >
-                    <span
-                      class="v-chip__content"
-                    >
-                      
-          164e41c60c28698ac30b0d17176d3e720e036918
-        
-                    </span>
-                  </span>
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  Hagrid
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  hagrid@example.com
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  hagrid
-                </span>
-              </div>
-               
-              <div
-                class="ma-2 text-center col"
-              >
-                <span>
-                  Git
-                </span>
-              </div>
-            </div>
+             Moving 1 identity
           </div>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <button
-              class="v-btn v-btn--disabled v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
-              disabled="disabled"
-              type="button"
-            >
-              <span
-                class="v-btn__content"
-              >
-                <i
-                  aria-hidden="true"
-                  class="v-icon notranslate mdi mdi-call-split theme--light"
-                />
-              </span>
-            </button>
-          </span>
-           
-          <span
-            class="v-tooltip v-tooltip--bottom"
-          >
-            <!---->
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate v-icon--disabled mdi mdi-drag-vertical theme--light"
-            />
-          </span>
         </div>
       </div>
        
@@ -2441,16 +2437,6 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           </button>
         </div>
          
-      </div>
-       
-      <div
-        class="dragged-identity v-card v-sheet theme--dark primary"
-      >
-        <div
-          class="v-card__subtitle"
-        >
-           Moving 1 identity
-        </div>
       </div>
     </td>
   </div>
@@ -2653,6 +2639,669 @@ exports[`Storyshots ExpandedOrganization Group 1`] = `
        
       <!---->
     </td>
+  </div>
+</div>
+`;
+
+exports[`Storyshots IdentitiesList Compact 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div>
+      <div
+        class="v-subheader d-flex justify-space-between theme--light"
+      >
+        <span>
+          Identities (4)
+        </span>
+         
+        <!---->
+      </div>
+       
+      <div
+        class="v-data-table v-data-table--dense theme--light"
+      >
+        <div
+          class="v-data-table__wrapper"
+        >
+          <table>
+            <thead>
+              <tr>
+                <th
+                  class="text-left"
+                >
+                  Name
+                </th>
+                 
+                <th
+                  class="text-left"
+                >
+                  Email
+                </th>
+                 
+                <th
+                  class="text-left"
+                >
+                  Username
+                </th>
+                 
+                <th
+                  class="text-left"
+                >
+                  Source
+                </th>
+              </tr>
+            </thead>
+             
+            <tbody>
+              <tr>
+                <td>
+                  Tom Marvolo Riddle
+                </td>
+                 
+                <td>
+                  triddle@example.net
+                </td>
+                 
+                <td>
+                  triddle
+                </td>
+                 
+                <td>
+                  <span
+                    class="v-tooltip v-tooltip--bottom"
+                  >
+                    <!---->
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-icon--left mdi mdi-github theme--light"
+                      style="font-size: 16px;"
+                    />
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  Voldemort
+                </td>
+                 
+                <td>
+                  -
+                </td>
+                 
+                <td>
+                  voldemort
+                </td>
+                 
+                <td>
+                  <span
+                    class="v-tooltip v-tooltip--bottom"
+                  >
+                    <!---->
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-icon--left mdi mdi-github theme--light"
+                      style="font-size: 16px;"
+                    />
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  voldemort
+                </td>
+                 
+                <td>
+                  voldemort@example.net
+                </td>
+                 
+                <td>
+                  -
+                </td>
+                 
+                <td>
+                  <span
+                    class="v-tooltip v-tooltip--bottom"
+                  >
+                    <!---->
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-icon--left mdi mdi-git theme--light"
+                      style="font-size: 16px;"
+                    />
+                  </span>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  -
+                </td>
+                 
+                <td>
+                  -
+                </td>
+                 
+                <td>
+                  voldemort
+                </td>
+                 
+                <td>
+                  <span
+                    class="v-tooltip v-tooltip--bottom"
+                  >
+                    <!---->
+                    <i
+                      aria-hidden="true"
+                      class="v-icon notranslate v-icon--left mdi mdi-account-multiple theme--light"
+                      style="font-size: 16px;"
+                    />
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+       
+      <div
+        class="dragged-identity v-card v-sheet theme--dark primary"
+      >
+        <div
+          class="v-card__subtitle"
+        >
+           Moving 1 identity
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots IdentitiesList Default 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div>
+      <div
+        class="v-subheader d-flex justify-space-between theme--light"
+      >
+        <span>
+          Identities (4)
+        </span>
+         
+        <button
+          class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            <i
+              aria-hidden="true"
+              class="v-icon notranslate v-icon--left mdi mdi-call-split theme--light"
+              style="font-size: 16px;"
+            />
+            
+      Split all
+    
+          </span>
+        </button>
+      </div>
+       
+      <div
+        class="v-list indented v-sheet theme--light v-list--dense row-border"
+        role="list"
+      >
+        <div
+          class="v-list-item theme--light"
+          draggable="false"
+          role="listitem"
+          tabindex="-1"
+        >
+          <div
+            class="v-list-item__icon"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-github theme--light"
+              />
+            </span>
+          </div>
+           
+          <div
+            class="v-list-item__content"
+          >
+            <div
+              class="row no-gutters"
+            >
+              <div
+                class="uuid col"
+              >
+                <span
+                  class="v-tooltip v-tooltip--bottom"
+                >
+                  <!---->
+                  <span
+                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                    tile=""
+                  >
+                    <span
+                      class="v-chip__content"
+                    >
+                      
+          06e6903c91180835b6ee91dd56782c6ca72bc562
+        
+                    </span>
+                  </span>
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  Tom Marvolo Riddle
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  triddle@example.net
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  triddle
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  GitHub
+                </span>
+              </div>
+            </div>
+          </div>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+            <button
+              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-call-split theme--light"
+                />
+              </span>
+            </button>
+          </span>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+          </span>
+        </div>
+        <div
+          class="v-list-item theme--light"
+          draggable="false"
+          role="listitem"
+          tabindex="-1"
+        >
+          <div
+            class="v-list-item__action"
+          />
+           
+          <div
+            class="v-list-item__content"
+          >
+            <div
+              class="row no-gutters"
+            >
+              <div
+                class="uuid col"
+              >
+                <span
+                  class="v-tooltip v-tooltip--bottom"
+                >
+                  <!---->
+                  <span
+                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                    tile=""
+                  >
+                    <span
+                      class="v-chip__content"
+                    >
+                      
+          164e41c60c28698ac30b0d17176d3e720e036918
+        
+                    </span>
+                  </span>
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  Voldemort
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  -
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  voldemort
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  GitHub
+                </span>
+              </div>
+            </div>
+          </div>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+            <button
+              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-call-split theme--light"
+                />
+              </span>
+            </button>
+          </span>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+          </span>
+        </div>
+      </div>
+      <div
+        class="v-list indented v-sheet theme--light v-list--dense row-border"
+        role="list"
+      >
+        <div
+          class="v-list-item theme--light"
+          draggable="false"
+          role="listitem"
+          tabindex="-1"
+        >
+          <div
+            class="v-list-item__icon"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-git theme--light"
+              />
+            </span>
+          </div>
+           
+          <div
+            class="v-list-item__content"
+          >
+            <div
+              class="row no-gutters"
+            >
+              <div
+                class="uuid col"
+              >
+                <span
+                  class="v-tooltip v-tooltip--bottom"
+                >
+                  <!---->
+                  <span
+                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                    tile=""
+                  >
+                    <span
+                      class="v-chip__content"
+                    >
+                      
+          10982379421b80e13266db011d6e5131dd519016
+        
+                    </span>
+                  </span>
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  voldemort
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  voldemort@example.net
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  -
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  git
+                </span>
+              </div>
+            </div>
+          </div>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+            <button
+              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-call-split theme--light"
+                />
+              </span>
+            </button>
+          </span>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+          </span>
+        </div>
+      </div>
+      <div
+        class="v-list indented v-sheet theme--light v-list--dense"
+        role="list"
+      >
+        <div
+          class="v-list-item theme--light"
+          draggable="false"
+          role="listitem"
+          tabindex="-1"
+        >
+          <div
+            class="v-list-item__icon"
+          >
+            <span
+              class="v-tooltip v-tooltip--bottom"
+            >
+              <!---->
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate mdi mdi-account-multiple theme--light"
+              />
+            </span>
+          </div>
+           
+          <div
+            class="v-list-item__content"
+          >
+            <div
+              class="row no-gutters"
+            >
+              <div
+                class="uuid col"
+              >
+                <span
+                  class="v-tooltip v-tooltip--bottom"
+                >
+                  <!---->
+                  <span
+                    class="text-center clip v-chip v-chip--no-color v-chip--outlined theme--light v-size--default"
+                    tile=""
+                  >
+                    <span
+                      class="v-chip__content"
+                    >
+                      
+          1f1a9e56dedb45f5969413eeb4442d982e33f0f6
+        
+                    </span>
+                  </span>
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  -
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  -
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  voldemort
+                </span>
+              </div>
+               
+              <div
+                class="ma-2 text-center col"
+              >
+                <span>
+                  irc
+                </span>
+              </div>
+            </div>
+          </div>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+            <button
+              class="v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--default"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate mdi mdi-call-split theme--light"
+                />
+              </span>
+            </button>
+          </span>
+           
+          <span
+            class="v-tooltip v-tooltip--bottom"
+          >
+            <!---->
+          </span>
+        </div>
+      </div>
+       
+      <div
+        class="dragged-identity v-card v-sheet theme--dark primary"
+      >
+        <div
+          class="v-card__subtitle"
+        >
+           Moving 1 identity
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -3790,6 +4439,27 @@ exports[`Storyshots IndividualEntry Bot 1`] = `
                           type="button"
                         />
                       </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
+                      </span>
                     </div>
                      
                     <div
@@ -3993,6 +4663,27 @@ exports[`Storyshots IndividualEntry Bot And Locked 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
+                      </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
                       </span>
                     </div>
                      
@@ -4199,6 +4890,27 @@ exports[`Storyshots IndividualEntry Default 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
+                      </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
                       </span>
                     </div>
                      
@@ -4422,6 +5134,27 @@ exports[`Storyshots IndividualEntry Gravatar 1`] = `
                           type="button"
                         />
                       </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
+                      </span>
                     </div>
                      
                     <div
@@ -4644,6 +5377,27 @@ exports[`Storyshots IndividualEntry Highlighted 1`] = `
                           type="button"
                         />
                       </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
+                      </span>
                     </div>
                      
                     <div
@@ -4848,6 +5602,27 @@ exports[`Storyshots IndividualEntry Locked 1`] = `
                           type="button"
                         />
                       </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
+                      </span>
                     </div>
                      
                     <div
@@ -5049,6 +5824,27 @@ exports[`Storyshots IndividualEntry No Email 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
+                      </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
                       </span>
                     </div>
                      
@@ -5272,6 +6068,27 @@ exports[`Storyshots IndividualEntry No Name 1`] = `
                           type="button"
                         />
                       </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
+                      </span>
                     </div>
                      
                     <div
@@ -5494,6 +6311,27 @@ exports[`Storyshots IndividualEntry No Organization 1`] = `
                           type="button"
                         />
                       </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
+                      </span>
                     </div>
                      
                     <div
@@ -5715,6 +6553,27 @@ exports[`Storyshots IndividualEntry Single Inital 1`] = `
                           style="font-size: 16px;"
                           type="button"
                         />
+                      </span>
+                       
+                      <span
+                        class="v-tooltip v-tooltip--bottom"
+                      >
+                        <!---->
+                        <a
+                          class="icon--hidden ml-1 v-btn v-btn--flat v-btn--icon v-btn--round theme--light v-size--small"
+                          href="individual/03b3428ee"
+                          target="_blank"
+                        >
+                          <span
+                            class="v-btn__content"
+                          >
+                            <i
+                              aria-hidden="true"
+                              class="v-icon notranslate mdi mdi-open-in-new theme--light"
+                              style="font-size: 16px;"
+                            />
+                          </span>
+                        </a>
                       </span>
                     </div>
                      
@@ -6818,7 +7677,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 />
                 <input
                   aria-checked="false"
-                  id="input-894"
+                  id="input-989"
                   role="checkbox"
                   type="checkbox"
                   value=""
@@ -6829,7 +7688,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               </div>
               <label
                 class="v-label theme--light"
-                for="input-894"
+                for="input-989"
                 style="left: 0px; position: relative;"
               >
                 Select all
@@ -6915,13 +7774,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-899"
+                    for="input-994"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-899"
+                    id="input-994"
                     type="text"
                   />
                 </div>
@@ -6993,7 +7852,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-owns="list-907"
+                aria-owns="list-1002"
                 class="v-input__slot"
                 role="button"
               >
@@ -7011,7 +7870,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-907"
+                    for="input-1002"
                     style="left: 0px; position: absolute;"
                   >
                     Order by
@@ -7022,7 +7881,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                     <input
                       aria-readonly="false"
                       autocomplete="off"
-                      id="input-907"
+                      id="input-1002"
                       readonly="readonly"
                       type="text"
                     />
@@ -7209,13 +8068,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label v-label--active theme--light"
-                    for="input-927"
+                    for="input-1022"
                     style="left: 0px; position: absolute;"
                   >
                     Items per page
                   </label>
                   <input
-                    id="input-927"
+                    id="input-1022"
                     max="0"
                     min="1"
                     type="number"
@@ -7754,13 +8613,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1201"
+                    for="input-1311"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1201"
+                    id="input-1311"
                     type="text"
                   />
                 </div>
@@ -7891,13 +8750,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1212"
+                  for="input-1322"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1212"
+                  id="input-1322"
                   max="0"
                   min="1"
                   type="number"
@@ -8035,13 +8894,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1144"
+                    for="input-1254"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1144"
+                    id="input-1254"
                     type="text"
                   />
                 </div>
@@ -8172,13 +9031,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1155"
+                  for="input-1265"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1155"
+                  id="input-1265"
                   max="0"
                   min="1"
                   type="number"
@@ -8500,13 +9359,13 @@ exports[`Storyshots Search Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1280"
+                  for="input-1390"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1280"
+                  id="input-1390"
                   type="text"
                 />
               </div>
@@ -8634,13 +9493,13 @@ exports[`Storyshots Search Filter Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1290"
+                  for="input-1400"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1290"
+                  id="input-1400"
                   type="text"
                 />
               </div>
@@ -8738,13 +9597,13 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1303"
+                  for="input-1413"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1303"
+                  id="input-1413"
                   type="text"
                 />
               </div>
@@ -8816,7 +9675,7 @@ exports[`Storyshots Search Order Selector 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="list-1308"
+              aria-owns="list-1418"
               class="v-input__slot"
               role="button"
             >
@@ -8834,7 +9693,7 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1308"
+                  for="input-1418"
                   style="left: 0px; position: absolute;"
                 >
                   Order by
@@ -8845,7 +9704,7 @@ exports[`Storyshots Search Order Selector 1`] = `
                   <input
                     aria-readonly="false"
                     autocomplete="off"
-                    id="input-1308"
+                    id="input-1418"
                     readonly="readonly"
                     type="text"
                   />
@@ -9517,7 +10376,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1416"
+                    id="input-1526"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -9528,7 +10387,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1416"
+                  for="input-1526"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -9614,13 +10473,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1421"
+                      for="input-1531"
                       style="left: 0px; position: absolute;"
                     >
                       Search
                     </label>
                     <input
-                      id="input-1421"
+                      id="input-1531"
                       type="text"
                     />
                   </div>
@@ -9692,7 +10551,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-owns="list-1429"
+                  aria-owns="list-1539"
                   class="v-input__slot"
                   role="button"
                 >
@@ -9710,7 +10569,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1429"
+                      for="input-1539"
                       style="left: 0px; position: absolute;"
                     >
                       Order by
@@ -9721,7 +10580,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       <input
                         aria-readonly="false"
                         autocomplete="off"
-                        id="input-1429"
+                        id="input-1539"
                         readonly="readonly"
                         type="text"
                       />
@@ -9908,13 +10767,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label v-label--active theme--light"
-                      for="input-1449"
+                      for="input-1559"
                       style="left: 0px; position: absolute;"
                     >
                       Items per page
                     </label>
                     <input
-                      id="input-1449"
+                      id="input-1559"
                       max="0"
                       min="1"
                       type="number"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -95,7 +95,7 @@ exports[`Storyshots DateInput Default 1`] = `
         class="v-menu"
       >
         <div
-          class="v-input v-input--hide-details theme--light v-text-field"
+          class="v-input theme--light v-text-field"
         >
           <div
             class="v-input__control"
@@ -134,6 +134,17 @@ exports[`Storyshots DateInput Default 1`] = `
                 </div>
               </div>
             </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                />
+              </div>
+            </div>
           </div>
         </div>
         <!---->
@@ -159,7 +170,7 @@ exports[`Storyshots DateInput Error 1`] = `
         class="v-menu"
       >
         <div
-          class="v-input v-input--hide-details v-input--is-label-active v-input--is-dirty v-input--dense theme--light v-text-field v-text-field--enclosed v-text-field--outlined"
+          class="v-input v-input--is-label-active v-input--is-dirty v-input--dense theme--light v-text-field v-text-field--enclosed v-text-field--outlined"
         >
           <div
             class="v-input__control"
@@ -184,13 +195,13 @@ exports[`Storyshots DateInput Error 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-49"
+                  for="input-55"
                   style="left: 0px; position: absolute;"
                 >
                   Label
                 </label>
                 <input
-                  id="input-49"
+                  id="input-55"
                   type="text"
                 />
               </div>
@@ -206,6 +217,17 @@ exports[`Storyshots DateInput Error 1`] = `
                     type="button"
                   />
                 </div>
+              </div>
+            </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                />
               </div>
             </div>
           </div>
@@ -233,7 +255,7 @@ exports[`Storyshots DateInput Filled 1`] = `
         class="v-menu"
       >
         <div
-          class="v-input v-input--hide-details theme--light v-text-field v-text-field--filled v-text-field--enclosed"
+          class="v-input theme--light v-text-field v-text-field--filled v-text-field--enclosed"
         >
           <div
             class="v-input__control"
@@ -247,13 +269,13 @@ exports[`Storyshots DateInput Filled 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-33"
+                  for="input-35"
                   style="left: 0px; position: absolute;"
                 >
                   Label
                 </label>
                 <input
-                  id="input-33"
+                  id="input-35"
                   type="text"
                 />
               </div>
@@ -270,6 +292,17 @@ exports[`Storyshots DateInput Filled 1`] = `
                     type="button"
                   />
                 </div>
+              </div>
+            </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                />
               </div>
             </div>
           </div>
@@ -297,7 +330,7 @@ exports[`Storyshots DateInput Outlined 1`] = `
         class="v-menu"
       >
         <div
-          class="v-input v-input--hide-details v-input--dense theme--light v-text-field v-text-field--enclosed v-text-field--outlined"
+          class="v-input v-input--dense theme--light v-text-field v-text-field--enclosed v-text-field--outlined"
         >
           <div
             class="v-input__control"
@@ -322,13 +355,13 @@ exports[`Storyshots DateInput Outlined 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-41"
+                  for="input-45"
                   style="left: 0px; position: absolute;"
                 >
                   Label
                 </label>
                 <input
-                  id="input-41"
+                  id="input-45"
                   type="text"
                 />
               </div>
@@ -347,8 +380,93 @@ exports[`Storyshots DateInput Outlined 1`] = `
                 </div>
               </div>
             </div>
+            <div
+              class="v-text-field__details"
+            >
+              <div
+                class="v-messages theme--light"
+              >
+                <div
+                  class="v-messages__wrapper"
+                />
+              </div>
+            </div>
           </div>
         </div>
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots EnrollModal Default 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="ma-auto"
+      data-app="true"
+    >
+      <button
+        class="v-btn v-btn--contained theme--dark v-size--default primary"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          
+      Open Dialog
+    
+        </span>
+      </button>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots EnrollModal With Organization 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="ma-auto"
+      data-app="true"
+    >
+      <button
+        class="v-btn v-btn--contained theme--dark v-size--default primary"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          
+      Open Dialog
+    
+        </span>
+      </button>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
         <!---->
       </div>
     </div>
@@ -495,23 +613,43 @@ exports[`Storyshots EnrollmentList Default 1`] = `
         
     Organizations (3)
     
-        <button
-          class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
-          type="button"
-        >
-          <span
-            class="v-btn__content"
+        <div>
+          <button
+            class="mr-4 v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            type="button"
           >
-            <i
-              aria-hidden="true"
-              class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
-              style="font-size: 16px;"
-            />
-            
-      Remove all
-    
-          </span>
-        </button>
+            <span
+              class="v-btn__content"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-icon--left mdi mdi-plus theme--light"
+                style="font-size: 16px;"
+              />
+              
+        Add
+      
+            </span>
+          </button>
+           
+          <button
+            class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            type="button"
+          >
+            <span
+              class="v-btn__content"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+                style="font-size: 16px;"
+              />
+              
+        Remove all
+      
+            </span>
+          </button>
+        </div>
       </div>
        
       <div
@@ -1898,23 +2036,43 @@ exports[`Storyshots ExpandedIndividual Default 1`] = `
           
     Organizations (2)
     
-          <button
-            class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
-            type="button"
-          >
-            <span
-              class="v-btn__content"
+          <div>
+            <button
+              class="mr-4 v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+              type="button"
             >
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
-                style="font-size: 16px;"
-              />
-              
-      Remove all
-    
-            </span>
-          </button>
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--left mdi mdi-plus theme--light"
+                  style="font-size: 16px;"
+                />
+                
+        Add
+      
+              </span>
+            </button>
+             
+            <button
+              class="v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+                  style="font-size: 16px;"
+                />
+                
+        Remove all
+      
+              </span>
+            </button>
+          </div>
         </div>
          
         <div
@@ -2417,24 +2575,44 @@ exports[`Storyshots ExpandedIndividual No Organizations 1`] = `
           
     Organizations (0)
     
-          <button
-            class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
-            disabled="disabled"
-            type="button"
-          >
-            <span
-              class="v-btn__content"
+          <div>
+            <button
+              class="mr-4 v-btn v-btn--depressed v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+              type="button"
             >
-              <i
-                aria-hidden="true"
-                class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
-                style="font-size: 16px;"
-              />
-              
-      Remove all
-    
-            </span>
-          </button>
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--left mdi mdi-plus theme--light"
+                  style="font-size: 16px;"
+                />
+                
+        Add
+      
+              </span>
+            </button>
+             
+            <button
+              class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+              disabled="disabled"
+              type="button"
+            >
+              <span
+                class="v-btn__content"
+              >
+                <i
+                  aria-hidden="true"
+                  class="v-icon notranslate v-icon--left mdi mdi-delete theme--light"
+                  style="font-size: 16px;"
+                />
+                
+        Remove all
+      
+              </span>
+            </button>
+          </div>
         </div>
          
       </div>
@@ -7677,7 +7855,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 />
                 <input
                   aria-checked="false"
-                  id="input-989"
+                  id="input-1015"
                   role="checkbox"
                   type="checkbox"
                   value=""
@@ -7688,7 +7866,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               </div>
               <label
                 class="v-label theme--light"
-                for="input-989"
+                for="input-1015"
                 style="left: 0px; position: relative;"
               >
                 Select all
@@ -7774,13 +7952,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-994"
+                    for="input-1020"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-994"
+                    id="input-1020"
                     type="text"
                   />
                 </div>
@@ -7852,7 +8030,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
               <div
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-owns="list-1002"
+                aria-owns="list-1028"
                 class="v-input__slot"
                 role="button"
               >
@@ -7870,7 +8048,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1002"
+                    for="input-1028"
                     style="left: 0px; position: absolute;"
                   >
                     Order by
@@ -7881,7 +8059,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                     <input
                       aria-readonly="false"
                       autocomplete="off"
-                      id="input-1002"
+                      id="input-1028"
                       readonly="readonly"
                       type="text"
                     />
@@ -8068,13 +8246,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
                 >
                   <label
                     class="v-label v-label--active theme--light"
-                    for="input-1022"
+                    for="input-1048"
                     style="left: 0px; position: absolute;"
                   >
                     Items per page
                   </label>
                   <input
-                    id="input-1022"
+                    id="input-1048"
                     max="0"
                     min="1"
                     type="number"
@@ -8095,6 +8273,13 @@ exports[`Storyshots IndividualsTable Default 1`] = `
             </div>
           </div>
         </div>
+      </div>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
       </div>
        
       <div
@@ -8613,13 +8798,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1311"
+                    for="input-1339"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1311"
+                    id="input-1339"
                     type="text"
                   />
                 </div>
@@ -8750,13 +8935,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1322"
+                  for="input-1350"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1322"
+                  id="input-1350"
                   max="0"
                   min="1"
                   type="number"
@@ -8894,13 +9079,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1254"
+                    for="input-1282"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1254"
+                    id="input-1282"
                     type="text"
                   />
                 </div>
@@ -9031,13 +9216,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1265"
+                  for="input-1293"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1265"
+                  id="input-1293"
                   max="0"
                   min="1"
                   type="number"
@@ -9359,13 +9544,13 @@ exports[`Storyshots Search Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1390"
+                  for="input-1418"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1390"
+                  id="input-1418"
                   type="text"
                 />
               </div>
@@ -9493,13 +9678,13 @@ exports[`Storyshots Search Filter Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1400"
+                  for="input-1428"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1400"
+                  id="input-1428"
                   type="text"
                 />
               </div>
@@ -9597,13 +9782,13 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1413"
+                  for="input-1441"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1413"
+                  id="input-1441"
                   type="text"
                 />
               </div>
@@ -9675,7 +9860,7 @@ exports[`Storyshots Search Order Selector 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="list-1418"
+              aria-owns="list-1446"
               class="v-input__slot"
               role="button"
             >
@@ -9693,7 +9878,7 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1418"
+                  for="input-1446"
                   style="left: 0px; position: absolute;"
                 >
                   Order by
@@ -9704,7 +9889,7 @@ exports[`Storyshots Search Order Selector 1`] = `
                   <input
                     aria-readonly="false"
                     autocomplete="off"
-                    id="input-1418"
+                    id="input-1446"
                     readonly="readonly"
                     type="text"
                   />
@@ -10194,6 +10379,13 @@ exports[`Storyshots WorkSpace Default 1`] = `
       >
         <!---->
       </div>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
     </div>
   </div>
 </div>
@@ -10311,6 +10503,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
         >
           <!---->
         </div>
+         
+        <div
+          class="v-dialog__container"
+          role="dialog"
+        >
+          <!---->
+        </div>
       </div>
        
       <section
@@ -10376,7 +10575,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1526"
+                    id="input-1560"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -10387,7 +10586,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1526"
+                  for="input-1560"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -10473,13 +10672,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1531"
+                      for="input-1565"
                       style="left: 0px; position: absolute;"
                     >
                       Search
                     </label>
                     <input
-                      id="input-1531"
+                      id="input-1565"
                       type="text"
                     />
                   </div>
@@ -10551,7 +10750,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-owns="list-1539"
+                  aria-owns="list-1573"
                   class="v-input__slot"
                   role="button"
                 >
@@ -10569,7 +10768,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1539"
+                      for="input-1573"
                       style="left: 0px; position: absolute;"
                     >
                       Order by
@@ -10580,7 +10779,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       <input
                         aria-readonly="false"
                         autocomplete="off"
-                        id="input-1539"
+                        id="input-1573"
                         readonly="readonly"
                         type="text"
                       />
@@ -10767,13 +10966,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label v-label--active theme--light"
-                      for="input-1559"
+                      for="input-1593"
                       style="left: 0px; position: absolute;"
                     >
                       Items per page
                     </label>
                     <input
-                      id="input-1559"
+                      id="input-1593"
                       max="0"
                       min="1"
                       type="number"
@@ -10794,6 +10993,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
               </div>
             </div>
           </div>
+        </div>
+         
+        <div
+          class="v-dialog__container"
+          role="dialog"
+        >
+          <!---->
         </div>
          
         <div
@@ -10934,6 +11140,13 @@ exports[`Storyshots WorkSpace Empty 1`] = `
       
           </span>
         </p>
+      </div>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
       </div>
        
       <div


### PR DESCRIPTION
This PR adds a view at `/individual/uuid` to show an individual's profile, identities and enrollments. A link to this view can be found in each individual's entry on the table, both in the buttons next to the name and in the dropdown menu.

![imagen](https://user-images.githubusercontent.com/26812577/181569805-c042dbbd-db7c-4bdf-84dd-512714f6020e.png)

![imagen](https://user-images.githubusercontent.com/26812577/181568997-5f9d054a-645e-41eb-a8b8-acb26b485489.png)

The list of identities in the expanded individual and the modal to enroll in an organization in the table and workspace are moved to new components so that they can be also used in this view. It also adds a button on the enrollment list to add one without using drag and drop.

Closes #628.