### PR TITLE
[ui] Fix uninitialized workspace

### DIFF
--- a/releases/unreleased/fix-individual-page-not-loadingd.yml
+++ b/releases/unreleased/fix-individual-page-not-loadingd.yml
@@ -1,0 +1,9 @@
+---
+title: Fix individual page not loading
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  The individual's view was not loading when the
+  workspace had not been used before or the cache
+  was cleared.

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -9,7 +9,7 @@ export default new Vuex.Store({
   state: {
     token: Cookies.get("sh_authtoken"),
     user: Cookies.get("sh_user"),
-    workspace: JSON.parse(localStorage.getItem("sh_workspace")),
+    workspace: JSON.parse(localStorage.getItem("sh_workspace")) || [],
   },
   mutations: {
     setToken(state, token) {

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -484,7 +484,7 @@ export default {
     },
     isInWorkspace() {
       const workspace = this.$store.getters.workspace;
-      return workspace.indexOf(this.mk) !== -1;
+      return workspace && workspace.indexOf(this.mk) !== -1;
     },
   },
   methods: {


### PR DESCRIPTION
This PR fixes the issue with the individual's page not loading. It initializes the workspace as an empty array if there is not one saved on the local storage. The individual's view also checks if the workspace exists before checking for the individual to prevent the view from not loading if there is no workspace.