### PR TITLE
[ui] Show hiden buttons when the mouse is over the table row

### DIFF
--- a/releases/unreleased/buttons-on-hover.yml
+++ b/releases/unreleased/buttons-on-hover.yml
@@ -1,0 +1,9 @@
+---
+title: Show hidden buttons when the mouse is over the table row
+category: fixed
+author: Eva Millan <evamillan@bitergia.com>
+issue: 787
+notes: >
+  The buttons to lock an individual or mark it as a bot were only
+  visible when the mouse wass over the individual's name, which made it
+  hard to find them. Now they appear when the mouse is over the table row.

--- a/ui/src/components/IndividualEntry.vue
+++ b/ui/src/components/IndividualEntry.vue
@@ -298,32 +298,6 @@ export default {
 }
 tr {
   cursor: pointer;
-}
-::v-deep .v-small-dialog__activator,
-.v-small-dialog {
-  display: inline-block;
-}
-.v-small-dialog__activator {
-  .v-icon {
-    opacity: 0;
-    padding-bottom: 2px;
-  }
-
-  &:hover {
-    .v-icon {
-      opacity: 1;
-    }
-  }
-}
-.v-list-item__title {
-  a {
-    color: rgba(0, 0, 0, 0.87);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
   ::v-deep .icon--hidden {
     opacity: 0;
     padding-bottom: 2px;
@@ -331,6 +305,17 @@ tr {
   &:hover {
     ::v-deep .icon--hidden {
       opacity: 1;
+    }
+  }
+}
+
+.v-list-item__title {
+  a {
+    color: rgba(0, 0, 0, 0.87);
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 }


### PR DESCRIPTION
Makes the buttons to lock an individual or mark it as bot visible when the mouse is over the table row instead of just the name.
Fixes #787.