### PR TITLE
[ui] Bump thenify to 3.3.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,8 @@
     "vuetify-loader": "^1.9.2"
   },
   "resolutions": {
-    "@vue/**/**/loader-utils": "2.0.4"
+    "@vue/**/**/loader-utils": "2.0.4",
+    "@vue/cli-service/cli-highlight/mz/thenify-all/thenify": "3.3.1"
   },
   "engines": {
     "node": ">=14 <=16"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8573,10 +8573,10 @@ thenify-all@^1.0.0:
   dependencies:
     thenify ">= 3.1.0 < 4"
 
-"thenify@>= 3.1.0 < 4":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
-  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
+thenify@3.3.1, "thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
 


### PR DESCRIPTION
Resolves the nested thenify dependency to 3.3.1.

Signed-off-by: Eva Millán <evamillan@bitergia.com>