### PR TITLE
Option to match individuals with the same source

### DIFF
--- a/releases/unreleased/unify-identities-with-same-source.yml
+++ b/releases/unreleased/unify-identities-with-same-source.yml
@@ -1,0 +1,9 @@
+---
+title: Unify identities with same source
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include a new option to only recommend or unify identities
+  from trusted sources like GitHub or GitLab that have the same
+  username and backend.

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1075,6 +1075,7 @@ class RecommendMatches(graphene.Mutation):
         verbose = graphene.Boolean(required=False)
         exclude = graphene.Boolean(required=False)
         strict = graphene.Boolean(required=False)
+        match_source = graphene.Boolean(required=False)
         last_modified = graphene.DateTime(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
@@ -1084,7 +1085,7 @@ class RecommendMatches(graphene.Mutation):
     def mutate(self, info, criteria,
                source_uuids=None, target_uuids=None,
                exclude=True, verbose=False, strict=True,
-               last_modified=MIN_PERIOD_DATE):
+               match_source=False, last_modified=MIN_PERIOD_DATE):
         user = info.context.user
         tenant = get_db_tenant()
         ctx = SortingHatContext(user=user, tenant=tenant)
@@ -1097,6 +1098,7 @@ class RecommendMatches(graphene.Mutation):
                       exclude,
                       verbose,
                       strict,
+                      match_source,
                       last_modified,
                       job_timeout=-1)
 
@@ -1158,6 +1160,7 @@ class Unify(graphene.Mutation):
         criteria = graphene.List(graphene.String)
         exclude = graphene.Boolean(required=False)
         strict = graphene.Boolean(required=False)
