### PR TITLE
Configure integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,3 +80,79 @@ jobs:
       - name: Run unit tests
         working-directory: ./ui
         run: yarn test:unit
+
+  integration:
+
+    services:
+      mysql:
+        image: mariadb:10.5
+        env:
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x]
+        python-version: [3.7, 3.8]
+
+    runs-on: ubuntu-latest
+    name: Node ${{ matrix.node-version }} Python ${{ matrix.python-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          poetry install -vvv
+          poetry run pip install -r requirements_dev.txt
+      - name: Set MySQL mode
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: ${{ job.services.mysql.ports[3306] }}
+        run: |
+          mysql --host $DB_HOST --port $DB_PORT -uroot -proot -e "SET GLOBAL sql_mode = 'NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'";
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build UI packages
+        working-directory: ./ui
+        run: |
+          yarn install
+          yarn build --mode development
+      - name: Setup database, static files and run service
+        env:
+          SORTINGHAT_SECRET_KEY: my-secret-key
+          SORTINGHAT_DB_PASSWORD: root
+          SORTINGHAT_SUPERUSER_USERNAME: root
+          SORTINGHAT_SUPERUSER_PASSWORD: root
+        run: |
+          poetry run sortinghat-admin --config sortinghat.config.settings setup
+      - name: Start server in the background
+        run: poetry run sortinghatd --config sortinghat.config.settings --dev &
+        env:
+          SORTINGHAT_SECRET_KEY: my-secret-key
+          SORTINGHAT_DB_PASSWORD: root
+          UWSGI_HTTP: "http://localhost:8000"
+      - name: Run integration tests
+        uses: cypress-io/github-action@v5
+        with:
+          install: false
+          start: yarn serve --api_url=http://localhost:8000/api/
+          command: yarn test:e2e --config baseUrl=http://localhost:8080
+          wait-on: 'http://localhost:8080, http://localhost:8000/api/'
+          spec: tests/e2e/specs/*.js
+          working-directory: ./ui
+        env:
+          CYPRESS_USERNAME: root
+          CYPRESS_PASSWORD: root
+          CYPRESS_API_URL: http://localhost:8000/api/

--- a/ui/cypress.config.js
+++ b/ui/cypress.config.js
@@ -3,6 +3,8 @@ const { defineConfig } = require("cypress");
 module.exports = defineConfig({
   e2e: {
     baseUrl: "http://localhost:8000",
+    defaultCommandTimeout: 6000,
+    requestTimeout: 6000,
     screenshotOnRunFailure: false,
     specPattern: "tests/e2e/specs/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "tests/e2e/support/index.js",

--- a/ui/src/components/ProfileModal.vue
+++ b/ui/src/components/ProfileModal.vue
@@ -71,6 +71,7 @@
             <v-col cols="2">
               <v-checkbox
                 v-model="profileForm.isBot"
+                :false-value="false"
                 label="Bot"
                 color="primary"
                 class="mt-1"
@@ -308,7 +309,7 @@ export default {
         countryCode: this.profileForm.country
           ? this.profileForm.country.code
           : null,
-        isBot: this.profileForm.isBot,
+        isBot: !!this.profileForm.isBot,
       };
       try {
         const response = await this.updateProfile(data, uuid);

--- a/ui/tests/e2e/support/commands.js
+++ b/ui/tests/e2e/support/commands.js
@@ -108,7 +108,9 @@ Cypress.Commands.add("deleteIndividuals", () => {
 });
 
 Cypress.Commands.add("getIndividualsCount", () => {
-  cy.get('[data-cy="individual-counter"]').invoke("text").then(parseFloat);
+  return cy.get('[data-cy="individual-counter"]')
+    .invoke("text")
+    .then(parseFloat);
 });
 
 Cypress.Commands.add("addToWorkspace", (individuals) => {

--- a/ui/tests/e2e/support/index.js
+++ b/ui/tests/e2e/support/index.js
@@ -18,3 +18,9 @@ import "./commands";
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+Cypress.on("uncaught:exception", (err, runnable) => {
+  // returning false here prevents Cypress from
+  // failing the test
+  return false;
+});


### PR DESCRIPTION
This PR adds the Cypress integration tests to GitHub actions. It also fixes the issues with adding individuals to the workspace and counting the number of individuals in the tests and an error in `ProfileModal` when the "bot" box was not checked.