### PR TITLE
Unify and recommend matches for all individuals

### DIFF
--- a/sortinghat/core/recommendations/matching.py
+++ b/sortinghat/core/recommendations/matching.py
@@ -24,6 +24,8 @@
 import logging
 import pandas
 
+from itertools import tee
+
 from django.forms.models import model_to_dict
 
 from ..db import (find_individual_by_uuid)
@@ -93,7 +95,9 @@ def recommend_matches(source_uuids, target_uuids, criteria, exclude=True, verbos
     aliases = {}
     input_set = set()
     target_set = set()
-    for uuid in source_uuids:
+    source_uuids_it1, source_uuids_it2 = tee(source_uuids)
+
+    for uuid in source_uuids_it1:
         identities = _get_identities(uuid)
         aliases[uuid] = [identity.uuid for identity in identities]
         input_set.update(identities)
@@ -108,7 +112,7 @@ def recommend_matches(source_uuids, target_uuids, criteria, exclude=True, verbos
 
     matched = _find_matches(input_set, target_set, criteria, exclude=exclude, verbose=verbose)
     # Return filtered results
-    for uuid in source_uuids:
+    for uuid in source_uuids_it2:
         result = set()
         if uuid in matched.keys():
             result = matched[uuid]

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -996,7 +996,8 @@ class RecommendAffiliations(graphene.Mutation):
 
 class RecommendMatches(graphene.Mutation):
     class Arguments:
-        source_uuids = graphene.List(graphene.String)
+        source_uuids = graphene.List(graphene.String,
+                                     required=False)
         target_uuids = graphene.List(graphene.String,
                                      required=False)
         criteria = graphene.List(graphene.String)
@@ -1007,7 +1008,7 @@ class RecommendMatches(graphene.Mutation):
 
     @check_permissions('core.execute_job')
     @check_auth
-    def mutate(self, info, source_uuids, criteria, target_uuids=None, exclude=True, verbose=False):
+    def mutate(self, info, criteria, source_uuids=None, target_uuids=None, exclude=True, verbose=False):
         user = info.context.user
         ctx = SortingHatContext(user)
 
@@ -1061,7 +1062,8 @@ class Affiliate(graphene.Mutation):
 
 class Unify(graphene.Mutation):
     class Arguments:
-        source_uuids = graphene.List(graphene.String)
+        source_uuids = graphene.List(graphene.String,
+                                     required=False)
         target_uuids = graphene.List(graphene.String,
                                      required=False)
         criteria = graphene.List(graphene.String)
@@ -1071,7 +1073,7 @@ class Unify(graphene.Mutation):
 
     @check_permissions('core.execute_job')
     @check_auth
-    def mutate(self, info, source_uuids, criteria, target_uuids=None, exclude=True):
+    def mutate(self, info, criteria, source_uuids=None, target_uuids=None, exclude=True):
         user = info.context.user
         ctx = SortingHatContext(user)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -575,6 +575,59 @@ class TestRecommendMatches(TestCase):
                                       source='scm',
                                       uuid=self.jrae.uuid)
 
+    def test_recommend_matches_all_individuals(self):
+        """Check if recommendations are obtained for all individuals"""
+
+        ctx = SortingHatContext(self.user)
+
+        # Test
+        expected = {
+            'results': {
+                self.john_smith.uuid: sorted([self.jsmith.uuid, self.js_alt.uuid]),
+                self.jsmith.uuid: sorted([self.js_alt.uuid]),
+                self.jane_rae.uuid: sorted([self.jrae.uuid]),
+                self.js_alt.uuid: [],
+                self.jrae.uuid: sorted([self.jane_rae.uuid])
+            }
+        }
+
+        individuals_expected = {
+            self.john_smith.individual.mk: [self.jsmith.individual.mk,self.js_alt.individual.mk],
+            self.jsmith.individual.mk: [self.js_alt.individual.mk],
+            self.jane_rae.individual.mk: [self.jrae.individual.mk],
+            self.jrae.individual.mk: [self.jane_rae.individual.mk]
+        }
+
+        criteria = ['email', 'name', 'username']
+
+        # Identities which don't have the fields in `criteria` or no matches won't be returned
+        job = recommend_matches.delay(ctx,
+                                      None,
+                                      None,
+                                      criteria)
+        # Preserve job results order for the comparison against the expected results
+        result = job.result
+        for key in result['results']:
+            result['results'][key] = sorted(result['results'][key])
+
+        self.assertDictEqual(result, expected)
+        for mr in MergeRecommendation.objects.all():
+            self.assertIn(mr.individual2.mk, individuals_expected[mr.individual1.mk])
+
+        # Should have the same result as passing all the uuids
+        all_source_uuids = [self.john_smith.uuid, self.jsmith.uuid,
+                            self.jane_rae.uuid, self.js_alt.uuid,self.jrae.uuid]
+
+        job_uuids = recommend_matches.delay(ctx,
+                                            all_source_uuids,
+                                            None,
+                                            criteria)
+        result_all_uuids = job_uuids.result
+        for key in result_all_uuids['results']:
+            result_all_uuids['results'][key] = sorted(result_all_uuids['results'][key])
+
+        self.assertDictEqual(result, result_all_uuids)
+
     def test_recommend_matches(self):
         """Check if recommendations are obtained for the specified individuals"""
 

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -295,6 +295,14 @@ const MANAGE_MERGE_RECOMMENDATION = gql`
   }
 `;
 
+const RECOMMEND_MATCHES = gql`
+  mutation recommendMatches($criteria: [String], $exclude: Boolean) {
+    recommendMatches(criteria: $criteria, exclude: $exclude) {
+      jobId
+    }
+  }
+`;
+
 const tokenAuth = (apollo, username, password) => {
   const response = apollo.mutate({
     mutation: TOKEN_AUTH,
@@ -536,6 +544,16 @@ const manageMergeRecommendation = (apollo, id, apply) => {
   });
 };
 
+const recommendMatches = (apollo, criteria, exclude) => {
+  return apollo.mutate({
+    mutation: RECOMMEND_MATCHES,
+    variables: {
+      criteria: criteria,
+      exclude: exclude,
+    },
+  });
+};
+
 export {
   tokenAuth,
   lockIndividual,
@@ -559,4 +577,5 @@ export {
   genderize,
   unify,
   manageMergeRecommendation,
+  recommendMatches,
 };

--- a/ui/src/components/JobModal.vue
+++ b/ui/src/components/JobModal.vue
@@ -62,6 +62,25 @@
             />
           </v-col>
         </v-row>
+        <v-row v-if="selected === 'recommendMatches'">
+          <v-col>
+            <v-select
+              v-model="forms.recommendMatches.criteria"
+              :items="['name', 'email', 'username']"
+              :menu-props="{ bottom: true, offsetY: true }"
+              label="Criteria"
+              dense
+              hide-details
+              multiple
+              outlined
+            />
+            <v-checkbox
+              v-model="forms.recommendMatches.exclude"
+              label="Exclude individuals in RecommenderExclusionTerm list"
+              id="recommend_exclude"
+            />
+          </v-col>
+        </v-row>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
@@ -99,6 +118,11 @@ const jobTypes = [
     value: "unify",
     description: "Merge individuals by using matching recommendations.",
   },
+  {
+    title: "Recommend matches",
+    value: "recommendMatches",
+    description: "Recommend identity matches for individuals.",
+  },
 ];
 const defaultForms = {
   genderize: {
@@ -106,6 +130,10 @@ const defaultForms = {
     noStrictMatching: false,
   },
   unify: {
+    criteria: ["name", "email", "username"],
+    exclude: true,
+  },
+  recommendMatches: {
     criteria: ["name", "email", "username"],
     exclude: true,
   },

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -6,6 +6,7 @@
       @affiliate="affiliate"
       @genderize="genderize"
       @unify="unify"
+      @recommendMatches="recommendMatches"
       ref="table"
     />
     <v-snackbar v-model="snackbar.isOpen" color="error" text>
@@ -16,7 +17,12 @@
 
 <script>
 import { getJobs } from "../apollo/queries";
-import { affiliate, genderize, unify } from "../apollo/mutations";
+import {
+  affiliate,
+  genderize,
+  unify,
+  recommendMatches,
+} from "../apollo/mutations";
 import JobsTable from "../components/JobsTable";
 
 export default {
@@ -60,6 +66,17 @@ export default {
     async unify({ criteria, exclude }) {
       try {
         await unify(this.$apollo, criteria, exclude);
+        this.$refs.table.getPaginatedJobs();
+      } catch (error) {
+        this.snackbar = Object.assign(this.snackbar, {
+          isOpen: true,
+          text: error,
+        });
+      }
+    },
+    async recommendMatches({ criteria, exclude }) {
+      try {
+        await recommendMatches(this.$apollo, criteria, exclude);
         this.$refs.table.getPaginatedJobs();
       } catch (error) {
         this.snackbar = Object.assign(this.snackbar, {

--- a/ui/tests/unit/__snapshots__/queries.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/queries.spec.js.snap
@@ -658,7 +658,7 @@ exports[`JobsTable Mock query for getJobs 1`] = `
   </div>
    
   <job-modal-stub
-    types="[object Object],[object Object],[object Object]"
+    types="[object Object],[object Object],[object Object],[object Object]"
   />
 </v-container-stub>
 `;


### PR DESCRIPTION
This PR runs the `unify` and `recommend_matches` jobs against all individuals if a list of `source_uuids` is not provided. It also adds the option to generate merge recommendations on the UI.