+        match_source = graphene.Boolean(required=False)
         last_modified = graphene.DateTime(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
@@ -1167,12 +1170,22 @@ class Unify(graphene.Mutation):
     def mutate(self, info, criteria,
                source_uuids=None, target_uuids=None,
                exclude=True, strict=True,
+               match_source=False,
                last_modified=MIN_PERIOD_DATE):
         user = info.context.user
         tenant = get_db_tenant()
         ctx = SortingHatContext(user=user, tenant=tenant)
 
-        job = enqueue(unify, ctx, criteria, source_uuids, target_uuids, exclude, strict, last_modified, job_timeout=-1)
+        job = enqueue(unify,
+                      ctx,
+                      criteria,
+                      source_uuids,
+                      target_uuids,
+                      exclude,
+                      strict,
+                      match_source,
+                      last_modified,
+                      job_timeout=-1)
 
         return Unify(
             job_id=job.id

--- a/tests/rec/test_matches.py
+++ b/tests/rec/test_matches.py
@@ -402,3 +402,101 @@ class TestRecommendMatches(TestCase):
         self.assertEqual(rec[0], '1234567890abcdefg')
         self.assertEqual(rec[1], '1234567890abcdefg')
         self.assertEqual(rec[2], [])
+
+    def test_recommend_match_source(self):
+        """Test if recommendations are created between same identities with same source"""
+
+        jr3 = api.add_identity(self.ctx,
+                               name='J. Rae',
+                               username='jane_rae',
+                               source='github',
+                               uuid=self.jane_rae.uuid)
+        jrae_github = api.add_identity(self.ctx,
+                                       name='Jane Rae',
+                                       username='jane_rae',
+                                       source='github')
+
+        source_uuids = [self.john_smith.uuid, self.jrae_no_name.uuid, self.jr2.uuid]
+        target_uuids = [self.john_smith.uuid, self.js2.uuid, self.js3.uuid,
+                        self.js4.uuid,
+                        self.jsmith.uuid, self.jsm2.uuid, self.jsm3.uuid,
+                        self.jane_rae.uuid, self.jr2.uuid,
+                        self.js_alt.uuid, self.js_alt2.uuid,
+                        self.js_alt3.uuid, self.js_alt4.uuid,
+                        self.jrae.uuid, self.jrae2.uuid,
+                        self.jrae_no_name.uuid, self.jsmith_no_email.uuid,
+                        jrae_github]
+
+        criteria = ['email', 'name', 'username']
+
+        # Recommend identities which match the fields in `criteria` for the same `source`
+        recs = list(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria,
+                                      match_source=True))
+
+        self.assertEqual(len(recs), 3)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], self.john_smith.uuid)
+        self.assertEqual(rec[1], self.john_smith.individual.mk)
+        self.assertEqual(rec[2], [])
+
+        rec = recs[1]
+        self.assertEqual(rec[0], self.jrae_no_name.uuid)
+        self.assertEqual(rec[1], self.jrae_no_name.individual.mk)
+        self.assertEqual(rec[2], [])
+
+        rec = recs[2]
+        self.assertEqual(rec[0], self.jr2.uuid)
+        self.assertEqual(rec[1], self.jr2.individual.mk)
+        self.assertEqual(rec[2], sorted([jrae_github.individual.mk]))
+
+    def test_recommend_same_source_not_trusted(self):
+        """Matches are not created for ids with same source but not github or gitlab"""
+
+        jr3 = api.add_identity(self.ctx,
+                               name='J. Rae',
+                               username='jane_rae',
+                               source='git',
+                               uuid=self.jane_rae.uuid)
+        jrae_git = api.add_identity(self.ctx,
+                                    name='Jane Rae',
+                                    username='jane_rae',
+                                    source='git')
+
+        source_uuids = [self.john_smith.uuid, self.jrae_no_name.uuid, self.jr2.uuid]
+        target_uuids = [self.john_smith.uuid, self.js2.uuid, self.js3.uuid,
+                        self.js4.uuid,
+                        self.jsmith.uuid, self.jsm2.uuid, self.jsm3.uuid,
+                        self.jane_rae.uuid, self.jr2.uuid,
+                        self.js_alt.uuid, self.js_alt2.uuid,
+                        self.js_alt3.uuid, self.js_alt4.uuid,
+                        self.jrae.uuid, self.jrae2.uuid,
+                        self.jrae_no_name.uuid, self.jsmith_no_email.uuid,
+                        jrae_git]
+
+        criteria = ['email', 'name', 'username']
+
+        # Recommend identities which match the fields in `criteria` for the same `source`
+        recs = list(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria,
+                                      match_source=True))
+
+        self.assertEqual(len(recs), 3)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], self.john_smith.uuid)
+        self.assertEqual(rec[1], self.john_smith.individual.mk)
+        self.assertEqual(rec[2], [])
+
+        rec = recs[1]
+        self.assertEqual(rec[0], self.jrae_no_name.uuid)
+        self.assertEqual(rec[1], self.jrae_no_name.individual.mk)
+        self.assertEqual(rec[2], [])
+
+        rec = recs[2]
+        self.assertEqual(rec[0], self.jr2.uuid)
+        self.assertEqual(rec[1], self.jr2.individual.mk)
+        self.assertEqual(rec[2], [])

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -288,8 +288,18 @@ const GENDERIZE = gql`
 `;
 
 const UNIFY = gql`
-  mutation unify($criteria: [String], $exclude: Boolean, $strict: Boolean) {
-    unify(criteria: $criteria, exclude: $exclude, strict: $strict) {
+  mutation unify(
+    $criteria: [String]
+    $exclude: Boolean
+    $strict: Boolean
+    $matchSource: Boolean
+  ) {
+    unify(
+      criteria: $criteria
+      exclude: $exclude
+      strict: $strict
+      matchSource: $matchSource
+    ) {
       jobId
     }
   }
@@ -312,12 +322,14 @@ const RECOMMEND_MATCHES = gql`
     $exclude: Boolean
     $sourceUuids: [String]
     $strict: Boolean
+    $matchSource: Boolean
   ) {
     recommendMatches(
       criteria: $criteria
       exclude: $exclude
       sourceUuids: $sourceUuids
       strict: $strict
+      matchSource: $matchSource
     ) {
       jobId
     }
@@ -670,13 +682,14 @@ const genderize = (apollo, exclude, noStrictMatching, uuids) => {
   });
 };
 
