### PR TITLE
Update setuptools version to >65.5.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1117,14 +1117,14 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "65.7.0"
+version = "66.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-65.7.0-py3-none-any.whl", hash = "sha256:8ab4f1dbf2b4a65f7eec5ad0c620e84c34111a68d3349833494b9088212214dd"},
-    {file = "setuptools-65.7.0.tar.gz", hash = "sha256:4d3c92fac8f1118bb77a22181355e29c239cabfe2b9effdaa665c66b711136d7"},
+    {file = "setuptools-66.0.0-py3-none-any.whl", hash = "sha256:a78d01d1e2c175c474884671dde039962c9d74c7223db7369771fcf6e29ceeab"},
+    {file = "setuptools-66.0.0.tar.gz", hash = "sha256:bd6eb2d6722568de6d14b87c44a96fac54b2a45ff5e940e639979a3d1792adb6"},
 ]
 
 [package.extras]
@@ -1275,4 +1275,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7.1"
-content-hash = "ecc9c8dc84e46432a730e19d3214ec433e812052f18ef3e57bd31d8ad5d1368c"
+content-hash = "d03f3600c4ba3d6b39f7cfc0970e9e11ccceed21c109f9965bf36f20010af29e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ PyJWT = "^2.4.0"
 uWSGI = "^2.0"
 django-treebeard = "^4.5.1"
 importlib-resources = "^5.2.0"
-setuptools = "^65.5.0"
+setuptools = ">65.5.0"
 grimoirelab-toolkit = { version = ">=0.3", allow-prereleases = true}
 django-storages = {extras = ["google"], version = "^1.13.2"}
 numpy = "==1.21.0"


### PR DESCRIPTION
This commit updates the version of `setuptools` without restrictions to be compatible with other packages that has the same constraints.
