### PR TITLE
Improve SortingHat database performance

### DIFF
--- a/releases/unreleased/sortinghat-database-performance.yml
+++ b/releases/unreleased/sortinghat-database-performance.yml
@@ -1,0 +1,8 @@
+---
+title: SortingHat database performance
+category: performance
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: |
+  Improve SortingHat performance when there are a lot of
+  individuals in the database.

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -567,7 +567,7 @@ class AbstractPaginatedType(graphene.ObjectType):
             has_prev=result.has_previous(),
             start_index=result.start_index(),
             end_index=result.end_index(),
-            total_results=len(query)
+            total_results=paginator.count
         )
 
         return cls(entities=entities, page_info=page_info)


### PR DESCRIPTION
This PR updates the way objects are counted using `query.count()` instead of `len(query)`.

This improves performance by an order of magnitude because objects don't need to be fetched.