-const unify = (apollo, criteria, exclude, strict) => {
+const unify = (apollo, criteria, exclude, strict, matchSource) => {
   return apollo.mutate({
     mutation: UNIFY,
     variables: {
       criteria: criteria,
       exclude: exclude,
       strict: strict,
+      matchSource: matchSource,
     },
   });
 };
@@ -692,7 +705,14 @@ const manageMergeRecommendation = (apollo, id, apply) => {
   });
 };
 
-const recommendMatches = (apollo, criteria, exclude, strict, sourceUuids) => {
+const recommendMatches = (
+  apollo,
+  criteria,
+  exclude,
+  strict,
+  sourceUuids,
+  matchSource
+) => {
   return apollo.mutate({
     mutation: RECOMMEND_MATCHES,
     variables: {
@@ -700,6 +720,7 @@ const recommendMatches = (apollo, criteria, exclude, strict, sourceUuids) => {
       exclude: exclude,
       sourceUuids: sourceUuids,
       strict: strict,
+      matchSource: matchSource,
     },
   });
 };

--- a/ui/src/components/JobModal.vue
+++ b/ui/src/components/JobModal.vue
@@ -54,7 +54,13 @@
               />
               <v-checkbox
                 v-model="forms.unify.strict"
-                label="Exclude individuals with invalid email adresses and names"
+                label="Exclude individuals with invalid email addresses and names"
+                dense
+                hide-details
+              />
+              <v-checkbox
+                v-model="forms.unify.matchSource"
+                label="Only unify identities that share the same source"
                 dense
                 hide-details
               />
@@ -103,6 +109,12 @@
               <v-checkbox
                 v-model="forms.recommendMatches.strict"
                 label="Exclude individuals with invalid email adresses and names"
+                dense
+                hide-details
+              />
+              <v-checkbox
+                v-model="forms.recommendMatches.matchSource"
+                label="Only recommend identities that share the same source"
                 dense
                 hide-details
               />
@@ -191,11 +203,13 @@ const defaultForms = {
     criteria: ["name", "email", "username"],
     exclude: true,
     strict: true,
+    matchSource: false,
   },
   recommendMatches: {
     criteria: ["name", "email", "username"],
     exclude: true,
     strict: true,
+    matchSource: false,
   },
 };
 

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -62,9 +62,9 @@ export default {
         });
       }
     },
-    async unify({ criteria, exclude, strict }) {
+    async unify({ criteria, exclude, strict, matchSource }) {
       try {
-        await unify(this.$apollo, criteria, exclude, strict);
+        await unify(this.$apollo, criteria, exclude, strict, matchSource);
         this.$refs.table.getPaginatedJobs();
       } catch (error) {
         this.snackbar = Object.assign(this.snackbar, {
@@ -73,9 +73,15 @@ export default {
         });
       }
     },
-    async recommendMatches({ criteria, exclude, strict }) {
+    async recommendMatches({ criteria, exclude, strict, matchSource }) {
       try {
-        await recommendMatches(this.$apollo, criteria, exclude, strict);
+        await recommendMatches(
+          this.$apollo,
+          criteria,
+          exclude,
+          strict,
+          matchSource
+        );
         this.$refs.table.getPaginatedJobs();
       } catch (error) {
         this.snackbar = Object.assign(this.snackbar, {

--- a/ui/src/views/SettingsGeneral.vue
+++ b/ui/src/views/SettingsGeneral.vue
@@ -141,7 +141,13 @@
                 />
                 <v-checkbox
                   v-model="tasks.unify.params.strict"
-                  label="Exclude individuals with invalid email adresses and names"
+                  label="Exclude individuals with invalid email addresses and names"
+                  dense
+                  hide-details
+                />
+                <v-checkbox
+                  v-model="tasks.unify.params.match_source"
+                  label="Only unify identities that share the same source"
                   dense
                   hide-details
                 />
@@ -258,6 +264,7 @@ export default {
             criteria: ["name", "email", "username"],
             exclude: true,
             strict: true,
+            match_source: false,
           },
         },
       },


### PR DESCRIPTION
This PR includes a new option to unify and recommend identities that share the defined criteria (name, username, email) and the source.

The option is called `match_source` when creating the job.