### PR TITLE
[ci] Do not checkout repository in docker action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           artifact-name: sortinghat-dist
           artifact-path: dist
+          skip-checkout: yes
 
   build-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR disables the checkout step in the docker build action to include the JS static files in the Python package.