### PR TITLE
UI to manage settings

### DIFF
--- a/releases/unreleased/manage-app-settings.yml
+++ b/releases/unreleased/manage-app-settings.yml
@@ -1,0 +1,9 @@
+---
+title: Manage app settings from the user interface
+category: added
+author: Eva Millan <evamillan@bitergia.com>
+issue: null
+notes: >
+  Users can configure automatic affiliations, profile unification
+  and identity data synchronization from the new `Settings` section
+  on the user interface.

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -8,50 +8,40 @@
       </router-link>
 
       <v-spacer></v-spacer>
-      <v-menu v-if="user && $route.name !== 'Login'" offset-y left>
-        <template v-slot:activator="{ on }">
-          <v-btn depressed small color="primary" v-on="on">
-            <v-icon small left> mdi-account-circle </v-icon>
-            {{ user }}
-            <v-icon small right> mdi-chevron-down </v-icon>
-          </v-btn>
-        </template>
-        <v-list color="primary" dark dense>
-          <v-list-item to="/">
-            <v-list-item-icon class="mr-2">
-              <v-icon small>mdi-view-dashboard-variant</v-icon>
-            </v-list-item-icon>
-            <v-list-item-title>Dashboard</v-list-item-title>
-          </v-list-item>
-          <v-divider />
-          <v-list-item to="/import-identities">
-            <v-list-item-icon class="mr-2">
-              <v-icon small>mdi-account-sync</v-icon>
-            </v-list-item-icon>
-            <v-list-item-title>Import identities</v-list-item-title>
-          </v-list-item>
-          <v-list-item to="/jobs">
-            <v-list-item-icon class="mr-2">
-              <v-icon small>mdi-tray-full</v-icon>
-            </v-list-item-icon>
-            <v-list-item-title>Jobs</v-list-item-title>
-          </v-list-item>
-          <v-divider />
-          <v-list-item to="/change-password">
-            <v-list-item-icon class="mr-2">
-              <v-icon small>mdi-cog-outline</v-icon>
-            </v-list-item-icon>
-            <v-list-item-title>Change password</v-list-item-title>
-          </v-list-item>
-          <v-divider />
-          <v-list-item @click="logOut">
-            <v-list-item-icon class="mr-2">
-              <v-icon small>mdi-logout-variant</v-icon>
-            </v-list-item-icon>
-            <v-list-item-title>Log out</v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-menu>
+      <div v-if="user && $route.name !== 'Login'">
+        <v-btn to="/" depressed small color="primary" class="mr-2">
+          <v-icon small left> mdi-view-dashboard-variant </v-icon>
+          Dashboard
+        </v-btn>
+        <v-btn to="/settings" depressed small color="primary" class="mr-2">
+          <v-icon small left> mdi-cog </v-icon>
+          Settings
+        </v-btn>
+        <v-menu offset-y left>
+          <template v-slot:activator="{ on }">
+            <v-btn depressed small color="primary" v-on="on">
+              <v-icon small left> mdi-account-circle </v-icon>
+              {{ user }}
+              <v-icon small right> mdi-chevron-down </v-icon>
+            </v-btn>
+          </template>
+          <v-list color="primary" dark dense>
+            <v-list-item to="/change-password">
+              <v-list-item-icon class="mr-2">
+                <v-icon small>mdi-form-textbox-password</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Change password</v-list-item-title>
+            </v-list-item>
+            <v-divider />
+            <v-list-item @click="logOut">
+              <v-list-item-icon class="mr-2">
+                <v-icon small>mdi-logout-variant</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Log out</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-menu>
+      </div>
     </v-app-bar>
     <transition name="fade" mode="out-in">
       <router-view />

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -374,6 +374,24 @@ const SCHEDULE_TASK = gql`
   }
 `;
 
