### PR TITLE
[ui] Resize search bar

### DIFF
--- a/ui/src/components/IndividualsTable.vue
+++ b/ui/src/components/IndividualsTable.vue
@@ -35,7 +35,7 @@
       >
       </v-checkbox>
       <search
-        class="ml-auto pa-0 flex-grow-0"
+        class="search-box pa-0 flex-grow-1"
         @search="filterSearch"
         filter-selector
         order-selector
@@ -62,7 +62,7 @@
             small
             outlined
             height="34"
-            class="mr-4 ml-2"
+            class="mr-4 ml-4 order-2"
             v-on="on"
             :disabled="disabledMerge"
             @click="mergeSelected(selectedIndividuals)"
@@ -79,6 +79,7 @@
             text
             small
             outlined
+            class="order-3"
             height="34"
             v-on="on"
             :disabled="disabledActions"
@@ -718,6 +719,23 @@ export default {
   ::v-deep .v-input--checkbox {
     padding-top: 6px;
     margin-left: -1px;
+  }
+
+  .search-box {
+    margin-left: 32px;
+  }
+
+  // Breakpoint for Material Design medium laptop missing on Vuetify
+  @media only screen and (max-width: 1439px) {
+    .v-input--checkbox {
+      order: 1;
+      margin-right: auto;
+    }
+
+    .search-box {
+      margin: 0;
+      flex-basis: 100%;
+    }
   }
 }
 .dragged-item {

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -341,7 +341,6 @@ export default {
 .search,
 .select {
   width: 100%;
-  max-width: 420px;
   margin-top: 2px;
   font-size: 0.9rem;
 
@@ -392,7 +391,6 @@ export default {
 .select {
   max-width: 12rem;
   margin-left: 1rem;
-  margin-right: 0.5rem;
 
   .v-select__selection {
     margin-top: 0;

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -98,7 +98,7 @@ exports[`IndividualsTable Mock query for deleteIdentity 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
@@ -465,7 +465,7 @@ exports[`IndividualsTable Mock query for merge 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
@@ -832,7 +832,7 @@ exports[`IndividualsTable Mock query for moveIdentity 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
@@ -1199,7 +1199,7 @@ exports[`IndividualsTable Mock query for unmerge 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
@@ -1566,7 +1566,7 @@ exports[`IndividualsTable Mock query for updateEnrollment 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
@@ -1933,7 +1933,7 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -105,7 +105,7 @@ exports[`IndividualsTable Mock query for getCountries 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"
@@ -474,7 +474,7 @@ exports[`IndividualsTable Mock query for getPaginatedIndividuals 1`] = `
     />
      
     <search-stub
-      class="ml-auto pa-0 flex-grow-0"
+      class="search-box pa-0 flex-grow-1"
       filterselector="true"
       orderoptions="[object Object],[object Object],[object Object]"
       orderselector="true"

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -7431,7 +7431,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
         </div>
          
         <div
-          class="d-flex ml-auto pa-0 flex-grow-0"
+          class="d-flex search-box pa-0 flex-grow-1"
         >
           <div
             class="v-input search pa-0 flex-grow-0 v-input--dense theme--light v-text-field v-text-field--single-line v-text-field--enclosed v-text-field--outlined"
@@ -7654,7 +7654,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
         >
           <!---->
           <button
-            class="mr-4 ml-2 v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            class="mr-4 ml-4 order-2 v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
             disabled="disabled"
             style="height: 34px;"
             type="button"
@@ -7679,7 +7679,7 @@ exports[`Storyshots IndividualsTable Default 1`] = `
         >
           <!---->
           <button
-            class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+            class="order-3 v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
             disabled="disabled"
             style="height: 34px;"
             type="button"
@@ -10151,7 +10151,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           </div>
            
           <div
-            class="d-flex ml-auto pa-0 flex-grow-0"
+            class="d-flex search-box pa-0 flex-grow-1"
           >
             <div
               class="v-input search pa-0 flex-grow-0 v-input--dense theme--light v-text-field v-text-field--single-line v-text-field--enclosed v-text-field--outlined"
@@ -10374,7 +10374,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           >
             <!---->
             <button
-              class="mr-4 ml-2 v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+              class="mr-4 ml-4 order-2 v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
               disabled="disabled"
               style="height: 34px;"
               type="button"
@@ -10399,7 +10399,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
           >
             <!---->
             <button
-              class="v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
+              class="order-3 v-btn v-btn--depressed v-btn--disabled v-btn--flat v-btn--outlined v-btn--text theme--light v-size--small"
               disabled="disabled"
               style="height: 34px;"
               type="button"


### PR DESCRIPTION
This PR resizes the search bar on the individual's table to take up all available space. It also reorders the table's actions items on smaller device sizes so the search bar still has enough space.

1920x1080:
![imagen](https://user-images.githubusercontent.com/26812577/186715414-aa66279f-48fe-42c7-b374-1566ecad75d3.png)

1366x768:
![imagen](https://user-images.githubusercontent.com/26812577/186715544-c15905e9-9074-46e1-a2c6-cd30f23eac92.png)

Closes  #640.
