### PR TITLE
Set node version to 16.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # 3.1.0
       - name: Setup Node ${{ matrix.node-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,7 +62,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
 
     runs-on: ubuntu-latest
     name: Node ${{ matrix.node-version }}
@@ -95,7 +95,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x]
         python-version: [3.7, 3.8]
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pinning node to 16.x ensures GitHub Actions is not going to use node 18 or later.