### PR TITLE
[tenants] Fix tenant selection in job context

### DIFF
--- a/releases/unreleased/tenant-selection-in-job-fixed.yml
+++ b/releases/unreleased/tenant-selection-in-job-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Tenant selection in job fixed
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Tenant selection raised an error when the job context was
+  defined as keyword argument.

--- a/sortinghat/core/decorators.py
+++ b/sortinghat/core/decorators.py
@@ -33,6 +33,7 @@ from graphql_jwt.shortcuts import get_user_by_token
 from graphql_jwt.exceptions import JSONWebTokenError
 
 from . import tenant
+from .errors import InvalidValueError
 
 # This custom decorator takes the `user` object from the request's
 # context and checks the value of the `is_authenticated` variable
@@ -80,7 +81,12 @@ def job_using_tenant(func):
     """Use the tenant provided in the context argument for the job"""
     @wraps(func)
     def using_tenant(*args, **kwargs):
-        ctx = kwargs.get('ctx', args[0])
+        ctx = kwargs.get('ctx', None)
+        if not ctx and args:
+            ctx = args[0]
+        if not ctx:
+            raise InvalidValueError(msg="Context not provided to the Job")
+
         tenant.set_db_tenant(ctx.tenant)
         try:
             return func(*args, **kwargs)


### PR DESCRIPTION
This PR fixes an error that was caused when the context of a Job wasn't defined as keyword argument and the tenant was not selected correctly.