### PR TITLE
Fix CSRF token header usage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,9 +148,8 @@ jobs:
         uses: cypress-io/github-action@v5
         with:
           install: false
-          start: yarn serve --api_url=http://localhost:8000/api/
-          command: yarn test:e2e --config baseUrl=http://localhost:8080
-          wait-on: 'http://localhost:8080, http://localhost:8000/api/'
+          command: yarn test:e2e --config baseUrl=http://localhost:8000
+          wait-on: 'http://localhost:8000/api/'
           spec: tests/e2e/specs/*.js
           working-directory: ./ui
         env:

--- a/README.md
+++ b/README.md
@@ -124,11 +124,16 @@ $ cd ui/
 $ yarn install
 ```
 
-#### Running the frontend
+#### Running the frontend on development mode
 
-Run SortingHat frontend Vue app:
+Run SortingHat backend Django app:
 ```
-$ yarn serve --api_url=http://localhost:8000/api/
+(.venv)$ ./manage.py runserver --settings=config.settings.devel
+```
+
+Build the frontend and watch for changes:
+```
+$ yarn watch --api_url=http://localhost:8000/api/ --publicpath="/static/" --mode development
 ```
 
 

--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -89,9 +89,8 @@ SECRET_KEY = 'fake-key'
 STATICFILES_DIRS = [
     "./sortinghat/core/static",
 ]
-STATIC_ROOT = "/tmp/static/"
 
-STATIC_URL = '/'
+STATIC_URL = '/static/'
 
 MEDIA_URL = 'http://media.example.com/'
 

--- a/releases/unreleased/csrf-token-only-required-from-ui.yml
+++ b/releases/unreleased/csrf-token-only-required-from-ui.yml
@@ -1,0 +1,11 @@
+---
+title: CSRF token is only required on web requests
+category: fixed
+author: Eva Millán <evamillan@bitergia
+issue: null
+notes: >
+  The GraphQL API required the 'X-CSRFToken' header, but the
+  token could only be retrieved by making a GET request.
+  Now, requests authenticated using JWT don't need to provide the
+  CSRF token and only the user interface, which is vulnerable
+  to CSRF attacks and uses a different authentication, requires it.

--- a/sortinghat/app/urls.py
+++ b/sortinghat/app/urls.py
@@ -4,12 +4,13 @@
 from django.conf import settings
 from django.urls import path, re_path
 from django.views.generic import TemplateView
+from django.views.decorators.csrf import csrf_exempt
 from sortinghat.core.views import (SortingHatGraphQLView, change_password, api_login)
 
 from .schema import schema
 
 urlpatterns = [
-    path('api/', SortingHatGraphQLView.as_view(graphiql=settings.DEBUG, schema=schema)),
+    path('api/', csrf_exempt(SortingHatGraphQLView.as_view(graphiql=settings.DEBUG, schema=schema))),
     path('api/login/', api_login, name='api_login'),
     path('password_change/', change_password, name='password_change'),
     re_path(r'^(?!static).*$', TemplateView.as_view(template_name="index.html"))

--- a/sortinghat/app/urls.py
+++ b/sortinghat/app/urls.py
@@ -4,13 +4,13 @@
 from django.conf import settings
 from django.urls import path, re_path
 from django.views.generic import TemplateView
-
-from sortinghat.core.views import (SortingHatGraphQLView, change_password)
+from sortinghat.core.views import (SortingHatGraphQLView, change_password, api_login)
 
 from .schema import schema
 
 urlpatterns = [
     path('api/', SortingHatGraphQLView.as_view(graphiql=settings.DEBUG, schema=schema)),
+    path('api/login/', api_login, name='api_login'),
     path('password_change/', change_password, name='password_change'),
     re_path(r'^(?!static).*$', TemplateView.as_view(template_name="index.html"))
 ]

--- a/sortinghat/cli/client/client.py
+++ b/sortinghat/cli/client/client.py
@@ -107,17 +107,7 @@ class SortingHatClient:
         session = requests.Session()
         session.verify = self.verify_ssl
 
-        try:
-            result = session.get(self.url, headers={'Accept': 'text/html'})
-            result.raise_for_status()
-        except requests.exceptions.RequestException as exc:
-            if result.status_code != 400:
-                msg = "Connection error; cause: {}".format(exc)
-                raise SortingHatClientError(msg)
-
         headers = {
-            'X-CSRFToken': result.cookies['csrftoken'],
-            'Cookie': 'csrftoken=' + result.cookies['csrftoken'],
             'Host': f"{self.host}:{self.port}" if self.port else self.host,
             'Referer': self.url
         }

--- a/sortinghat/core/views.py
+++ b/sortinghat/core/views.py
@@ -36,8 +36,6 @@ from .errors import (CODE_TOKEN_EXPIRED,
                      CODE_INVALID_CREDENTIALS,
                      CODE_UNKNOWN_ERROR)
 
-from .decorators import jwt_login_required
-
 
 class SortingHatGraphQLView(BaseGraphQLView):
     """Base GraphQL view for SortingHat server."""
@@ -69,7 +67,7 @@ class SortingHatGraphQLView(BaseGraphQLView):
         return formatted_error
 
 
-@jwt_login_required
+@login_required
 def change_password(request):
     if request.method == 'POST':
         form = PasswordChangeForm(request.user, request.POST)

--- a/sortinghat/core/views.py
+++ b/sortinghat/core/views.py
@@ -20,8 +20,11 @@
 #
 
 import json
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseForbidden, JsonResponse
+from django.contrib.auth import authenticate, login
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordChangeForm
+from django.views.decorators.http import require_POST
 
 from graphene_django.views import GraphQLView as BaseGraphQLView
 from graphql_jwt.exceptions import (PermissionDenied,
@@ -86,3 +89,30 @@ def change_password(request):
                                 content_type='application/json')
     else:
         return HttpResponse(status=405)
+
+
+@require_POST
+def api_login(request):
+    data = json.loads(request.body)
+    username = data.get('username')
+    password = data.get('password')
+
+    if username is None or password is None:
+        return JsonResponse({'detail': 'Please provide username and password.'},
+                            status=400)
+
+    user = authenticate(username=username, password=password)
+
+    if user is None:
+        response = {
+            'errors': 'Invalid credentials.'
+        }
+        return HttpResponseForbidden(json.dumps(response),
+                                     content_type='application/json')
+    else:
+        login(request, user)
+        response = {
+            'user': username,
+            'isAdmin': user.is_superuser
+        }
+        return JsonResponse(response)

--- a/ui/cypress.config.js
+++ b/ui/cypress.config.js
@@ -9,5 +9,9 @@ module.exports = defineConfig({
     specPattern: "tests/e2e/specs/**/*.cy.{js,jsx,ts,tsx}",
     supportFile: "tests/e2e/support/index.js",
     video: false,
