### PR TITLE
Strict criteria for merge recommendations

### DIFF
--- a/releases/unreleased/strict-criteria.yml
+++ b/releases/unreleased/strict-criteria.yml
@@ -1,0 +1,10 @@
+---
+title: Strict criteria for merge recommendations
+category: added
+author: Eva Millan <evamillan@bitergia.com>
+issue: 812
+notes: >
+  The merge recommendations filter out invalid email adresses
+  and names that don't have at least a first and last name 
+  when looking for matches. To disable this behavior, set the
+  `strict` parameter on `recommendMatches` or `unify` to `false`.

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -196,7 +196,7 @@ def recommend_affiliations(ctx, uuids=None):
 
 @django_rq.job
 @job_using_tenant
-def recommend_matches(ctx, source_uuids, target_uuids, criteria, exclude=True, verbose=False):
+def recommend_matches(ctx, source_uuids, target_uuids, criteria, exclude=True, verbose=False, strict=True):
     """Generate a list of affiliation recommendations from a set of individuals.
 
     This function generates a list of recommendations which include the
@@ -243,7 +243,7 @@ def recommend_matches(ctx, source_uuids, target_uuids, criteria, exclude=True, v
 
     trxl = TransactionsLog.open('recommend_matches', job_ctx)
 
-    for rec in engine.recommend('matches', source_uuids, target_uuids, criteria, exclude, verbose):
+    for rec in engine.recommend('matches', source_uuids, target_uuids, criteria, exclude, verbose, strict):
         results[rec.key] = list(rec.options)
         # Store matches in the database
         for match in rec.options:
@@ -401,7 +401,7 @@ def affiliate(ctx, uuids=None):
 
 @django_rq.job
 @job_using_tenant
-def unify(ctx, criteria, source_uuids=None, target_uuids=None, exclude=True):
+def unify(ctx, criteria, source_uuids=None, target_uuids=None, exclude=True, strict=True):
     """Unify a set of individuals by merging them using matching recommendations.
 
     This function automates the identities unify process obtaining
@@ -471,7 +471,7 @@ def unify(ctx, criteria, source_uuids=None, target_uuids=None, exclude=True):
     trxl = TransactionsLog.open('unify', job_ctx)
 
     match_recs = {}
-    for rec in engine.recommend('matches', source_uuids, target_uuids, criteria, exclude=exclude):
+    for rec in engine.recommend('matches', source_uuids, target_uuids, criteria, exclude=exclude, strict=strict):
         match_recs[rec.key] = list(rec.options)
 
     match_groups = _group_recommendations(match_recs)

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1073,17 +1073,18 @@ class RecommendMatches(graphene.Mutation):
         criteria = graphene.List(graphene.String)
         verbose = graphene.Boolean(required=False)
         exclude = graphene.Boolean(required=False)
+        strict = graphene.Boolean(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
 
     @check_permissions('core.execute_job')
     @check_auth
-    def mutate(self, info, criteria, source_uuids=None, target_uuids=None, exclude=True, verbose=False):
+    def mutate(self, info, criteria, source_uuids=None, target_uuids=None, exclude=True, verbose=False, strict=True):
         user = info.context.user
         tenant = get_db_tenant()
         ctx = SortingHatContext(user=user, tenant=tenant)
 
-        job = enqueue(recommend_matches, ctx, source_uuids, target_uuids, criteria, exclude, verbose, job_timeout=-1)
+        job = enqueue(recommend_matches, ctx, source_uuids, target_uuids, criteria, exclude, verbose, strict, job_timeout=-1)
 
         return RecommendMatches(
             job_id=job.id
@@ -1141,17 +1142,18 @@ class Unify(graphene.Mutation):
                                      required=False)
         criteria = graphene.List(graphene.String)
         exclude = graphene.Boolean(required=False)
+        strict = graphene.Boolean(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
 
     @check_permissions('core.execute_job')
     @check_auth
-    def mutate(self, info, criteria, source_uuids=None, target_uuids=None, exclude=True):
+    def mutate(self, info, criteria, source_uuids=None, target_uuids=None, exclude=True, strict=True):
         user = info.context.user
         tenant = get_db_tenant()
         ctx = SortingHatContext(user=user, tenant=tenant)
 
-        job = enqueue(unify, ctx, criteria, source_uuids, target_uuids, exclude, job_timeout=-1)
+        job = enqueue(unify, ctx, criteria, source_uuids, target_uuids, exclude, strict, job_timeout=-1)
 
         return Unify(
             job_id=job.id

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -286,8 +286,8 @@ const GENDERIZE = gql`
 `;
 
 const UNIFY = gql`
-  mutation unify($criteria: [String], $exclude: Boolean) {
-    unify(criteria: $criteria, exclude: $exclude) {
+  mutation unify($criteria: [String], $exclude: Boolean, $strict: Boolean) {
+    unify(criteria: $criteria, exclude: $exclude, strict: $strict) {
       jobId
     }
   }
@@ -309,11 +309,13 @@ const RECOMMEND_MATCHES = gql`
     $criteria: [String]
     $exclude: Boolean
     $sourceUuids: [String]
+    $strict: Boolean
   ) {
     recommendMatches(
       criteria: $criteria
       exclude: $exclude
       sourceUuids: $sourceUuids
+      strict: $strict
     ) {
       jobId
     }
@@ -614,12 +616,13 @@ const genderize = (apollo, exclude, noStrictMatching, uuids) => {
   });
 };
 
-const unify = (apollo, criteria, exclude) => {
+const unify = (apollo, criteria, exclude, strict) => {
   return apollo.mutate({
     mutation: UNIFY,
     variables: {
       criteria: criteria,
       exclude: exclude,
+      strict: strict,
     },
   });
 };
@@ -634,13 +637,14 @@ const manageMergeRecommendation = (apollo, id, apply) => {
   });
 };
 
