### PR TITLE
[ui] Fix API URLs to login and change password

### DIFF
--- a/releases/unreleased/fix-api-url-to-change-password.yml
+++ b/releases/unreleased/fix-api-url-to-change-password.yml
@@ -1,0 +1,8 @@
+---
+title: Use correct base URL for login and change password API calls
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 851
+notes: >
+  The URLs called to login and change password now use the public
+  path found in vue.config.js if no API URL is specified.

--- a/ui/src/store/index.js
+++ b/ui/src/store/index.js
@@ -25,13 +25,14 @@ export default new Vuex.Store({
   actions: {
     async login({ commit }, { username, password }) {
       const csrftoken = Cookies.get("csrftoken");
-      let url = "/api/login/";
+      const pathname = "/api/login/";
+      let origin = process.env.BASE_URL.replace(/\/$/, "");
 
       if (process.env.VUE_APP_API_URL) {
-        const origin = new URL(process.env.VUE_APP_API_URL).origin;
-        url = `${origin}${url}`;
+        origin = new URL(process.env.VUE_APP_API_URL).origin.replace(/\/$/, "");
       }
 
+      const url = `${origin}${pathname}`;
       const response = await fetch(url, {
         method: "POST",
         credentials: "include",

--- a/ui/src/views/ChangePassword.vue
+++ b/ui/src/views/ChangePassword.vue
@@ -85,14 +85,13 @@ export default {
   computed: {
     url() {
       const pathname = "/password_change/";
+      let origin = process.env.BASE_URL.replace(/\/$/, "");
 
       if (process.env.VUE_APP_API_URL) {
-        const origin = new URL(process.env.VUE_APP_API_URL).origin;
-
-        return `${origin}${pathname}`;
-      } else {
-        return pathname;
+        origin = new URL(process.env.VUE_APP_API_URL).origin.replace(/\/$/, "");
       }
+
+      return `${origin}${pathname}`;
     },
     headers() {
       const csrftoken = Cookies.get("csrftoken");


### PR DESCRIPTION
This PR changes the login and change password URLs to use the public path as a base if no API URL was specified, eg. `/identities/` in production.
Fixes #851.