### PR TITLE
[ui] Interface to create jobs

### DIFF
--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -416,6 +416,38 @@ const UPDATE_ENROLLMENT = gql`
   }
 `;
 
+const AFFILIATE = gql`
+  mutation affiliate($uuids: [String]) {
+    affiliate(uuids: $uuids) {
+      jobId
+    }
+  }
+`;
+
+const GENDERIZE = gql`
+  mutation genderize(
+    $uuids: [String]
+    $exclude: Boolean
+    $noStrictMatching: Boolean
+  ) {
+    genderize(
+      uuids: $uuids
+      exclude: $exclude
+      noStrictMatching: $noStrictMatching
+    ) {
+      jobId
+    }
+  }
+`;
+
+const UNIFY = gql`
+  mutation unify($criteria: [String], $exclude: Boolean) {
+    unify(criteria: $criteria, exclude: $exclude) {
+      jobId
+    }
+  }
+`;
+
 const tokenAuth = (apollo, username, password) => {
   const response = apollo.mutate({
     mutation: TOKEN_AUTH,
@@ -617,6 +649,36 @@ const updateEnrollment = (apollo, data) => {
   return response;
 };
 
+const affiliate = (apollo, uuids) => {
+  return apollo.mutate({
+    mutation: AFFILIATE,
+    variables: {
+      uuids: uuids
+    }
+  });
+};
+
+const genderize = (apollo, exclude, noStrictMatching, uuids) => {
+  return apollo.mutate({
+    mutation: GENDERIZE,
+    variables: {
+      uuids: uuids,
+      exclude: exclude,
+      noStrictMatching: noStrictMatching
+    }
+  });
+};
+
+const unify = (apollo, criteria, exclude) => {
+  return apollo.mutate({
+    mutation: UNIFY,
+    variables: {
+      criteria: criteria,
+      exclude: exclude
+    }
+  });
+};
+
 export {
   tokenAuth,
   lockIndividual,
@@ -635,5 +697,8 @@ export {
   addIdentity,
   updateProfile,
   withdraw,
-  updateEnrollment
+  updateEnrollment,
+  affiliate,
+  genderize,
+  unify
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -339,7 +339,8 @@ const getJobs = (apollo, page, pageSize) => {
     variables: {
       page: page,
       pageSize: pageSize
-    }
+    },
+    fetchPolicy: "no-cache"
   });
   return response;
 };

--- a/ui/src/components/JobModal.stories.js
+++ b/ui/src/components/JobModal.stories.js
@@ -1,0 +1,22 @@
+import JobModal from "./JobModal.vue";
+
+export default {
+  title: "JobModal",
+  excludeStories: /.*Data$/
+};
+
+const JobModalTemplate = `
+  <div class="ma-auto">
+    <v-btn color="primary" dark @click.stop="open = true">
+      Open Dialog
+    </v-btn>
+    <job-modal :is-open.sync="open"/>
+  </div>`;
+
+export const Default = () => ({
+  components: { JobModal },
+  template: JobModalTemplate,
+  data: () => ({
+    open: false
+  })
+});

--- a/ui/src/components/JobModal.vue
+++ b/ui/src/components/JobModal.vue
@@ -1,0 +1,156 @@
+<template>
+  <v-dialog v-model="isOpen" max-width="550px" @click:outside="onClose">
+    <v-card class="section">
+      <v-card-title class="header title">New job</v-card-title>
+      <v-card-text class="mt-3">
+        <v-row>
+          <v-col>
+            <v-select
+              v-model="selected"
+              :items="types"
+              :menu-props="{ offsetY: true, maxWidth: 500 }"
+              label="Type"
+              item-text="title"
+              id="type"
+              dense
+              hide-details
+              outlined
+            >
+              <template v-slot:item="{ index, item }">
+                <v-list-item-content>
+                  <v-list-item-title>
+                    {{ item.title }}
+                  </v-list-item-title>
+                  <v-list-item-subtitle>
+                    {{ item.description }}
+                  </v-list-item-subtitle>
+                </v-list-item-content>
+              </template>
+            </v-select>
+          </v-col>
+        </v-row>
+        <v-row v-if="selected === 'genderize'">
+          <v-col>
+            <v-checkbox
+              v-model="forms.genderize.exclude"
+              label="Exclude individuals in RecommenderExclusionTerm list"
+              id="genderize_exclude"
+            />
+            <v-checkbox
+              v-model="forms.genderize.noStrictMatching"
+              label="Disable strict name validation"
+              id="genderize_noStrictMatching"
+            />
+          </v-col>
+        </v-row>
+        <v-row v-if="selected === 'unify'">
+          <v-col>
+            <v-select
+              v-model="forms.unify.criteria"
+              :items="['name', 'email', 'username']"
+              :menu-props="{ bottom: true, offsetY: true }"
+              label="Criteria"
+              dense
+              hide-details
+              multiple
+              outlined
+            />
+            <v-checkbox
+              v-model="forms.unify.exclude"
+              label="Exclude individuals in RecommenderExclusionTerm list"
+              id="unify_exclude"
+            />
+          </v-col>
+        </v-row>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="primary darken-1" text @click="onClose">
+          Cancel
+        </v-btn>
+        <v-btn
+          :disabled="!selected"
+          color="primary"
+          id="confirm"
+          depressed
+          @click="onSave"
+        >
+          Confirm
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script>
+const jobTypes = [
+  {
+    title: "Affiliate",
+    value: "affiliate",
+    description: "Affiliate individuals to organizations using recommendations."
+  },
+  {
+    title: "Genderize",
+    value: "genderize",
+    description:
+      "Autocomplete the gender information of individuals using genderize.io recommendations. "
+  },
+  {
+    title: "Unify",
+    value: "unify",
+    description: "Merge individuals by using matching recommendations."
+  }
+];
+const defaultForms = {
+  genderize: {
+    exclude: true,
+    noStrictMatching: false
+  },
+  unify: {
+    criteria: ["name", "email", "username"],
+    exclude: true
+  }
+};
+
+export default {
+  name: "JobModal",
+  props: {
+    isOpen: {
+      type: Boolean,
+      required: true
+    },
+    types: {
+      type: Array,
+      required: false,
+      default: () => jobTypes
+    }
+  },
+  data() {
+    return {
+      selected: null,
+      forms: defaultForms
+    };
+  },
+  methods: {
+    onClose() {
+      this.$emit("update:isOpen", false);
+      this.selected = null;
+      this.forms = Object.assign({}, this.forms, defaultForms);
+    },
+    onSave() {
+      this.$emit(this.selected, this.forms[this.selected]);
+      this.onClose();
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "../styles/index.scss";
+
+.v-list-item .v-list-item__subtitle {
+  max-width: 490px;
+  overflow: visible;
+  white-space: normal;
+}
+</style>

--- a/ui/src/components/JobsTable.vue
+++ b/ui/src/components/JobsTable.vue
@@ -7,6 +7,16 @@
         </v-icon>
         Jobs
       </h4>
+      <v-btn
+        depressed
+        small
+        height="34"
+        color="secondary"
+        class="black--text"
+        @click.stop="openModal = true"
+      >
+        Add
+      </v-btn>
     </header>
     <v-simple-table v-if="jobs.length > 0">
       <template v-slot:default>
@@ -62,12 +72,16 @@
       ></v-pagination>
     </div>
     <p v-else class="text-subtitle-1 pa-7">There are no jobs in the queue.</p>
+    <job-modal :is-open.sync="openModal" v-on="$listeners" />
   </v-container>
 </template>
 
 <script>
+import JobModal from "./JobModal.vue";
+
 export default {
   name: "JobsTable",
+  components: { JobModal },
   props: {
     getJobs: {
       type: Function,
@@ -79,7 +93,8 @@ export default {
       jobs: [],
       page: 1,
       pageSize: 10,
-      pageCount: 1
+      pageCount: 1,
+      openModal: false
     };
   },
   created() {
@@ -112,6 +127,7 @@ export default {
 };
 </script>
 <style lang="scss" scoped>
+@import "../styles/index.scss";
 .capitalize {
   text-transform: capitalize;
 }

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -1,20 +1,72 @@
 <template>
   <v-main>
-    <jobs-table :get-jobs="getJobs" class="mt-md-6" />
+    <jobs-table
+      :get-jobs="getJobs"
+      class="mt-md-6"
+      @affiliate="affiliate"
+      @genderize="genderize"
+      @unify="unify"
+      ref="table"
+    />
+    <v-snackbar v-model="snackbar.isOpen" color="error" text>
+      {{ snackbar.text }}
+    </v-snackbar>
   </v-main>
 </template>
 
 <script>
 import { getJobs } from "../apollo/queries";
+import { affiliate, genderize, unify } from "../apollo/mutations";
 import JobsTable from "../components/JobsTable";
 
 export default {
   name: "Jobs",
   components: { JobsTable },
+  data() {
+    return {
+      snackbar: {
+        isOpen: false,
+        text: null
+      }
+    };
+  },
   methods: {
     async getJobs(page, pageSize) {
       const response = await getJobs(this.$apollo, page, pageSize);
       return response;
+    },
+    async affiliate() {
+      try {
+        await affiliate(this.$apollo);
+        this.$refs.table.getPaginatedJobs();
+      } catch (error) {
+        this.snackbar = Object.assign(this.snackbar, {
+          isOpen: true,
+          text: error
+        });
+      }
+    },
+    async genderize({ exclude, noStrictMatching }) {
+      try {
+        await genderize(this.$apollo, exclude, noStrictMatching);
+        this.$refs.table.getPaginatedJobs();
+      } catch (error) {
+        this.snackbar = Object.assign(this.snackbar, {
+          isOpen: true,
+          text: error
+        });
+      }
+    },
+    async unify({ criteria, exclude }) {
+      try {
+        await unify(this.$apollo, criteria, exclude);
+        this.$refs.table.getPaginatedJobs();
+      } catch (error) {
+        this.snackbar = Object.assign(this.snackbar, {
+          isOpen: true,
+          text: error
+        });
+      }
     }
   }
 };

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -2214,6 +2214,81 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
 </section>
 `;
 
+exports[`Jobs Mock mutation for affiliate 1`] = `
+<v-main-stub
+  tag="main"
+>
+  <jobs-table-stub
+    class="mt-md-6"
+    getjobs="function () { [native code] }"
+  />
+   
+  <v-snackbar-stub
+    color="error"
+    contentclass=""
+    tag="div"
+    text="true"
+    timeout="5000"
+    transition="v-snack-transition"
+    value="true"
+  >
+    
+    TypeError: this.$refs.table.getPaginatedJobs is not a function
+  
+  </v-snackbar-stub>
+</v-main-stub>
+`;
+
+exports[`Jobs Mock mutation for genderize 1`] = `
+<v-main-stub
+  tag="main"
+>
+  <jobs-table-stub
+    class="mt-md-6"
+    getjobs="function () { [native code] }"
+  />
+   
+  <v-snackbar-stub
+    color="error"
+    contentclass=""
+    tag="div"
+    text="true"
+    timeout="5000"
+    transition="v-snack-transition"
+    value="true"
+  >
+    
+    TypeError: this.$refs.table.getPaginatedJobs is not a function
+  
+  </v-snackbar-stub>
+</v-main-stub>
+`;
+
+exports[`Jobs Mock mutation for unify 1`] = `
+<v-main-stub
+  tag="main"
+>
+  <jobs-table-stub
+    class="mt-md-6"
+    getjobs="function () { [native code] }"
+  />
+   
+  <v-snackbar-stub
+    color="error"
+    contentclass=""
+    tag="div"
+    text="true"
+    timeout="5000"
+    transition="v-snack-transition"
+    value="true"
+  >
+    
+    TypeError: this.$refs.table.getPaginatedJobs is not a function
+  
+  </v-snackbar-stub>
+</v-main-stub>
+`;
+
 exports[`Login Mock mutation for tokenAuth 1`] = `
 <v-main-stub
   class="align-center"

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -771,6 +771,21 @@ exports[`JobsTable Mock query for getJobs 1`] = `
       Jobs
     
     </h4>
+     
+    <v-btn-stub
+      activeclass=""
+      class="black--text"
+      color="secondary"
+      depressed="true"
+      height="34"
+      small="true"
+      tag="button"
+      type="button"
+    >
+      
+      Add
+    
+    </v-btn-stub>
   </header>
    
   <!---->
@@ -780,6 +795,10 @@ exports[`JobsTable Mock query for getJobs 1`] = `
   >
     There are no jobs in the queue.
   </p>
+   
+  <job-modal-stub
+    types="[object Object],[object Object],[object Object]"
+  />
 </v-container-stub>
 `;
 

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -8045,6 +8045,42 @@ exports[`Storyshots IndividualsTable Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots JobModal Default 1`] = `
+<div
+  class="v-application v-application--is-ltr theme--light"
+  data-app="true"
+  id="app"
+>
+  <div
+    class="v-application--wrap"
+  >
+    <div
+      class="ma-auto"
+    >
+      <button
+        class="v-btn v-btn--contained theme--dark v-size--default primary"
+        type="button"
+      >
+        <span
+          class="v-btn__content"
+        >
+          
+      Open Dialog
+    
+        </span>
+      </button>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storyshots JobsTable Default 1`] = `
 <div
   class="v-application v-application--is-ltr theme--light"
@@ -8071,6 +8107,20 @@ exports[`Storyshots JobsTable Default 1`] = `
       Jobs
     
         </h4>
+         
+        <button
+          class="black--text v-btn v-btn--depressed theme--light v-size--small secondary"
+          style="height: 34px;"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            
+      Add
+    
+          </span>
+        </button>
       </header>
        
       <!---->
@@ -8080,6 +8130,13 @@ exports[`Storyshots JobsTable Default 1`] = `
       >
         There are no jobs in the queue.
       </p>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
     </div>
   </div>
 </div>
@@ -8111,6 +8168,20 @@ exports[`Storyshots JobsTable Empty 1`] = `
       Jobs
     
         </h4>
+         
+        <button
+          class="black--text v-btn v-btn--depressed theme--light v-size--small secondary"
+          style="height: 34px;"
+          type="button"
+        >
+          <span
+            class="v-btn__content"
+          >
+            
+      Add
+    
+          </span>
+        </button>
       </header>
        
       <!---->
@@ -8120,6 +8191,13 @@ exports[`Storyshots JobsTable Empty 1`] = `
       >
         There are no jobs in the queue.
       </p>
+       
+      <div
+        class="v-dialog__container"
+        role="dialog"
+      >
+        <!---->
+      </div>
     </div>
   </div>
 </div>
@@ -8441,7 +8519,7 @@ exports[`Storyshots OrganizationSelector Default 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-owns="list-1209"
+            aria-owns="list-1222"
             class="v-input__slot"
             role="combobox"
           >
@@ -8461,14 +8539,14 @@ exports[`Storyshots OrganizationSelector Default 1`] = `
             >
               <label
                 class="v-label v-label--active theme--light"
-                for="input-1209"
+                for="input-1222"
                 style="left: 0px; position: absolute;"
               >
                 Organization
               </label>
               <input
                 autocomplete="off"
-                id="input-1209"
+                id="input-1222"
                 type="text"
               />
               <div
@@ -8545,7 +8623,7 @@ exports[`Storyshots OrganizationSelector Selected Organization 1`] = `
           <div
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-owns="list-1220"
+            aria-owns="list-1233"
             class="v-input__slot"
             role="combobox"
           >
@@ -8565,14 +8643,14 @@ exports[`Storyshots OrganizationSelector Selected Organization 1`] = `
             >
               <label
                 class="v-label v-label--active theme--light"
-                for="input-1220"
+                for="input-1233"
                 style="left: 0px; position: absolute;"
               >
                 Organization
               </label>
               <input
                 autocomplete="off"
-                id="input-1220"
+                id="input-1233"
                 type="text"
               />
               <div
@@ -8736,13 +8814,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1292"
+                    for="input-1305"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1292"
+                    id="input-1305"
                     type="text"
                   />
                 </div>
@@ -8873,13 +8951,13 @@ exports[`Storyshots OrganizationsTable Groups 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1303"
+                  for="input-1316"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1303"
+                  id="input-1316"
                   max="0"
                   min="1"
                   type="number"
@@ -9017,13 +9095,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
                 >
                   <label
                     class="v-label theme--light"
-                    for="input-1235"
+                    for="input-1248"
                     style="left: 0px; position: absolute;"
                   >
                     Search
                   </label>
                   <input
-                    id="input-1235"
+                    id="input-1248"
                     type="text"
                   />
                 </div>
@@ -9154,13 +9232,13 @@ exports[`Storyshots OrganizationsTable Organizations 1`] = `
               >
                 <label
                   class="v-label v-label--active theme--light"
-                  for="input-1246"
+                  for="input-1259"
                   style="left: 0px; position: absolute;"
                 >
                   Items per page
                 </label>
                 <input
-                  id="input-1246"
+                  id="input-1259"
                   max="0"
                   min="1"
                   type="number"
@@ -9482,13 +9560,13 @@ exports[`Storyshots Search Default 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1371"
+                  for="input-1384"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1371"
+                  id="input-1384"
                   type="text"
                 />
               </div>
@@ -9616,13 +9694,13 @@ exports[`Storyshots Search Filter Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1381"
+                  for="input-1394"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1381"
+                  id="input-1394"
                   type="text"
                 />
               </div>
@@ -9720,13 +9798,13 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1394"
+                  for="input-1407"
                   style="left: 0px; position: absolute;"
                 >
                   Search
                 </label>
                 <input
-                  id="input-1394"
+                  id="input-1407"
                   type="text"
                 />
               </div>
@@ -9798,7 +9876,7 @@ exports[`Storyshots Search Order Selector 1`] = `
             <div
               aria-expanded="false"
               aria-haspopup="listbox"
-              aria-owns="list-1399"
+              aria-owns="list-1412"
               class="v-input__slot"
               role="button"
             >
@@ -9816,7 +9894,7 @@ exports[`Storyshots Search Order Selector 1`] = `
               >
                 <label
                   class="v-label theme--light"
-                  for="input-1399"
+                  for="input-1412"
                   style="left: 0px; position: absolute;"
                 >
                   Order by
@@ -9827,7 +9905,7 @@ exports[`Storyshots Search Order Selector 1`] = `
                   <input
                     aria-readonly="false"
                     autocomplete="off"
-                    id="input-1399"
+                    id="input-1412"
                     readonly="readonly"
                     type="text"
                   />
@@ -10513,7 +10591,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1513"
+                    id="input-1526"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -10524,7 +10602,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1513"
+                  for="input-1526"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -10610,13 +10688,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1518"
+                      for="input-1531"
                       style="left: 0px; position: absolute;"
                     >
                       Search
                     </label>
                     <input
-                      id="input-1518"
+                      id="input-1531"
                       type="text"
                     />
                   </div>
@@ -10688,7 +10766,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-owns="list-1526"
+                  aria-owns="list-1539"
                   class="v-input__slot"
                   role="button"
                 >
@@ -10706,7 +10784,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1526"
+                      for="input-1539"
                       style="left: 0px; position: absolute;"
                     >
                       Order by
@@ -10717,7 +10795,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       <input
                         aria-readonly="false"
                         autocomplete="off"
-                        id="input-1526"
+                        id="input-1539"
                         readonly="readonly"
                         type="text"
                       />
@@ -10904,13 +10982,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label v-label--active theme--light"
-                      for="input-1546"
+                      for="input-1559"
                       style="left: 0px; position: absolute;"
                     >
                       Items per page
                     </label>
                     <input
-                      id="input-1546"
+                      id="input-1559"
                       max="0"
                       min="1"
                       type="number"

--- a/ui/tests/unit/mutations.spec.js
+++ b/ui/tests/unit/mutations.spec.js
@@ -7,6 +7,7 @@ import OrganizationsTable from "@/components/OrganizationsTable";
 import ProfileModal from "@/components/ProfileModal";
 import * as Mutations from "@/apollo/mutations";
 import TeamModal from "@/components/TeamModal";
+import Jobs from "@/views/Jobs";
 
 Vue.use(Vuetify);
 
@@ -245,6 +246,18 @@ const updateEnrollmentResponse = {
       __typename: "UpdateEnrollment"
     }
   }
+};
+
+const affiliateResponse = {
+  data: { affiliate: { jobId: "384f26af-aae4-4c73-96af-e0af90a4cdf3" }}
+};
+
+const genderizeResponse = {
+  data: { genderize: { jobId: "384f26af-aae4-4c73-96af-e0af90a4cdf3" }}
+};
+
+const unifyResponse = {
+  data: { unify: { jobId: "384f26af-aae4-4c73-96af-e0af90a4cdf3" }}
 };
 
 describe("IndividualsTable", () => {
@@ -682,6 +695,65 @@ describe("TeamModal", () => {
     });
 
     const response = await Mutations.deleteTeam(wrapper.vm.$apollo, "test");
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+});
+
+describe("Jobs", () => {
+  test("Mock mutation for affiliate", async () => {
+    const mutate = jest.fn(() => Promise.resolve(affiliateResponse));
+    const wrapper = shallowMount(Jobs, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      }
+    });
+
+    await wrapper.vm.affiliate()
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock mutation for genderize", async () => {
+    const mutate = jest.fn(() => Promise.resolve(genderizeResponse));
+    const wrapper = shallowMount(Jobs, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      }
+    });
+
+    await wrapper.vm.genderize({
+      exclude: false,
+      noStrictMatching: true
+    });
+
+    expect(mutate).toBeCalled();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  test("Mock mutation for unify", async () => {
+    const mutate = jest.fn(() => Promise.resolve(unifyResponse));
+    const wrapper = shallowMount(Jobs, {
+      Vue,
+      mocks: {
+        $apollo: {
+          mutate
+        }
+      }
+    });
+
+    await wrapper.vm.unify({
+      criteria: ["name"],
+      exclude: false
+    });
 
     expect(mutate).toBeCalled();
     expect(wrapper.element).toMatchSnapshot();


### PR DESCRIPTION
This PR adds the ability to create jobs from the UI. Clicking the "add" button on the jobs table opens a dialog where users can select the type of job and configure the options it may have. Current jobs are `affiliate`, `genderize` and `unify` and are applied to all individuals. This makes trying to create the `unify` job fail since selecting specific source UUIDs is mandatory.