### PR TITLE
Delete scheduled tasks with no job due to Redis connection error

### DIFF
--- a/releases/unreleased/api-method-to-create-task.yml
+++ b/releases/unreleased/api-method-to-create-task.yml
@@ -1,0 +1,8 @@
+---
+title: API method to create a scheduled task 
+category: added
+author: Eva Millan <evamillan@bitergia.com>
+issue: null
+notes: >
+  The `add_scheduled_task` API method adds a new scheduled
+  task to the registry.

--- a/releases/unreleased/delete-task-on-error.yml
+++ b/releases/unreleased/delete-task-on-error.yml
@@ -1,0 +1,11 @@
+---
+title: Remove tasks that fail to be scheduled
+category: fixed
+author: Eva Millan <evamillan@bitergia.com>
+issue: null
+notes: >
+  When there was an issue with the Redis connection when
+  a task was created, the task was added to the database
+  but there was not scheduled job linked to it. Tasks are 
+  now removed from the database and an error is raised in
+  this case.


### PR DESCRIPTION
This PR adds an API function to create scheduled tasks and fixes the issue with the tasks that have no enqueued job due to a Redis connection error when they are created.