### PR TITLE
Change user password

### DIFF
--- a/sortinghat/app/urls.py
+++ b/sortinghat/app/urls.py
@@ -5,11 +5,12 @@ from django.conf import settings
 from django.urls import path, re_path
 from django.views.generic import TemplateView
 
-from sortinghat.core.views import SortingHatGraphQLView
+from sortinghat.core.views import (SortingHatGraphQLView, change_password)
 
 from .schema import schema
 
 urlpatterns = [
     path('api/', SortingHatGraphQLView.as_view(graphiql=settings.DEBUG, schema=schema)),
+    path('password_change/', change_password, name='password_change'),
     re_path(r'^(?!static).*$', TemplateView.as_view(template_name="index.html"))
 ]

--- a/sortinghat/core/decorators.py
+++ b/sortinghat/core/decorators.py
@@ -21,7 +21,12 @@
 #
 
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponse
 from graphql_jwt.decorators import user_passes_test
+from graphql_jwt.utils import get_credentials
+from graphql_jwt.shortcuts import get_user_by_token
+from graphql_jwt.exceptions import JSONWebTokenError
 
 
 # This custom decorator takes the `user` object from the request's
@@ -36,3 +41,21 @@ def check_permissions(perms):
     return user_passes_test(
         lambda u: u.has_perms(perms) or not settings.SORTINGHAT_AUTHENTICATION_REQUIRED
     )
+
+
+# Use GraphQL JWT authentication on Django views
+# https://github.com/flavors/django-graphql-jwt/issues/176
+def jwt_login_required(func):
+    def wrap(request, *args, **kwargs):
+        token = get_credentials(request, **kwargs)
+        if token is not None:
+            try:
+                request.user = get_user_by_token(token, request)
+                return func(request, *args, **kwargs)
+            except JSONWebTokenError:
+                return HttpResponse(status=401)
+            except ObjectDoesNotExist:
+                return HttpResponse(status=404)
+        else:
+            return HttpResponse(status=401)
+    return wrap

--- a/sortinghat/core/views.py
+++ b/sortinghat/core/views.py
@@ -19,6 +19,10 @@
 #     Santiago Dueñas <sduenas@bitergia.com>
 #
 
