### PR TITLE
[client] Update SortingHat client headers

### DIFF
--- a/releases/unreleased/graphql-client-headers-updated.yml
+++ b/releases/unreleased/graphql-client-headers-updated.yml
@@ -1,0 +1,8 @@
+---
+title: GraphQL client headers updated
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  SortingHat client headers are updated adding `Referer` and
+  `Host` to fix the CSRF token issue.

--- a/sortinghat/cli/client/client.py
+++ b/sortinghat/cli/client/client.py
@@ -111,7 +111,9 @@ class SortingHatClient:
 
         headers = {
             'X-CSRFToken': result.cookies['csrftoken'],
-            'Cookie': 'csrftoken=' + result.cookies['csrftoken']
+            'Cookie': 'csrftoken=' + result.cookies['csrftoken'],
+            'Host': f"{self.host}:{self.port}" if self.port else self.host,
+            'Referer': self.url
         }
 
         self.gqlc = HTTPEndpoint(self.url, headers)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -150,7 +150,9 @@ class TestSortingHatClient(unittest.TestCase):
         # Connection was established and tokens set
         expected = {
             'X-CSRFToken': 'ABCDEFGHIJK',
-            'Cookie': 'csrftoken=ABCDEFGHIJK'
+            'Cookie': 'csrftoken=ABCDEFGHIJK',
+            'Referer': 'http://localhost:9314/',
+            'Host': 'localhost:9314'
         }
         self.assertDictEqual(client.gqlc.base_headers, expected)
 
@@ -201,7 +203,9 @@ class TestSortingHatClient(unittest.TestCase):
         expected = {
             'Authorization': 'JWT 12345678',
             'X-CSRFToken': 'ABCDEFGHIJK',
-            'Cookie': 'csrftoken=ABCDEFGHIJK'
+            'Cookie': 'csrftoken=ABCDEFGHIJK',
+            'Referer': 'http://localhost:9314/',
+            'Host': 'localhost:9314'
         }
         self.assertDictEqual(client.gqlc.base_headers, expected)
 


### PR DESCRIPTION
This PR includes Referer header in all the graphQL queries to fix an issue with CSRF token.
