### PR TITLE
[ui] Move date picker to the side of the input

### DIFF
--- a/releases/unreleased/open-calendar-to-the-side-of-the-date-input.yml
+++ b/releases/unreleased/open-calendar-to-the-side-of-the-date-input.yml
@@ -1,0 +1,9 @@
+---
+title: Open calendar to the side of the date input
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 838
+notes: >
+  The date picker calendar that is used to edit affiliation
+  dates now opens to the right side of the text field to avoid
+  covering it.

--- a/ui/src/components/DateInput.vue
+++ b/ui/src/components/DateInput.vue
@@ -1,10 +1,11 @@
 <template>
   <v-menu
     v-model="openPicker"
+    v-bind="$attrs"
     :close-on-content-click="false"
     transition="scale-transition"
     min-width="290px"
-    nudge-bottom="60"
+    offset-x
     right
   >
     <template v-slot:activator="{ on }">

--- a/ui/src/components/EnrollmentList.vue
+++ b/ui/src/components/EnrollmentList.vue
@@ -85,6 +85,8 @@
                 <date-input
                   v-model="enrollment.form.fromDate"
                   label="Date from"
+                  nudge-top="20"
+                  nudge-right="10"
                   :max="enrollment.end"
                 />
               </v-card-text>
@@ -144,6 +146,8 @@
                   v-model="enrollment.form.toDate"
                   :min="enrollment.start"
                   label="Date to"
+                  nudge-top="20"
+                  nudge-right="10"
                 />
               </v-card-text>
               <v-card-actions class="pt-0">


### PR DESCRIPTION
This PR changes the position of the affiliation date calendar to open on the right side of the date input to avoid covering it.
Fixes #838

![image](https://github.com/chaoss/grimoirelab-sortinghat/assets/26812577/2cd312f8-7c22-4e6a-b771-a2ee5de6f626)