+import json
+from django.http import HttpResponse
+from django.contrib.auth.forms import PasswordChangeForm
+
 from graphene_django.views import GraphQLView as BaseGraphQLView
 from graphql_jwt.exceptions import (PermissionDenied,
                                     JSONWebTokenExpired,
@@ -28,6 +32,8 @@ from .errors import (CODE_TOKEN_EXPIRED,
                      CODE_PERMISSION_DENIED,
                      CODE_INVALID_CREDENTIALS,
                      CODE_UNKNOWN_ERROR)
+
+from .decorators import jwt_login_required
 
 
 class SortingHatGraphQLView(BaseGraphQLView):
@@ -58,3 +64,25 @@ class SortingHatGraphQLView(BaseGraphQLView):
             formatted_error['extensions'] = {'code': code}
 
         return formatted_error
+
+
+@jwt_login_required
+def change_password(request):
+    if request.method == 'POST':
+        form = PasswordChangeForm(request.user, request.POST)
+        if form.is_valid():
+            user = form.save()
+            response = {
+                'updated': user.username
+            }
+            return HttpResponse(json.dumps(response),
+                                content_type='application/json')
+        else:
+            response = {
+                'errors': form.errors.get_json_data()
+            }
+
+            return HttpResponse(json.dumps(response),
+                                content_type='application/json')
+    else:
+        return HttpResponse(status=405)

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -8,7 +8,7 @@
       </router-link>
 
       <v-spacer></v-spacer>
-      <v-menu v-if="user && $route.name !== 'Login'" offset-y>
+      <v-menu v-if="user && $route.name !== 'Login'" offset-y left>
         <template v-slot:activator="{ on }">
           <v-btn depressed small color="primary" v-on="on">
             <v-icon small left>
@@ -33,6 +33,13 @@
               <v-icon small>mdi-tray-full</v-icon>
             </v-list-item-icon>
             <v-list-item-title>Jobs</v-list-item-title>
+          </v-list-item>
+          <v-divider />
+          <v-list-item to="/change-password">
+            <v-list-item-icon class="mr-2">
+              <v-icon small>mdi-cog-outline</v-icon>
+            </v-list-item-icon>
+            <v-list-item-title>Change password</v-list-item-title>
           </v-list-item>
           <v-divider />
           <v-list-item @click="logOut">

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -15,6 +15,12 @@ const routes = [
     meta: { requiresAuth: true, title: "Sorting Hat" }
   },
   {
+    path: "/change-password",
+    name: "ChangePassword",
+    component: () => import("../views/ChangePassword"),
+    meta: { requiresAuth: true, title: "Password change - Sorting Hat" }
+  },
+  {
     path: "/login",
     name: "Login",
     component: () => import("../views/Login"),

--- a/ui/src/views/ChangePassword.vue
+++ b/ui/src/views/ChangePassword.vue
@@ -1,0 +1,134 @@
+<template lang="html">
+  <v-main>
+    <v-card class="mx-auto mt-6 section" max-width="500" elevation="0" outlined>
+      <v-card-title class="header">Password change</v-card-title>
+      <v-card-subtitle v-if="showForm" class="pa-8 pb-0">
+        Please enter your old password, for security’s sake, and then enter your
+        new password twice so we can verify you typed it in correctly.
+      </v-card-subtitle>
+      <v-card-text class="pa-8">
+        <v-form v-if="showForm" ref="form_change_password">
+          <v-text-field
+            v-model="old_password"
+            label="Old password"
+            name="old_password"
+            type="password"
+            error-count="5"
+            class="mb-4"
+            :error-messages="
+              errors.old_password
+                ? errors.old_password.map(error => error.message)
+                : []
+            "
+            outlined
+            dense
+          />
+          <v-text-field
+            v-model="new_password1"
+            label="New password"
+            name="new_password1"
+            type="password"
+            error-count="5"
+            class="mb-4"
+            :error-messages="
+              errors.new_password1
+                ? errors.new_password1.map(error => error.message)
+                : []
+            "
+            outlined
+            dense
+          />
+          <v-text-field
+            v-model="new_password2"
+            label="New password confirmation"
+            name="new_password2"
+            type="password"
+            error-count="5"
+            class="mb-4"
+            :error-messages="
+              errors.new_password2
+                ? errors.new_password2.map(error => error.message)
+                : []
+            "
+            outlined
+            dense
+          />
+          <v-btn
+            :disabled="!old_password || !new_password1 || !new_password2"
+            color="primary"
+            depressed
+            @click.prevent="onSubmit"
+          >
+            Save
+          </v-btn>
+        </v-form>
+        <v-alert v-else outlined type="success" text>
+          Password changed successfully
+        </v-alert>
+      </v-card-text>
+    </v-card>
+  </v-main>
+</template>
+
+<script>
+import Cookies from "js-cookie";
+
+export default {
+  name: "ChangePassword",
+  data: () => ({
+    old_password: "",
+    new_password1: "",
+    new_password2: "",
+    errors: {},
+    showForm: true
+  }),
+  computed: {
+    url() {
+      const pathname = "/password_change/";
+
+      if (process.env.VUE_APP_API_URL) {
+        const origin = new URL(process.env.VUE_APP_API_URL).origin;
+
+        return `${origin}${pathname}`;
+      } else {
+        return pathname;
+      }
+    },
+    headers() {
+      const csrftoken = Cookies.get("csrftoken");
+      const authtoken = Cookies.get("sh_authtoken");
+      const headers = {
+        "X-CSRFToken": csrftoken,
+        Authorization: `JWT ${authtoken}`
+      };
+
+      return headers;
+    }
+  },
+  methods: {
+    onSubmit() {
+      const HTMLForm = this.$refs.form_change_password.$el;
+      const body = new FormData(HTMLForm);
+
+      this.errors = {};
+
+      fetch(this.url, {
+        method: "POST",
+        credentials: "include",
+        headers: this.headers,
+        body: body
+      })
+        .then(response => response.json())
+        .then(data => {
+          if (data.errors) {
+            this.errors = data.errors;
+            this.$logger.error("Error changing password", data);
+          } else {
+            this.showForm = false;
+            this.$logger.info(`Changed password for user ${data.updated}`);
+          }
+        });
+    }
+  }
+};
+</script>


### PR DESCRIPTION
This PR adds a form where users can change their password at `/change-password` from the UI, and a Django view at `/password_change` to process the request.

Example request:
```
curl -XPOST 'http://XXX/password_change/' \
--header 'X-CSRFToken: XXX' \
--header 'Cookie: csrftoken=XXX' \
--header 'Authorization: JWT XXX' \
--form 'old_password="XXX"' \
--form 'new_password1="XXX"' \
--form 'new_password2="XXX"'
```

Fixes #664.