### PR TITLE
[ui] Fix enrollment in individual's profile

### DIFF
--- a/releases/unreleased/fix-enroll-in-profile.yml
+++ b/releases/unreleased/fix-enroll-in-profile.yml
@@ -1,0 +1,8 @@
+---
+title: Fix enrollment in individual's profile
+category: fixed
+author: Eva Millan <evamillan@bitergia.com>
+issue: null
+notes: >
+  In the individual's profile, the button to add an
+  organization was not working. 

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -253,7 +253,7 @@
                 v-if="individual.enrollments"
                 :enrollments="individual.enrollments"
                 :is-locked="individual.isLocked"
-                @openEnrollmentModal="confirmEnroll"
+                @openEnrollmentModal="confirmEnroll(individual)"
                 @openTeamModal="openTeamModal"
                 @updateEnrollment="updateEnrollment"
                 @withdraw="withdraw"


### PR DESCRIPTION
This PR fixes an issue with the button to add an organization in the individual's profile that was not opening the modal.