### PR TITLE
Migrate SortingHat 0.7 schema on Docker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ $ sortinghatw --config sortinghat.config.settings
 
 
 ## Compatibility between versions
-SortingHat 0.7.x is not longer supported. Any database using this version will not work.
+SortingHat 0.7.x is no longer supported. Any database using this version will not work.
 
 SortingHat databases 0.7.x are no longer compatible. The `uidentities` table was renamed
 to `individuals`. The database schema changed in all tables to add the fields `created_at`
@@ -202,26 +202,10 @@ there are some specific changes to the column names:
     * `country_code` to `country`
     * `uuid` to `individual`
 
-Please update your database following the next steps:
-
-1. Use the script `utils/create_sh_0_7_fixture.py` to create the fixture
-JSON file
-   ```
-   $ python3 utils/create_sh_0_7_fixture.py test_sh -o test_sh_fixture.json
-   [2021-06-10 17:29:11,461][INFO] Start creating fixture file for test_sh
-   [2021-06-10 17:29:21,252][INFO] Fixture file created to test_sh_fixture.json
-   ```
-
-2. Create a new database.
-   ```
-   $ sortinghat-admin --config sortinghat.config.settings setup
-   ```
-
-4. Load fixture JSON file using Django
-   ```
-   $ python3 manage.py loaddata test_sh_fixture.json --settings= sortinghat.config.settings
-   Installed 148542 object(s) from 1 fixture(s)
-   ```
+Please update your database running the following command:
+```
+$ sortinghat-admin --config sortinghat.config.settings migrate-old-database
+```
 
 ## Running tests
 

--- a/docker/server-entrypoint.sh
+++ b/docker/server-entrypoint.sh
@@ -68,6 +68,9 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+# Migrate SortingHat database from 0.7 to 0.8 if needed
+sortinghat-admin migrate-old-database --no-interactive
+
 # Setup the service if the database doesn't exist
 if ! sortinghat_check_service ; then
     sortinghat-admin setup --no-interactive

--- a/releases/unreleased/migration-command-for-sortinghat-0.7.yml
+++ b/releases/unreleased/migration-command-for-sortinghat-0.7.yml
@@ -1,0 +1,10 @@
+---
+title: Migration command for SortingHat 0.7
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 726
+notes: |
+  Include a new command to migrate SortingHat 0.7 database
+  schema to 0.8. The command can be executed as
+  `sortinghat-admin migrate-old-database`. It will migrate
+  all the data from the old version.

--- a/sortinghat/server/utils/create_sh_0_7_fixture.py
+++ b/sortinghat/server/utils/create_sh_0_7_fixture.py
@@ -78,7 +78,7 @@ ENROLLMENT_MAPPING = {
     "id": "id",
     "start": "start",
     "end": "end",
-    "organization_id": "organization",
+    "organization_id": "group",
     "uuid": "individual"
 }
 
@@ -93,7 +93,7 @@ IDENTITY_MAPPING = {
 }
 
 MATCHING_BLACKLIST_MAPPING = {
-    "excluded": "excluded"
+    "excluded": "term"
 }
 
 ORGANIZATION_MAPPING = {
@@ -134,7 +134,7 @@ TABLE_MAPPING = {
         'mapping': IDENTITY_MAPPING
     },
     "matching_blacklist": {
-        'model': "core.matchingblacklist",
+        'model': "core.recommenderexclusionterm",
         'mapping': MATCHING_BLACKLIST_MAPPING
     },
     "organizations": {
@@ -162,15 +162,28 @@ def main():
     if args.debug_mode:
         logger.setLevel(logging.DEBUG)
 
-    logger.info(f"Start creating fixture file for {args.database}")
+    create_sh_fixture(db_host=args.host,
+                      db_port=args.port,
+                      db_user=args.user,
+                      db_password=args.password,
+                      database=args.database,
+                      output_fh=args.output)
 
-    conn = MySQLdb.connect(args.host, args.user, args.password, args.database)
+
+def create_sh_fixture(db_host, db_port, db_user, db_password, database, output_fh):
+    logger.info(f"Start creating fixture file for {database}")
+
+    conn = MySQLdb.connect(host=db_host,
+                           port=db_port,
+                           user=db_user,
+                           password=db_password,
+                           database=database)
     fixtures = generate_sortinghat_fixtures(conn)
     conn.close()
 
-    write_json(args.output, fixtures)
+    write_json(output_fh, fixtures)
 
-    logger.info(f"Fixture file created to {args.output.name}")
+    logger.info(f"Fixture file created to {output_fh.name}")
 
 
 def parse_args():
@@ -182,6 +195,10 @@ def parse_args():
     parser.add_argument("--host",
                         default="localhost",
                         help="MariaDB/MySQL host (by default = 'localhost')")
+    parser.add_argument("--port",
+                        default=3306,
+                        type=int,
+                        help="MariaDB/MySQL port (by default = 3306)")
     parser.add_argument("-u", "--user",
                         default="root",
                         help="MariaDB/MySQL user (by default = 'root')")


### PR DESCRIPTION
This commits includes a new command in sortinghat-admin command to migrate the old database schema from SortingHat 0.7 to the new 0.8 version.

If the database schema is old, it creates a migration of the data, moves the database to a new database with `_backup`, initializes the database, and restores the data using the new schema.

Closes https://github.com/chaoss/grimoirelab-sortinghat/issues/726