### PR TITLE
[affiliation] Improve performance of affiliation jobs

### DIFF
--- a/releases/unreleased/performance-on-affiliation-recommendations-improved.yml
+++ b/releases/unreleased/performance-on-affiliation-recommendations-improved.yml
@@ -1,0 +1,9 @@
+---
+title: Performance on affiliation recommendations improved
+category: performance
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  We have improved the affiliation performance by
+  one order of magnitude removing unnecessary queries
+  to the database.


### PR DESCRIPTION
The current algorithm was running unnecessary calls to 'find_individual_by_uuid' when the generic affiliation job was called. In other words, when the list of individuals to affiliate was all the individuals in the database.
To improve it, we have followed the same approach we did with the matching recommendations. We get the full list of individuals with a direct query using Django's API.