### PR TITLE
[affiliation] Fix subdomain affiliation when it's not top domain

### DIFF
--- a/releases/unreleased/subdomain-affiliation-error.yml
+++ b/releases/unreleased/subdomain-affiliation-error.yml
@@ -1,0 +1,8 @@
+---
+title: Sub-domain affiliation error
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 805
+notes: |
+  The `affiliate` and `recommend affiliations` jobs no longer recommend
+  matches based on a domain's sub-domains if it is not marked as `top_domain`.

--- a/sortinghat/core/recommendations/affiliation.py
+++ b/sortinghat/core/recommendations/affiliation.py
@@ -133,17 +133,21 @@ def _find_matching_domain(domain):
     """Look for domains and sub-domains that match with the given one."""
 
     keep_looking = True
+    is_subdomain = False
 
     # Splits the domain into root domains until
     # is found in the database.
     while keep_looking:
         try:
             result = find_domain(domain)
+            if is_subdomain and not result.is_top_domain:
+                result = None
             keep_looking = False
         except NotFoundError:
             index = domain.find('.')
             if index > -1:
                 domain = domain[index + 1:]
+                is_subdomain = True
             else:
                 result = None
                 keep_looking = False


### PR DESCRIPTION
This PR prevents the affiliation jobs from matching subdomains if the domain is not marked as `top_domain`.
Fixes #805.