### PR TITLE
[ui] Fix the endpoint of the SortingHat API in production

### DIFF
--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -13,7 +13,7 @@ import { ApolloLink } from "apollo-link";
 import Logger from "./plugins/logger";
 import GetErrorMessage from "./plugins/errors";
 
-const API_URL = process.env.VUE_APP_API_URL || "/api/";
+const API_URL = process.env.VUE_APP_API_URL || `${process.env.BASE_URL}api/`;
 
 // Force HTTP GET to the Django Server for getting the csrf token
 fetch(API_URL, { credentials: "include" }).then(() => {

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -2,7 +2,7 @@ var path = require('path');
 const { argv } = require('yargs');
 
 module.exports = {
-  publicPath: process.env.NODE_ENV === 'production' ? './' : '/',
+  publicPath: process.env.NODE_ENV === 'production' ? '/identities/' : '/',
   outputDir: path.resolve(__dirname, "../sortinghat/", "core", "static"),
   indexPath: path.resolve(__dirname, "../sortinghat", "core", "templates", "index.html"),
   transpileDependencies: ["vuetify"],


### PR DESCRIPTION
For production deployments, the API of SortingHat will be under '/identities' path. Therefore, the path of the API will be '/identities/api'.

This is a temporary solution. We will try to make the deployment of SortingHat more flexible, so instances can use different paths and configurations where the SortingHat service will running.

Signed-off-by: Santiago Dueñas <sduenas@bitergia.com>