### PR TITLE
Fix missing 'django_sessions' table when using tenants

### DIFF
--- a/releases/unreleased/create-django_sessions-table.yml
+++ b/releases/unreleased/create-django_sessions-table.yml
@@ -1,0 +1,14 @@
+---
+title: Fix "Table 'django_session' doesn't exist" error
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  Fixes the "Table 'django_session' doesn't exist" error
+  for new installs.
+  For existing databases, run the following commands to
+  create the table:
+  ```
+  django-admin migrate --fake sessions zero
+  django-admin migrate
+  ```

--- a/sortinghat/core/middleware.py
+++ b/sortinghat/core/middleware.py
@@ -78,7 +78,7 @@ class TenantDatabaseRouter:
     that is set for every request using a middleware.
     """
 
-    auth_app_labels = {'auth', 'contenttypes', 'admin'}
+    auth_app_labels = {'auth', 'contenttypes', 'admin', 'sessions'}
 
     def db_for_read(self, model, **hints):
         if model._meta.app_label in self.auth_app_labels:


### PR DESCRIPTION
Adds the `sessions` app to the tenant database router to create the `django_sessions` table on the default database to fix the `Table 'django_session' doesn't exist` error. For existing databases, run the following commands to create the table:
  ```
  django-admin migrate --fake sessions zero
  django-admin migrate
  ```