### PR TITLE
[ci] Do not checkout repository in build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           artifact-name: sortinghat-dist
           artifact-path: dist
+          skip-checkout: yes
 
   tests:
     needs: [build]

--- a/releases/unreleased/static-not-included-in-wheel-package.yml
+++ b/releases/unreleased/static-not-included-in-wheel-package.yml
@@ -1,0 +1,8 @@
+---
+title: Static files not included in wheel package
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  SortingHat static files were not included in the Python
+  package. The problem was in the GitHub action.


### PR DESCRIPTION
This PR disables the checkout step in the build action to include the JS static files built in the action.