### PR TITLE
[jobs] Sort jobs from newest to oldest

### DIFF
--- a/releases/unreleased/sort-jobs-from-newest.yml
+++ b/releases/unreleased/sort-jobs-from-newest.yml
@@ -1,0 +1,8 @@
+---
+title: Sort jobs from newest to oldest
+category: fixed
+author: Eva Millan <evamillan@bitergia.com>
+issue: 769
+notes: >
+  The jobs page now sorts the list from newest to oldest
+  to show running jobs first.

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -115,7 +115,7 @@ def get_jobs(tenant=None):
     if tenant:
         jobs = (job for job in jobs if job_in_tenant(job, tenant))
 
-    sorted_jobs = sorted(jobs, key=lambda x: x.enqueued_at if x.enqueued_at else datetime.datetime.utcnow())
+    sorted_jobs = sorted(jobs, key=lambda x: x.enqueued_at if x.enqueued_at else datetime.datetime.utcnow(), reverse=True)
 
     logger.debug(f"List of jobs retrieved; total jobs: {len(sorted_jobs)};")
 


### PR DESCRIPTION
Sorts the list of jobs from newest to oldest to show running jobs first.