### PR TITLE
Select most recent affiliation as main organization

### DIFF
--- a/releases/unreleased/display-individuals-most-recent-organization.yml
+++ b/releases/unreleased/display-individuals-most-recent-organization.yml
@@ -1,0 +1,8 @@
+---
+title: Display individual's most recent organization
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  The individual's current affiliation is now the most
+  recent one instead of the oldest.

--- a/ui/src/components/IndividualCard.vue
+++ b/ui/src/components/IndividualCard.vue
@@ -30,8 +30,8 @@
             <span @click.stop>{{ name || email }}</span>
           </router-link>
         </v-list-item-title>
-        <v-list-item-subtitle v-if="enrollments && enrollments.length > 0">
-          {{ enrollments[0].group.name }}
+        <v-list-item-subtitle v-if="organization">
+          {{ organization }}
         </v-list-item-subtitle>
         <v-list-item-subtitle>
           <v-tooltip
@@ -144,6 +144,16 @@ export default {
     return {
       isDragging: false,
     };
+  },
+  computed: {
+    organization() {
+      if (this.enrollments && this.enrollments.length > 0) {
+        return this.enrollments.findLast(
+          (enrollment) => !enrollment.group.parentOrg
+        ).group.name;
+      }
+      return null;
+    },
   },
   methods: {
     selectSourceIcon(source) {

--- a/ui/src/utils/actions.js
+++ b/ui/src/utils/actions.js
@@ -104,7 +104,9 @@ const formatIndividual = (individual) => {
   };
 
   if (individual.enrollments && individual.enrollments.length > 0) {
-    const organization = individual.enrollments[0].group.name;
+    const organization = individual.enrollments.findLast(
+      (enrollment) => !enrollment.group.parentOrg
+    ).group.name;
     Object.assign(formattedIndividual, { organization: organization });
   }
   if (individual.matchRecommendationSet) {

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -4153,7 +4153,7 @@ exports[`Storyshots IndividualCard Organization 1`] = `
             class="v-list-item__subtitle"
           >
             
-        Slytherin
+        Hogwarts School of Witchcraft and Wizardry
       
           </div>
            
@@ -4669,7 +4669,7 @@ exports[`Storyshots IndividualCard Sources And Organization 1`] = `
             class="v-list-item__subtitle"
           >
             
-        Slytherin
+        Hogwarts School of Witchcraft and Wizardry
       
           </div>
            
@@ -12206,7 +12206,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   class="v-list-item__subtitle"
                 >
                   
-        Slytherin
+        Hogwarts School of Witchcraft and Wizardry
       
                 </div>
                  
@@ -12340,7 +12340,7 @@ exports[`Storyshots WorkSpace Default 1`] = `
                   class="v-list-item__subtitle"
                 >
                   
-        Griffyndor
+        Hogwarts School of Witchcraft and Wizardry
       
                 </div>
                  


### PR DESCRIPTION
This PR changes the organization displayed under the individual's name to be the latest affiliated one instead of the oldest.