### PR TITLE
[affiliation] Fix ValueError on email ending in dot

### DIFF
--- a/releases/unreleased/email-affiliation-error.yml
+++ b/releases/unreleased/email-affiliation-error.yml
@@ -1,0 +1,8 @@
+---
+title: Email affiliation error
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 793
+notes: >
+  Fix an error when the email domain ends with
+  a dot, causing the affiliation process to stop.

--- a/sortinghat/core/recommendations/affiliation.py
+++ b/sortinghat/core/recommendations/affiliation.py
@@ -147,4 +147,7 @@ def _find_matching_domain(domain):
             else:
                 result = None
                 keep_looking = False
+        except ValueError:
+            result = None
+            keep_looking = False
     return result

--- a/tests/rec/test_affiliations.py
+++ b/tests/rec/test_affiliations.py
@@ -211,6 +211,24 @@ class TestRecommendAffiliations(TestCase):
         self.assertEqual(rec[0], jdoe.uuid)
         self.assertListEqual(rec[1], [])
 
+    def test_wrong_email(self):
+        """Check if email ending in a dot doesn't raise an exception"""
+
+        ctx = SortingHatContext(self.user)
+
+        wrong_email = api.add_identity(ctx,
+                                       source='unknown',
+                                       email='novalid@example.com.')
+
+        # Test
+        recs = list(recommend_affiliations([wrong_email.uuid]))
+
+        self.assertEqual(len(recs), 1)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], wrong_email.uuid)
+        self.assertListEqual(rec[1], [])
+
     def test_not_found_individual(self):
         """Check if no recommendations are generated when an
         individual does not exist"""


### PR DESCRIPTION
This PR fixes an issue that the affiliation stopped when the identity emails end in a dot.

Fixes https://github.com/chaoss/grimoirelab-sortinghat/issues/793