### PR TITLE
[unify] Fix unify job performance

### DIFF
--- a/releases/unreleased/performance-improved-for-recommendations-and-merging-jobs.yml
+++ b/releases/unreleased/performance-improved-for-recommendations-and-merging-jobs.yml
@@ -1,0 +1,11 @@
+---
+title: Performance improved for recommendations and merging jobs
+category: performance
+author:
+  - Jose Javier Merchante <jjmerchante@bitergia.com>
+  - Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: |
+  The performance of the matching and merging algorithms that
+  are used on these jobs have been considerably improved.
+  These jobs will be 4 times faster than on the previous version.

--- a/sortinghat/core/recommendations/matching.py
+++ b/sortinghat/core/recommendations/matching.py
@@ -23,6 +23,7 @@
 
 import logging
 import pandas
+import numpy
 
 from collections import defaultdict
 from django.forms.models import model_to_dict
@@ -163,6 +164,7 @@ def _find_matches(set_x, set_y, criteria, exclude, verbose):
     def _to_df(data_set):
         """Convert identities set into a Pandas `Dataframe` object"""
         df = pandas.DataFrame(data_set)
+        df.replace('', numpy.nan, inplace=True)
         return df.sort_values(['individual'])
 
     def _apply_recommender_exclusion_list(df):

--- a/sortinghat/core/recommendations/matching.py
+++ b/sortinghat/core/recommendations/matching.py
@@ -194,6 +194,8 @@ def _find_matches(set_x, set_y, criteria, exclude, verbose):
             group key.
         """
         matches = {}
+        processed = set()
+
         # Group by main keys from Individuals or by uuids from Identities
         col_name = 'uuid_y' if verbose else 'individual_y'
 
@@ -205,13 +207,19 @@ def _find_matches(set_x, set_y, criteria, exclude, verbose):
             for uuid in grouped_uids.get_group(group_key)[col_name]:
                 uuid_set.add(uuid)
 
-            for key in matches:
-                prev_match = matches[key]
-                if prev_match == uuid_set:
-                    continue
-                elif prev_match.intersection(uuid_set):
-                    prev_match.update(uuid_set)
-                    uuid_set = prev_match
+            if processed.intersection(uuid_set):
+                # There are common identities already seen.
+                # Find the common sets
+
+                for key in matches:
+                    prev_match = matches[key]
+                    if prev_match == uuid_set:
+                        continue
+                    elif prev_match.intersection(uuid_set):
+                        prev_match.update(uuid_set)
+                        uuid_set = prev_match
+
+            processed.update(uuid_set)
             matches[group_key] = uuid_set
 
         return matches

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -594,8 +594,8 @@ class TestRecommendMatches(TestCase):
         }
 
         recommendations_expected = {
-            self.john_smith.individual.mk: [self.jsmith.individual.mk, self.js_alt.individual.mk],
-            self.jsmith.individual.mk: [self.js_alt.individual.mk],
+            self.js_alt.individual.mk: [self.jsmith.individual.mk, self.john_smith.individual.mk],
+            self.jsmith.individual.mk: [self.john_smith.individual.mk],
             self.jane_rae.individual.mk: [self.jrae.individual.mk],
             self.jrae.individual.mk: [self.jane_rae.individual.mk]
         }


### PR DESCRIPTION
This PR updates the way unify job fetches all the individuals from the database. Instead of retrieving identities from each individual, fetch all the identities at once.