+const DELETE_TASK = gql`
+  mutation deleteTask($taskId: Int!) {
+    deleteScheduledTask(taskId: $taskId) {
+      deleted
+    }
+  }
+`;
+
+const UPDATE_TASK = gql`
+  mutation updateTask($taskId: Int!, $data: ScheduledTaskInputType!) {
+    updateScheduledTask(taskId: $taskId, data: $data) {
+      task {
+        id
+      }
+    }
+  }
+`;
+
 const tokenAuth = (apollo, username, password) => {
   const response = apollo.mutate({
     mutation: TOKEN_AUTH,
@@ -676,6 +694,25 @@ const scheduleTask = (apollo, job, interval, params) => {
   });
 };
 
+const deleteTask = (apollo, taskId) => {
+  return apollo.mutate({
+    mutation: DELETE_TASK,
+    variables: {
+      taskId,
+    },
+  });
+};
+
+const updateTask = (apollo, taskId, data) => {
+  return apollo.mutate({
+    mutation: UPDATE_TASK,
+    variables: {
+      taskId,
+      data,
+    },
+  });
+};
+
 export {
   tokenAuth,
   lockIndividual,
@@ -705,4 +742,6 @@ export {
   updateImportTask,
   mergeOrganizations,
   scheduleTask,
+  deleteTask,
+  updateTask,
 };

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -261,6 +261,22 @@ const GET_ORGANIZATION = gql`
   }
 `;
 
+const GET_SCHEDULED_TASKS = gql`
+  query getScheduledTasks($filters: ScheduledTasksFilterType) {
+    scheduledTasks(filters: $filters) {
+      entities {
+        id
+        jobType
+        interval
+        args
+        jobId
+        lastExecution
+        failed
+      }
+    }
+  }
+`;
+
 const getIndividualByUuid = (apollo, uuid) => {
   let response = apollo.query({
     query: GET_INDIVIDUAL_BYUUID,
@@ -417,6 +433,18 @@ const getOrganization = (apollo, name) => {
   });
 };
 
+const getScheduledTasks = (apollo, jobType, backend) => {
+  return apollo.query({
+    query: GET_SCHEDULED_TASKS,
+    variables: {
+      filters: {
+        jobType,
+        backend,
+      },
+    },
+  });
+};
+
 export {
   getCountries,
   getIndividuals,
@@ -431,4 +459,5 @@ export {
   getImporterTypes,
   getImportIdentitiesTasks,
   getOrganization,
+  getScheduledTasks,
 };

--- a/ui/src/components/TasksTable.stories.js
+++ b/ui/src/components/TasksTable.stories.js
@@ -29,12 +29,14 @@ export const Default = () => ({
     },
     tasks: {
       data: {
-        importIdentitiesTask: {
+        scheduledTasks: {
           entities: [
             {
               id: 1,
-              backend: "mailmap",
-              url: "http://test.com",
+              args: {
+                backend_name: "mailmap",
+                url: "http://test.com",
+              },
               interval: 43800,
               lastExecution: "2023-03-14T14:21:10.041445+00:00",
               failed: true,
@@ -44,9 +46,11 @@ export const Default = () => ({
             },
             {
               id: 2,
-              backend: "external plugin",
-              url: "http://test.com",
-              args: JSON.stringify({ token: "XXXX" }),
+              args: {
+                backend_name: "external plugin",
+                url: "http://test.com",
+                token: "XXXX"
+              },
               interval: 0,
               lastExecution: "2023-03-12T11:01:40.041445+00:00",
               failed: false,
@@ -66,8 +70,8 @@ export const Default = () => ({
       return this.tasks;
     },
     deleteTask(id) {
-      this.tasks.data.importIdentitiesTask.entities =
-        this.tasks.data.importIdentitiesTask.entities.filter(
+      this.tasks.data.scheduledTasks.entities =
+        this.tasks.data.scheduledTasks.entities.filter(
           (task) => task.id !== id
         );
       return {

--- a/ui/src/components/TasksTable.vue
+++ b/ui/src/components/TasksTable.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-container class="section jobs mt-6 pa-0">
+  <section class="section">
     <header class="header">
-      <h1 class="title">Import identities</h1>
+      <h1 class="title">Synchronization</h1>
       <v-menu offset-y>
         <template v-slot:activator="{ on }">
           <v-btn color="primary" depressed small v-on="on">
@@ -30,48 +30,37 @@
       indeterminate
       color="primary"
     ></v-progress-linear>
-    <v-simple-table>
+    <v-simple-table v-else>
       <template v-slot:default>
-        <thead v-if="tasks.length > 0">
-          <tr>
-            <th class="text-left">Source</th>
-            <th class="text-left">Last run</th>
-            <th class="text-left">Next run</th>
-            <th class="text-right">Executions</th>
-            <th class="text-right">Failures</th>
-            <th></th>
-          </tr>
-        </thead>
-        <div v-else class="ma-9">
-          <h3 class="text-h6">No scheduled tasks</h3>
+        <div v-if="tasks.length === 0" class="ma-8">
+          <h3 class="text-subtitle-2">No connected sources</h3>
           <p class="text-body-2">
-            You can sync identities from different data sources automatically
-            and periodically.
+            You can sync identities data from different data sources
+            automatically and periodically.
           </p>
         </div>
         <tbody>
           <tr v-for="task in tasks" :key="task.id">
-            <td>
-              <span class="font-weight-medium">
+            <td class="pr-6 py-4 pl-8">
+              <p class="subheader mb-0">
                 {{ task.args.backend_name }}
-              </span>
-            </td>
-            <td>
-              <v-icon
+              </p>
+              <p
                 v-if="task.lastExecution"
-                :color="task.failed ? 'failed' : 'finished'"
-                :aria-label="task.failed ? 'failed' : 'finished'"
-                aria-hidden="false"
-                class="mb-1 mr-1"
-                small
+                class="v-list-item__subtitle text--secondary mb-0"
               >
-                {{ task.failed ? "mdi-alert-circle" : "mdi-check-circle" }}
-              </v-icon>
-              {{ formatDate(task.lastExecution) }}
+                <v-icon
+                  :color="task.failed ? 'failed' : 'finished'"
+                  :aria-label="task.failed ? 'failed' : 'finished'"
+                  aria-hidden="false"
+                  class="mb-1 mr-1"
+                  small
+                >
+                  {{ task.failed ? "mdi-alert" : "mdi-check" }}
+                </v-icon>
+                Last sync {{ formatDate(task.lastExecution) }}
+              </p>
             </td>
-            <td>{{ formatDate(task.scheduledDatetime) }}</td>
-            <td class="text-right">{{ task.executions }}</td>
-            <td class="text-right">{{ task.failures }}</td>
             <td class="text-right pr-8">
               <v-btn
                 class="mr-2"
@@ -109,7 +98,7 @@
       @update:open="modal.isOpen = $event"
       @update:tasks="getTasks()"
     />
-  </v-container>
+  </section>
 </template>
 <script>
 import ImporterModal from "./ImporterModal";
@@ -206,4 +195,7 @@ export default {
 </script>
 <style lang="scss" scoped>
 @import "../styles/index.scss";
+.subheader {
+  line-height: 1.775rem;
+}
 </style>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -33,18 +33,6 @@ const routes = [
     meta: { title: "Search Help - Sorting Hat" },
   },
   {
-    path: "/jobs",
-    name: "Jobs",
-    component: () => import("../views/Jobs"),
-    meta: { title: "Jobs - Sorting Hat" },
-  },
-  {
-    path: "/import-identities",
-    name: "ImportIdentities",
-    component: () => import("../views/ImportIdentities"),
-    meta: { requiresAuth: true, title: "Import identities - Sorting Hat" },
-  },
-  {
     path: "/organization/:name",
     name: "Organization",
     component: () => import("../views/Organization"),
@@ -61,6 +49,16 @@ const routes = [
         path: "general",
         name: "SettingsGeneral",
         component: () => import("../views/SettingsGeneral"),
+      },
+      {
+        path: "sync",
+        name: "SettingsSync",
+        component: () => import("../views/SettingsSync"),
+      },
+      {
+        path: "jobs",
+        name: "SettingsJobs",
+        component: () => import("../views/Jobs"),
       },
     ],
   },

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -50,6 +50,20 @@ const routes = [
     component: () => import("../views/Organization"),
     meta: { requiresAuth: true, title: "Sorting Hat" },
   },
+  {
+    path: "/settings",
+    name: "Settings",
+    redirect: "/settings/general",
+    component: () => import("../views/SettingsLayout"),
+    meta: { requiresAuth: true, title: "Settings - Sorting Hat" },
+    children: [
+      {
+        path: "general",
+        name: "SettingsGeneral",
+        component: () => import("../views/SettingsGeneral"),
+      },
+    ],
+  },
 ];
 
 const router = new Router({

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -1,8 +1,7 @@
 <template>
-  <v-main>
+  <section>
     <jobs-table
       :get-jobs="getJobs"
-      class="mt-md-6"
       @affiliate="affiliate"
       @genderize="genderize"
       @unify="unify"
@@ -12,7 +11,7 @@
     <v-snackbar v-model="snackbar.isOpen" color="error" text>
       {{ snackbar.text }}
     </v-snackbar>
-  </v-main>
+  </section>
 </template>
 
 <script>

--- a/ui/src/views/SettingsGeneral.vue
+++ b/ui/src/views/SettingsGeneral.vue
@@ -1,0 +1,414 @@
+<template>
+  <section class="section">
+    <header class="header">
+      <h1 class="title">General settings</h1>
+    </header>
+    <v-progress-linear v-if="isLoading" color="primary" indeterminate />
+    <v-expansion-panels v-else accordion flat>
+      <v-expansion-panel>
+        <v-expansion-panel-header aria-label="Show advanced configuration">
+          <v-row class="ma-0 px-2">
+            <v-col>
+              <p class="subheader mb-0">
+                Affiliate to organizations automatically
+              </p>
+              <span
+                v-if="tasks.affiliate.lastExecution"
+                class="v-list-item__subtitle text--secondary mt-3"
+              >
+                <v-icon v-if="tasks.affiliate.failed" color="error" left small>
+                  mdi-alert
+                </v-icon>
+                <v-icon v-else color="green" left small> mdi-check </v-icon>
+                Last run {{ formatDate(tasks.affiliate.lastExecution) }}
+              </span>
+            </v-col>
+            <v-col class="d-flex justify-end">
+              <v-switch
+                v-model="tasks.affiliate.isActive"
+                class="mt-0"
+                dense
+                inset
+                hide-details
+                @change="toggleTask('affiliate')"
+                @click.stop
+                @mousedown.prevent
+              >
+                <template v-slot:label>
+                  <label class="d-sr-only"> Affiliate to organizations </label>
+                </template>
+              </v-switch>
+            </v-col>
+          </v-row>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <v-row class="ma-0 pt-4 pl-2">
+            <v-col class="pa-0">
+              <p class="text-subtitle-2">Advanced configuration</p>
+            </v-col>
+          </v-row>
+          <v-form>
+            <v-row class="ma-0 pl-2">
+              <v-col cols="3" class="pa-0">
+                <v-radio-group
+                  v-model="tasks.affiliate.interval"
+                  class="mt-0"
+                  dense
+                >
+                  <template v-slot:label>
+                    <h3 class="subheader text--secondary">Interval</h3>
+                  </template>
+                  <v-radio :value="1440" label="Every day"></v-radio>
+                  <v-radio :value="10080" label="Every week"></v-radio>
+                  <v-radio :value="43800" label="Every month"></v-radio>
+                  <v-radio value="custom" label="Custom"></v-radio>
+                </v-radio-group>
+                <v-text-field
+                  v-model="tasks.affiliate.customInterval"
+                  label="Every"
+                  type="number"
+                  suffix="minutes"
+                  class="ml-8"
+                  dense
+                  hide-details
+                  outlined
+                >
+                </v-text-field>
+              </v-col>
+            </v-row>
+            <v-row v-if="tasks.affiliate.isActive" class="ma-0 pt-8 pl-2">
+              <v-col class="pa-0">
+                <v-btn
+                  color="primary"
+                  depressed
+                  small
+                  @click="updateScheduledTask('affiliate')"
+                >
+                  Update
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-form>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+      <v-expansion-panel>
+        <v-expansion-panel-header aria-label="Show advanced configuration">
+          <v-row class="ma-0 px-2">
+            <v-col>
+              <p class="subheader mb-0">Unify profiles automatically</p>
+              <span v-if="tasks.unify.lastExecution" class="mt-3">
+                <v-icon v-if="tasks.unify.failed" color="error" left small>
+                  mdi-alert
+                </v-icon>
+                <v-icon v-else color="green" left small> mdi-check </v-icon>
+                <span class="v-list-item__subtitle text--secondary">
+                  Last run {{ formatDate(tasks.unify.lastExecution) }}
+                </span>
+              </span>
+            </v-col>
+            <v-col class="d-flex justify-end">
+              <v-switch
+                v-model="tasks.unify.isActive"
+                dense
+                inset
+                hide-details
+                class="mt-0"
+                @change="toggleTask('unify')"
+                @click.stop
+                @mousedown.prevent
+              >
+                <template v-slot:label>
+                  <label class="d-sr-only">Unify profiles automatically</label>
+                </template>
+              </v-switch>
+            </v-col>
+          </v-row>
+        </v-expansion-panel-header>
+        <v-expansion-panel-content>
+          <v-row class="ma-0 pt-4 pl-2">
+            <v-col class="pa-0">
+              <p class="text-subtitle-2">Advanced configuration</p>
+            </v-col>
+          </v-row>
+          <v-form>
+            <v-row class="ma-0 pl-2">
+              <v-col class="pa-0 mb-3">
+                <v-checkbox
+                  v-model="tasks.unify.params.exclude"
+                  label="Exclude individuals in RecommenderExclusionTerm list"
+                  dense
+                  hide-details
+                />
+              </v-col>
+            </v-row>
+            <v-row class="ma-0 pl-2">
+              <v-col cols="3" class="pa-0 mb-2">
+                <h3 class="subheader text--secondary">
+                  Unify profiles based on their
+                </h3>
+                <v-checkbox
+                  v-model="tasks.unify.params.criteria"
+                  label="Name"
+                  value="name"
+                  dense
+                  hide-details
+                />
+                <v-checkbox
+                  v-model="tasks.unify.params.criteria"
+                  label="Email"
+                  value="email"
+                  dense
+                  hide-details
+                />
+                <v-checkbox
+                  v-model="tasks.unify.params.criteria"
+                  label="Username"
+                  value="username"
+                  dense
+                  hide-details
+                />
+              </v-col>
+            </v-row>
+            <v-row class="ma-0 pl-2">
+              <v-col cols="3" class="pa-0">
+                <v-radio-group
+                  v-model="tasks.unify.interval"
+                  class="mt-0"
+                  dense
+                >
+                  <template v-slot:label>
+                    <h3 class="subheader text--secondary">Interval</h3>
+                  </template>
+                  <v-radio :value="1440" label="Every day"></v-radio>
+                  <v-radio :value="10080" label="Every week"></v-radio>
+                  <v-radio :value="43800" label="Every month"></v-radio>
+                  <v-radio value="custom" label="Custom"></v-radio>
+                </v-radio-group>
+                <v-text-field
+                  v-model="tasks.unify.customInterval"
+                  label="Every"
+                  type="number"
+                  suffix="minutes"
+                  class="ml-8"
+                  dense
+                  hide-details
+                  outlined
+                >
+                </v-text-field>
+              </v-col>
+            </v-row>
+            <v-row v-if="tasks.unify.isActive" class="ma-0 pt-8 pl-2">
+              <v-col class="pa-0">
+                <v-btn
+                  color="primary"
+                  depressed
+                  small
+                  @click="updateScheduledTask('unify')"
+                >
+                  Update
+                </v-btn>
+              </v-col>
+            </v-row>
+          </v-form>
+        </v-expansion-panel-content>
+      </v-expansion-panel>
+    </v-expansion-panels>
+    <v-snackbar
+      v-model="snackbar.isActive"
+      :color="snackbar.color"
+      timeout="4000"
+      text
+    >
+      {{ snackbar.text }}
+    </v-snackbar>
+  </section>
+</template>
+<script>
+import { getScheduledTasks } from "../apollo/queries";
+import { scheduleTask, deleteTask, updateTask } from "../apollo/mutations";
+
+export default {
+  name: "SettingsGeneral",
+  data() {
+    return {
+      isLoading: true,
+      tasks: {
+        affiliate: {
+          isActive: false,
+          interval: 10080,
+          customInterval: "",
+          failed: false,
+          lastExecution: null,
+          id: null,
+          params: {},
+        },
+        unify: {
+          isActive: false,
+          interval: 10080,
+          failed: false,
+          lastExecution: null,
+          id: null,
+          params: {
+            criteria: ["name", "email", "username"],
+            exclude: true,
+          },
+        },
+      },
+      snackbar: {
+        isActive: false,
+        text: "",
+        color: "success",
+      },
+    };
+  },
+  methods: {
+    async fetchScheduledTasks() {
+      this.isLoading = true;
+
+      const query = await getScheduledTasks(this.$apollo);
+      const tasks = query.data.scheduledTasks.entities;
+      const affiliateTask = tasks.find((task) => task.jobType === "affiliate");
+      const unifyTask = tasks.find((task) => task.jobType === "unify");
+
+      if (affiliateTask) {
+        this.buildForm(affiliateTask);
+      }
+      if (unifyTask) {
+        this.buildForm(unifyTask);
+      }
+      this.isLoading = false;
+    },
+    buildForm(task) {
+      const intervals = [1440, 10080, 43800];
+      const interval = intervals.find((interval) => interval === task.interval)
+        ? task.interval
+        : "custom";
+
+      Object.assign(this.tasks[task.jobType], {
+        isActive: true,
+        interval: interval,
+        failed: task.failed,
+        lastExecution: task.lastExecution,
+        id: task.id,
+        customInterval: task.interval,
+        params: task.args,
+      });
+    },
+    formatDate(dateTime) {
+      return new Date(dateTime).toLocaleString();
+    },
+    toggleTask(job) {
+      if (this.tasks[job].isActive) {
+        this.createTask(job);
+      } else {
+        this.deleteScheduledTask(job);
+      }
+    },
+    async createTask(job) {
+      const interval =
+        this.tasks[job].interval === "custom"
+          ? this.tasks[job].customInterval
+          : this.tasks[job].interval;
+      const task = await scheduleTask(
+        this.$apollo,
+        job,
+        interval,
+        JSON.stringify(this.tasks[job].params)
+      ).catch((error) => {
+        this.openSnackbar(error);
+        this.tasks[job].isActive = false;
+      });
+
+      Object.assign(this.tasks[job], {
+        isActive: true,
+        id: task.data.scheduleTask.task.id,
+        lastExecution: task.data.scheduleTask.task.lastExecution,
+        failed: task.data.scheduleTask.task.failed,
+      });
+      this.openSnackbar();
+    },
+    async deleteScheduledTask(job) {
+      const response = await deleteTask(this.$apollo, this.tasks[job].id).catch(
+        (error) => this.openSnackbar(error)
+      );
+
+      if (response.data.deleteScheduledTask.deleted) {
+        Object.assign(this.tasks[job], {
+          isActive: false,
+          id: null,
+          lastExecution: null,
+          failed: null,
+        });
+        this.openSnackbar();
+      }
+    },
+    async updateScheduledTask(job) {
+      const interval =
+        this.tasks[job].interval === "custom"
+          ? this.tasks[job].customInterval
+          : this.tasks[job].interval;
+      const data = {
+        interval: interval,
+        params: JSON.stringify(this.tasks[job].params),
+      };
+
+      await updateTask(this.$apollo, this.tasks[job].id, data).catch((error) =>
+        this.openSnackbar(error)
+      );
+      this.openSnackbar();
+    },
+    openSnackbar(error) {
+      const text = error
+        ? `Error saving settings: ${this.$getErrorMessage(error)}`
+        : `Changes saved successfully`;
+
+      Object.assign(this.snackbar, {
+        isActive: true,
+        text: text,
+        color: error ? "error" : "success",
+      });
+    },
+  },
+  async mounted() {
+    await this.fetchScheduledTasks();
+  },
+};
+</script>
+<style lang="scss" scoped>
+.v-expansion-panel::after {
+  border-top: thin solid;
+}
+
+.v-expansion-panel--active > .v-expansion-panel-header {
+  min-height: unset;
+}
+
+.v-expansion-panel-header {
+  align-items: flex-start;
+
+  &:hover {
+    background-color: #f6f6f6;
+  }
+
+  .col {
+    padding: 0;
+  }
+}
+
+::v-deep .v-expansion-panel-header__icon {
+  margin-top: 4px;
+}
+
+.v-expansion-panel-content {
+  border-top: thin solid rgba(0, 0, 0, 0.08);
+}
+
+::v-deep .v-label,
+::v-deep .v-text-field__suffix {
+  font-size: 0.875rem;
+}
+
+.subheader {
+  line-height: 1.775rem;
+}
+</style>

--- a/ui/src/views/SettingsLayout.vue
+++ b/ui/src/views/SettingsLayout.vue
@@ -17,6 +17,24 @@
               <v-list-item-title>General</v-list-item-title>
             </v-list-item-content>
           </v-list-item>
+          <v-list-item
+            :to="{ name: 'SettingsSync' }"
+            active-class="primary--text white"
+            link
+          >
+            <v-list-item-content>
+              <v-list-item-title>Synchronization</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+          <v-list-item
+            :to="{ name: 'SettingsJobs' }"
+            active-class="primary--text white"
+            link
+          >
+            <v-list-item-content>
+              <v-list-item-title>Jobs</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
         </v-list>
       </v-navigation-drawer>
       <v-container class="pa-0 pr-6">

--- a/ui/src/views/SettingsLayout.vue
+++ b/ui/src/views/SettingsLayout.vue
@@ -1,0 +1,41 @@
+<template>
+  <v-main>
+    <div class="d-flex pa-8">
+      <v-navigation-drawer width="300" color="transparent" floating permanent>
+        <v-list class="pr-6 pt-0" dense nav>
+          <v-list-item-content class="pt-0">
+            <v-list-item-title class="text-subtitle-1 font-weight-medium">
+              Settings
+            </v-list-item-title>
+          </v-list-item-content>
+          <v-list-item
+            :to="{ name: 'SettingsGeneral' }"
+            active-class="primary--text white"
+            link
+          >
+            <v-list-item-content>
+              <v-list-item-title>General</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-navigation-drawer>
+      <v-container class="pa-0 pr-6">
+        <transition name="fade" mode="out-in">
+          <router-view />
+        </transition>
+      </v-container>
+    </div>
+  </v-main>
+</template>
+<script>
+export default {
+  name: "SettingLayout",
+};
+</script>
+<style lang="scss" scoped>
+@media (min-width: 1904px) {
+  .container {
+    max-width: 1185px;
+  }
+}
+</style>

--- a/ui/src/views/SettingsSync.vue
+++ b/ui/src/views/SettingsSync.vue
@@ -1,13 +1,11 @@
 <template>
-  <v-main>
-    <tasks-table
-      :fetch-backends="fetchBackends"
-      :fetch-tasks="fetchTasks"
-      :create-task="createTask"
-      :delete-task="deleteTask"
-      :edit-task="editTask"
-    />
-  </v-main>
+  <tasks-table
+    :fetch-backends="fetchBackends"
+    :fetch-tasks="fetchTasks"
+    :create-task="createTask"
+    :delete-task="deleteTask"
+    :edit-task="editTask"
+  />
 </template>
 <script>
 import {
@@ -22,7 +20,7 @@ import {
 import TasksTable from "./../components/TasksTable";
 
 export default {
-  name: "ImportIdentities",
+  name: "SettingsSync",
   components: { TasksTable },
   methods: {
     async fetchBackends() {
@@ -48,8 +46,3 @@ export default {
   },
 };
 </script>
-<style lang="scss" scoped>
-.container {
-  max-width: 1160px;
-}
-</style>

--- a/ui/tests/unit/__snapshots__/mutations.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/mutations.spec.js.snap
@@ -1789,11 +1789,8 @@ exports[`IndividualsTable Mock query for withdraw 1`] = `
 `;
 
 exports[`Jobs Mock mutation for affiliate 1`] = `
-<v-main-stub
-  tag="main"
->
+<section>
   <jobs-table-stub
-    class="mt-md-6"
     getjobs="[Function]"
   />
    
@@ -1810,15 +1807,12 @@ exports[`Jobs Mock mutation for affiliate 1`] = `
     TypeError: this.$refs.table.getPaginatedJobs is not a function
   
   </v-snackbar-stub>
-</v-main-stub>
+</section>
 `;
 
 exports[`Jobs Mock mutation for genderize 1`] = `
-<v-main-stub
-  tag="main"
->
+<section>
   <jobs-table-stub
-    class="mt-md-6"
     getjobs="[Function]"
   />
    
@@ -1835,15 +1829,12 @@ exports[`Jobs Mock mutation for genderize 1`] = `
     TypeError: this.$refs.table.getPaginatedJobs is not a function
   
   </v-snackbar-stub>
-</v-main-stub>
+</section>
 `;
 
 exports[`Jobs Mock mutation for unify 1`] = `
-<v-main-stub
-  tag="main"
->
+<section>
   <jobs-table-stub
-    class="mt-md-6"
     getjobs="[Function]"
   />
    
@@ -1860,7 +1851,7 @@ exports[`Jobs Mock mutation for unify 1`] = `
     TypeError: this.$refs.table.getPaginatedJobs is not a function
   
   </v-snackbar-stub>
-</v-main-stub>
+</section>
 `;
 
 exports[`Login Mock mutation for tokenAuth 1`] = `

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -11659,8 +11659,8 @@ exports[`Storyshots TasksTable Default 1`] = `
   <div
     class="v-application--wrap"
   >
-    <div
-      class="container section jobs mt-6 pa-0"
+    <section
+      class="section"
     >
       <header
         class="header"
@@ -11668,7 +11668,7 @@ exports[`Storyshots TasksTable Default 1`] = `
         <h1
           class="title"
         >
-          Import identities
+          Synchronization
         </h1>
          
         <div
@@ -11697,8 +11697,6 @@ exports[`Storyshots TasksTable Default 1`] = `
        
       <!---->
        
-      <!---->
-       
       <div
         class="v-data-table theme--light"
       >
@@ -11707,20 +11705,20 @@ exports[`Storyshots TasksTable Default 1`] = `
         >
           <table>
             <div
-              class="ma-9"
+              class="ma-8"
             >
               <h3
-                class="text-h6"
+                class="text-subtitle-2"
               >
-                No scheduled tasks
+                No connected sources
               </h3>
                
               <p
                 class="text-body-2"
               >
                 
-          You can sync identities from different data sources automatically
-          and periodically.
+          You can sync identities data from different data sources
+          automatically and periodically.
         
               </p>
             </div>
@@ -11731,7 +11729,7 @@ exports[`Storyshots TasksTable Default 1`] = `
       </div>
        
       <!---->
-    </div>
+    </section>
   </div>
 </div>
 `;
@@ -11745,8 +11743,8 @@ exports[`Storyshots TasksTable Empty 1`] = `
   <div
     class="v-application--wrap"
   >
-    <div
-      class="container section jobs mt-6 pa-0"
+    <section
+      class="section"
     >
       <header
         class="header"
@@ -11754,7 +11752,7 @@ exports[`Storyshots TasksTable Empty 1`] = `
         <h1
           class="title"
         >
-          Import identities
+          Synchronization
         </h1>
          
         <div
@@ -11783,8 +11781,6 @@ exports[`Storyshots TasksTable Empty 1`] = `
        
       <!---->
        
-      <!---->
-       
       <div
         class="v-data-table theme--light"
       >
@@ -11793,20 +11789,20 @@ exports[`Storyshots TasksTable Empty 1`] = `
         >
           <table>
             <div
-              class="ma-9"
+              class="ma-8"
             >
               <h3
-                class="text-h6"
+                class="text-subtitle-2"
               >
-                No scheduled tasks
+                No connected sources
               </h3>
                
               <p
                 class="text-body-2"
               >
                 
-          You can sync identities from different data sources automatically
-          and periodically.
+          You can sync identities data from different data sources
+          automatically and periodically.
         
               </p>
             </div>
@@ -11817,7 +11813,7 @@ exports[`Storyshots TasksTable Empty 1`] = `
       </div>
        
       <!---->
-    </div>
+    </section>
   </div>
 </div>
 `;
@@ -12532,7 +12528,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   />
                   <input
                     aria-checked="false"
-                    id="input-1987"
+                    id="input-1997"
                     role="checkbox"
                     type="checkbox"
                     value=""
@@ -12543,7 +12539,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 </div>
                 <label
                   class="v-label theme--light"
-                  for="input-1987"
+                  for="input-1997"
                   style="left: 0px; position: relative;"
                 >
                   Select all
@@ -12631,13 +12627,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1992"
+                      for="input-2002"
                       style="left: 0px; position: absolute;"
                     >
                       Search
                     </label>
                     <input
-                      id="input-1992"
+                      id="input-2002"
                       type="text"
                     />
                   </div>
@@ -12700,7 +12696,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                 <div
                   aria-expanded="false"
                   aria-haspopup="listbox"
-                  aria-owns="list-1999"
+                  aria-owns="list-2009"
                   class="v-input__slot"
                   role="button"
                 >
@@ -12720,7 +12716,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label theme--light"
-                      for="input-1999"
+                      for="input-2009"
                       style="left: 0px; position: absolute;"
                     >
                       Order by
@@ -12731,7 +12727,7 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                       <input
                         aria-readonly="false"
                         autocomplete="off"
-                        id="input-1999"
+                        id="input-2009"
                         readonly="readonly"
                         type="text"
                       />
@@ -12958,13 +12954,13 @@ exports[`Storyshots WorkSpace Drag And Drop 1`] = `
                   >
                     <label
                       class="v-label v-label--active theme--light"
-                      for="input-2021"
+                      for="input-2031"
                       style="left: 0px; position: absolute;"
                     >
                       Items per page
                     </label>
                     <input
-                      id="input-2021"
+                      id="input-2031"
                       max="0"
                       min="1"
                       type="number"


### PR DESCRIPTION
This PR adds a `Settings` section where users can manage the `affiliate` and `unify` tasks. `Import identities` and `jobs` are also moved to this section .