### PR TITLE
[ui] Fix search syntax link

### DIFF
--- a/releases/unreleased/fix-search-syntax-link.yml
+++ b/releases/unreleased/fix-search-syntax-link.yml
@@ -1,0 +1,7 @@
+---
+title: Fix search syntax link
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 735
+notes: |
+  Fixes the link to the search syntax page on the search bar.

--- a/ui/src/components/Search.vue
+++ b/ui/src/components/Search.vue
@@ -46,7 +46,7 @@
               </v-list-item-title>
             </v-list-item>
             <v-divider />
-            <v-list-item href="/search-help" target="_blank">
+            <v-list-item to="/search-help" target="_blank">
               <v-list-item-title>
                 <v-icon small left>mdi-open-in-new</v-icon>
                 View search syntax


### PR DESCRIPTION
This PR changes the link to the search syntax view on the search bar from a plain `href` to use Vue Router's `to` prop, which prepends the base path (`/identities` in production).

Fixes #735.