### PR TITLE
[schema] Match organization's full name in enrollment filter

### DIFF
--- a/releases/unreleased/filter-by-org-full-name.yml
+++ b/releases/unreleased/filter-by-org-full-name.yml
@@ -1,0 +1,10 @@
+---
+title: Enrollment filter on organizations view
+category: fixed
+author: Eva Millan <evamillan@bitergia.com>
+issue: null
+notes: >
+  Filtering individuals by their affiliation to an organization
+  also returned results of organizations that contained that name.
+  The filter now only returns organizations that match the exact
+  name.

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1594,7 +1594,7 @@ class SortingHatQuery:
                                                  .values_list('individual__mk')))
         if filters and 'enrollment' in filters:
             query = query.filter(mk__in=Subquery(Enrollment.objects
-                                                 .filter(group__name__icontains=filters['enrollment'])
+                                                 .filter(group__name=filters['enrollment'])
                                                  .values_list('individual__mk')))
             if 'enrollment_parent_org' in filters:
                 query = query.filter(mk__in=Subquery(Enrollment.objects

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3659,12 +3659,12 @@ class TestQueryIndividuals(django.test.TestCase):
         enrollment = indv['enrollments'][0]
         self.assertEqual(enrollment['group']['name'], 'Bitergia')
 
-        # Test partial organization name match
+        # Test no results for partial organization name match
         executed = client.execute(SH_INDIVIDUALS_ENROLLMENT_FILTER % 'bit',
                                   context_value=self.context_value)
 
         individuals = executed['data']['individuals']['entities']
-        self.assertEqual(len(individuals), 2)
+        self.assertEqual(len(individuals), 0)
 
         # Test organization name with spaces
         executed = client.execute(SH_INDIVIDUALS_ENROLLMENT_FILTER % 'bit company',
@@ -3709,12 +3709,12 @@ class TestQueryIndividuals(django.test.TestCase):
         self.assertEqual(enrollment['group']['name'], 'Team 1')
         self.assertEqual(enrollment['group']['type'], 'team')
 
-        # Test partial team name match
+        # Test no results for partial team name match
         executed = client.execute(SH_INDIVIDUALS_ENROLLMENT_FILTER % 'tea',
                                   context_value=self.context_value)
 
         individuals = executed['data']['individuals']['entities']
-        self.assertEqual(len(individuals), 2)
+        self.assertEqual(len(individuals), 0)
 
         # Test no results for enrollment
         executed = client.execute(SH_INDIVIDUALS_ENROLLMENT_FILTER % 'Organization',


### PR DESCRIPTION
This PR changes the `enrollment` filter of the `individuals` query to only match the organization's full name. This fixes the issue with some organizations showing more members than they actually have.