+    retries: {
+      runMode: 2,
+      openMode: 0,
+    },
   },
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,8 @@
     "test:e2e": "cypress run --e2e",
     "lint": "vue-cli-service lint",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "watch": "vue-cli-service build --watch"
   },
   "dependencies": {
     "apollo-cache-inmemory": "^1.6.6",

--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -12,6 +12,7 @@
     <noscript>
       <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
     </noscript>
+    {% csrf_token %}
     <div id="app"></div>
     <!-- built files will be auto injected -->
   </body>

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -60,12 +60,10 @@ export default {
   },
   methods: {
     logOut() {
-      Cookies.remove("sh_authtoken");
+      this.$logger.info(`Log out user ${this.user}`);
       Cookies.remove("sh_user");
-      this.$store.commit("setToken", undefined);
       this.$store.commit("loginUser", undefined);
       this.$router.push("/login");
-      this.$logger.info(`Log out user ${this.user}`);
     },
   },
   watch: {

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -60,7 +60,6 @@ export default {
     async submit() {
       try {
         const authDetails = {
-          apollo: this.$apollo,
           username: this.username,
           password: this.password,
         };

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -2,7 +2,7 @@ var path = require("path");
 const { argv } = require("yargs");
 
 module.exports = {
-  publicPath: process.env.NODE_ENV === "production" ? "/identities/" : "/",
+  publicPath: argv.publicpath ? argv.publicpath : process.env.NODE_ENV === "production" ? "/identities/" : "/",
   outputDir: path.resolve(__dirname, "../sortinghat/", "core", "static"),
   indexPath: path.resolve(
     __dirname,


### PR DESCRIPTION
This PR changes how the CSRF token header is used. API calls using the JWT authorization header don't need the CSRF token. The token is only required on requests that are made from the UI, which now uses a new endpoint at `/api/login` to authenticate users instead of JWT. Django sets a `csrftoken` cookie when the interface is loaded and a `sessionid` cookie for authenticated users that is not available to JavaScript and includes it automatically in all requests.
Since the UI needs to be served by Django to get the token, to run it for development use `yarn watch` instead of `yarn serve`, which watches for changes and rebuilds the static files, and serve it with `./manage.py runserver `, which collects the files automatically.