### PR TITLE
Cache individuals queries to avoid reloading the table

### DIFF
--- a/releases/unreleased/cache-individuals-table-data.yml
+++ b/releases/unreleased/cache-individuals-table-data.yml
@@ -1,0 +1,14 @@
+---
+title: Cache individuals table data
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 821
+notes: >
+  Using cached queries prevents the table from
+  refetching all the data from the server everytime
+  any information is edited. This is particularly
+  helpful if there is a huge number of identities,
+  where reloading the table is very slow.
+  However, there are some cases when the queries
+  need to be refetched, eg. when identities are
+  merged or split.

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -14,10 +14,11 @@ const LOCK_INDIVIDUAL = gql`
     lock(uuid: $uuid) {
       uuid
       individual {
-        isLocked
+        ...individual
       }
     }
   }
+  ${FULL_INDIVIDUAL}
 `;
 
 const UNLOCK_INDIVIDUAL = gql`
@@ -25,10 +26,11 @@ const UNLOCK_INDIVIDUAL = gql`
     unlock(uuid: $uuid) {
       uuid
       individual {
-        isLocked
+        ...individual
       }
     }
   }
+  ${FULL_INDIVIDUAL}
 `;
 
 const DELETE_IDENTITY = gql`
@@ -411,6 +413,14 @@ const lockIndividual = (apollo, uuid) => {
     variables: {
       uuid: uuid,
     },
+    update: (cache) => {
+      // TODO: Use cache.evict() on Apollo v3
+      if (cache) {
+        Object.keys(cache.data.data || {})
+          .filter((name) => name.includes("lastModified"))
+          .forEach((name) => cache.data.delete(name));
+      }
+    },
   });
   return response;
 };
@@ -420,6 +430,13 @@ const unlockIndividual = (apollo, uuid) => {
     mutation: UNLOCK_INDIVIDUAL,
     variables: {
       uuid: uuid,
+    },
+    update: (cache) => {
+      if (cache) {
+        Object.keys(cache.data.data || {})
+          .filter((name) => name.includes("lastModified"))
+          .forEach((name) => cache.data.delete(name));
+      }
     },
   });
   return response;
@@ -431,6 +448,7 @@ const deleteIdentity = (apollo, uuid) => {
     variables: {
       uuid: uuid,
     },
+    update: (cache) => cache.reset(),
   });
   return response;
 };
@@ -442,6 +460,7 @@ const merge = (apollo, fromUuids, toUuid) => {
       fromUuids: fromUuids,
       toUuid: toUuid,
     },
+    update: (cache) => cache.reset(),
   });
   return response;
 };
@@ -452,6 +471,7 @@ const unmerge = (apollo, uuids) => {
     variables: {
       uuids: uuids,
     },
+    update: (cache) => cache.reset(),
   });
   return response;
 };
@@ -463,6 +483,7 @@ const moveIdentity = (apollo, fromUuid, toUuid) => {
       fromUuid: fromUuid,
       toUuid: toUuid,
     },
+    update: (cache) => cache.reset(),
   });
   return response;
 };
@@ -477,6 +498,15 @@ const enroll = (apollo, uuid, group, fromDate, toDate, parentOrg) => {
       toDate: toDate,
       parentOrg: parentOrg,
     },
+    update: (cache) => {
+      if (cache) {
+        Object.keys(cache.data.data || {})
+          .filter(
+            (name) => name.includes(group) || name.includes("lastModified")
+          )
+          .forEach((name) => cache.data.delete(name));
+      }
+    },
   });
   return response;
 };
@@ -490,6 +520,7 @@ const addIdentity = (apollo, email, name, source, username) => {
       source: source,
       username: username,
     },
+    update: (cache) => cache.reset(),
   });
   return response;
 };
@@ -500,6 +531,13 @@ const updateProfile = (apollo, data, uuid) => {
     variables: {
       data: data,
       uuid: uuid,
+    },
+    update: (cache) => {
+      if (cache) {
+        Object.keys(cache.data.data || {})
+          .filter((name) => name.includes("lastModified"))
+          .forEach((name) => cache.data.delete(name));
+      }
     },
   });
   return response;
@@ -557,6 +595,15 @@ const withdraw = (apollo, uuid, group, fromDate, toDate, parentOrg) => {
       toDate: toDate,
       parentOrg: parentOrg,
     },
+    update: (cache) => {
+      if (cache) {
+        Object.keys(cache.data.data || {})
+          .filter(
+            (name) => name.includes(group) || name.includes("lastModified")
+          )
+          .forEach((name) => cache.data.delete(name));
+      }
+    },
   });
   return response;
 };
@@ -591,6 +638,13 @@ const updateEnrollment = (apollo, data) => {
       toDate: data.toDate,
       uuid: data.uuid,
       parentOrg: data.parentOrg,
+    },
+    update: (cache) => {
+      if (cache) {
+        Object.keys(cache.data.data || {})
+          .filter((name) => name.includes("lastModified"))
+          .forEach((name) => cache.data.delete(name));
+      }
     },
   });
   return response;
@@ -634,6 +688,7 @@ const manageMergeRecommendation = (apollo, id, apply) => {
       recommendationId: id,
       apply: apply,
     },
+    update: (cache) => cache.reset(),
   });
 };
 

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -283,7 +283,7 @@ const getIndividualByUuid = (apollo, uuid) => {
     variables: {
       uuid: uuid,
     },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-first",
   });
   return response;
 };
@@ -328,7 +328,7 @@ const getPaginatedIndividuals = (
       filters: filters,
       orderBy: orderBy,
     },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-first",
   });
   return response;
 };

--- a/ui/src/main.js
+++ b/ui/src/main.js
@@ -7,7 +7,7 @@ import VueApollo from "vue-apollo";
 import VueRouter from "vue-router";
 import { ApolloClient } from "apollo-client";
 import { createHttpLink } from "apollo-link-http";
-import { InMemoryCache } from "apollo-cache-inmemory";
+import { InMemoryCache, defaultDataIdFromObject } from "apollo-cache-inmemory";
 import Cookies from "js-cookie";
 import { ApolloLink } from "apollo-link";
 import Logger from "./plugins/logger";
@@ -26,7 +26,20 @@ fetch(API_URL, { credentials: "include" }).then(() => {
   });
 
   // Cache implementation
-  const cache = new InMemoryCache();
+  // Specify object IDs so Apollo can update the cache automatically
+  // https://www.apollographql.com/docs/react/v2/caching/cache-configuration/#custom-identifiers
+  const cache = new InMemoryCache({
+    dataIdFromObject: (object) => {
+      switch (object.__typename) {
+        case "IndividualType":
+          return object.mk;
+        case "IdentityType":
+          return object.uuid;
+        default:
+          return defaultDataIdFromObject(object);
+      }
+    },
+  });
 
   const AuthLink = (operation, next) => {
     const token = csrftoken;


### PR DESCRIPTION
This PR sets the fetch policy of the individuals queries to `cache-first`. When a mutation changes the data of a cached query, Apollo uses the returned data to update the cache automatically, so no refetching is needed. Apollo can't update the queries if items are added or removed from a list, so after a merge, unmerge, create or delete, or if the query was sorted by `lastModified` or was filtered by an organization that was added or removed from the individual, the queries need to be refetched.
Fixes #821 