-const recommendMatches = (apollo, criteria, exclude, sourceUuids) => {
+const recommendMatches = (apollo, criteria, exclude, strict, sourceUuids) => {
   return apollo.mutate({
     mutation: RECOMMEND_MATCHES,
     variables: {
       criteria: criteria,
       exclude: exclude,
       sourceUuids: sourceUuids,
+      strict: strict,
     },
   });
 };

--- a/ui/src/components/JobModal.vue
+++ b/ui/src/components/JobModal.vue
@@ -56,6 +56,12 @@
               outlined
             />
             <v-checkbox
+              v-model="forms.unify.strict"
+              label="Exclude individuals with invalid email adresses and names"
+              id="unify_strict"
+              hide-details
+            />
+            <v-checkbox
               v-model="forms.unify.exclude"
               label="Exclude individuals in RecommenderExclusionTerm list"
               id="unify_exclude"
@@ -73,6 +79,12 @@
               hide-details
               multiple
               outlined
+            />
+            <v-checkbox
+              v-model="forms.recommendMatches.strict"
+              label="Exclude individuals with invalid email adresses and names"
+              id="recommend_strict"
+              hide-details
             />
             <v-checkbox
               v-model="forms.recommendMatches.exclude"
@@ -132,10 +144,12 @@ const defaultForms = {
   unify: {
     criteria: ["name", "email", "username"],
     exclude: true,
+    strict: true,
   },
   recommendMatches: {
     criteria: ["name", "email", "username"],
     exclude: true,
+    strict: true,
   },
 };
 

--- a/ui/src/components/MatchesModal.vue
+++ b/ui/src/components/MatchesModal.vue
@@ -41,6 +41,12 @@
         <v-divider></v-divider>
         <div class="my-4">
           <v-checkbox
+            v-model="form.strict"
+            label="Strict matching criteria"
+            dense
+            hide-details
+          />
+          <v-checkbox
             v-model="form.exclude"
             label="Exclude individuals in RecommenderExclusionTerm list"
             dense
@@ -87,6 +93,7 @@ export default {
       form: {
         criteria: ["name", "email", "username"],
         exclude: true,
+        strict: true,
       },
       jobId: null,
       error: null,
@@ -98,6 +105,7 @@ export default {
       this.form = {
         criteria: ["name", "email", "username"],
         exclude: true,
+        strict: true,
       };
       this.error = null;
       this.jobId = null;
@@ -107,6 +115,7 @@ export default {
         const response = await this.recommendMatches(
           this.form.criteria,
           this.form.exclude,
+          this.form.strict,
           [this.uuid]
         );
         this.jobId = response.data.recommendMatches.jobId;

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -674,11 +674,12 @@ export default {
         this.$logger.error(`Error applying recommendation ${id}: ${error}`);
       }
     },
-    async recommendMatches(criteria, exclude, uuid) {
+    async recommendMatches(criteria, exclude, strict, uuid) {
       const response = await recommendMatches(
         this.$apollo,
         criteria,
         exclude,
+        strict,
         uuid
       );
       return response;

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -62,9 +62,9 @@ export default {
         });
       }
     },
-    async unify({ criteria, exclude }) {
+    async unify({ criteria, exclude, strict }) {
       try {
-        await unify(this.$apollo, criteria, exclude);
+        await unify(this.$apollo, criteria, exclude, strict);
         this.$refs.table.getPaginatedJobs();
       } catch (error) {
         this.snackbar = Object.assign(this.snackbar, {
@@ -73,9 +73,9 @@ export default {
         });
       }
     },
-    async recommendMatches({ criteria, exclude }) {
+    async recommendMatches({ criteria, exclude, strict }) {
       try {
-        await recommendMatches(this.$apollo, criteria, exclude);
+        await recommendMatches(this.$apollo, criteria, exclude, strict);
         this.$refs.table.getPaginatedJobs();
       } catch (error) {
         this.snackbar = Object.assign(this.snackbar, {

--- a/ui/src/views/SettingsGeneral.vue
+++ b/ui/src/views/SettingsGeneral.vue
@@ -139,6 +139,12 @@
                   dense
                   hide-details
                 />
+                <v-checkbox
+                  v-model="tasks.unify.params.strict"
+                  label="Exclude individuals with invalid email adresses and names"
+                  dense
+                  hide-details
+                />
               </v-col>
             </v-row>
             <v-row class="ma-0 pl-2">
@@ -251,6 +257,7 @@ export default {
           params: {
             criteria: ["name", "email", "username"],
             exclude: true,
+            strict: true,
           },
         },
       },


### PR DESCRIPTION
This PR adds the `strict` parameter to the merge recommendations, which evaluates if the individual's names and emails are valid when looking for matches. This is enabled by default.
Fixes #812.