### PR TITLE
[jobs] Define dedicated queues for tenants

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,13 @@ or affiliation. To start a worker run the command:
 $ sortinghatw --config sortinghat.config.settings
 ```
 
+To start a worker that processes jobs from a set of tenants when
+`dedicated_queue` is active (see [below](#multi-tenancy))
+use the next command:
+```
+$ sortinghatw --config sortinghat.config.settings tenant_A tenant_B
+```
+
 ## Create new accounts
 To create new accounts for SortingHat use the following command:
 
@@ -240,9 +247,22 @@ instance's data isolated in different databases.
 
 To enable this feature follow these guidelines:
 - Set `MULTI_TENANT` settings to `True`.
-- Define a list of tenants using the configuration file `sortinghat/config/tenants.json`. 
-You can use a different json file using the environment variable 
-`SORTINGHAT_MULTI_TENANT_LIST_PATH`
+- Define a list of tenants using the configuration file `sortinghat/config/tenants.json`.
+  You can use a different json file using the environment variable 
+  `SORTINGHAT_MULTI_TENANT_LIST_PATH`. The file should have the next schema:
+
+  ```json
+  {
+    'tenants': [
+      {'name': 'tenant A', 'dedicated_queue': true},
+      {'name': 'tenant B', 'dedicated_queue': false}
+    ]
+  }
+  ```
+  
+  Where `name` is the name of each tenant and `dedicated_queue`
+  is a boolean value to set whether jobs will be run on a specific
+  queue with the same tenant name.
 - Assign users to tenants with the following command:
   `sortinghat-admin set-user-tenant username header tenant`
 - The selected tenant should be included in the request using the
@@ -253,6 +273,9 @@ There are some limitations:
 users and databases, it won't store anything else related with SortingHat models.
 - Usernames are shared across all instances, which means that it is not possible
 to have the same username with two different passwords in different instances.
+- Tenants with `dedicated_queue` set as active will add their jobs to the queue
+of the same name. Queues will be created by SortingHat but, you will have
+to run a worker that processes that query.
 
 
 ## Running tests

--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -81,6 +81,8 @@ GRAPHQL_JWT = {
 
 SORTINGHAT_API_PAGE_SIZE = 10
 
+MULTI_TENANT = False
+
 
 # Configuration to pretend there is a Redis service
 # available. We need to set up the connection before
@@ -88,6 +90,7 @@ SORTINGHAT_API_PAGE_SIZE = 10
 # must be the same because in fakeredis connections
 # do not share the state. Therefore, we define a
 # singleton object to reuse it.
+
 class FakeRedisConn:
     """Singleton FakeRedis connection."""
 

--- a/config/settings/testing_tenant.py
+++ b/config/settings/testing_tenant.py
@@ -1,6 +1,16 @@
 from .testing import *  # noqa: F403,F401
-from .testing import SQL_MODE, DATABASES
+from .testing import SQL_MODE, DATABASES, RQ_QUEUES
 
+tenants_cfg = [
+    {'name': 'tenant_1', 'dedicated_queue': True},
+    {'name': 'tenant_2', 'dedicated_queue': False},
+    {'name': 'error_tenant', 'dedicated_queue': True}
+]
+
+MULTI_TENANT = True
+
+TENANTS_NAMES = [t["name"] for t in tenants_cfg]
+TENANTS_DEDICATED_QUEUES = [t["name"] for t in tenants_cfg if t["dedicated_queue"]]
 
 DATABASES.update({
     tenant: {
@@ -20,7 +30,20 @@ DATABASES.update({
         'HOST': '127.0.0.1',
         'PORT': 3306
     }
-    for tenant in ['tenant_1', 'tenant_2']
+    for tenant in [t["name"] for t in tenants_cfg]
+})
+
+RQ_QUEUES.update({
+    tenant: {
+        'HOST': 'localhost',
+        'PORT': 6379,
+        'ASYNC': False,
+        'DB': 0
+    }
+    for tenant in [
+        t["name"] for t in tenants_cfg
+        if t["dedicated_queue"] and t["name"] != "error_tenant"
+    ]
 })
 
 DATABASE_ROUTERS = [

--- a/releases/unreleased/dedicated-queues-in-multi-tenancy.yml
+++ b/releases/unreleased/dedicated-queues-in-multi-tenancy.yml
@@ -1,0 +1,16 @@
+---
+title: Dedicated queues in multi-tenancy
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  This new feature allows to run jobs in dedicated
+  queues when multi-tenancy is active. Therefore,
+  tenants that require more computing time,
+  can run in a separate environment without taking
+  the resources of others.
+  This new feature changes the format of the
+  `tenants.json` file, so please update it before
+  you install this new version. You can find more
+  info about how to configure it in the
+  `README.md` file.

--- a/sortinghat/core/errors.py
+++ b/sortinghat/core/errors.py
@@ -32,6 +32,7 @@ CODE_LOCKED_IDENTITY_ERROR = 13
 CODE_DUPLICATE_RANGE_ERROR = 14
 CODE_EQUAL_INDIVIDUAL_ERROR = 15
 CODE_FILTER_ERROR = 16
+CODE_JOB_ERROR = 80
 CODE_RECOMMENDATION_ERROR = 100
 CODE_TOKEN_EXPIRED = 126
 CODE_PERMISSION_DENIED = 127
@@ -132,6 +133,13 @@ class DuplicateRangeError(BaseError):
 
     _msg = "range date '%(start)s'-'%(end)s' is part of an existing range for %(group)s"
     code = CODE_DUPLICATE_RANGE_ERROR
+
+
+class JobError(BaseError):
+    """Exception raised when there is an job related error"""
+
+    _msg = "%(msg)s"
+    code = CODE_JOB_ERROR
 
 
 class RecommendationEngineError(BaseError):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2014-2020 Bitergia
+# Copyright (C) 2014-2024 Bitergia
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -34,6 +34,7 @@ from sortinghat.core.errors import (BaseError,
                                     ClosedTransactionError,
                                     LockedIdentityError,
                                     DuplicateRangeError,
+                                    JobError,
                                     RecommendationEngineError)
 
 
@@ -273,6 +274,25 @@ class TestEnrollmentRangeError(TestCase):
         """
         kwargs = {}
         self.assertRaises(KeyError, DuplicateRangeError, **kwargs)
+
+
+class TestJobError(TestCase):
+    """Unit tests for JobError"""
+
+    def test_message(self):
+        """Make sure that prints the right error"""
+
+        e = JobError(msg="job error")
+        self.assertEqual("job error", str(e))
+
+    def test_no_args(self):
+        """Check when required arguments are not given.
+
+        When this happens, it raises a KeyError exception.
+        """
+        kwargs = {}
+        self.assertRaises(KeyError, JobError,
+                          **kwargs)
 
 
 class TestRecommendationEngineError(TestCase):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -68,7 +68,7 @@ class TestFindJob(TestCase):
         """Check if it finds a job in the registry"""
 
         job = enqueue(job_echo, 'ABC')
-        qjob = find_job(job.id)
+        qjob = find_job(job.id, 'default')
         self.assertEqual(qjob, job)
 
     def test_not_found_job(self):
@@ -78,7 +78,7 @@ class TestFindJob(TestCase):
 
         with self.assertRaisesRegex(NotFoundError,
                                     JOB_NOT_FOUND_ERROR):
-            find_job('DEF')
+            find_job('DEF', 'default')
 
 
 class TestRecommendAffiliations(TestCase):


### PR DESCRIPTION
So far, jobs could only run in the default RQ queue. With this change, tenant jobs can run in dedicated queues when needed.

To implement this feature, it was neccesary to update the creation of the databases and queues in the
configuration file. Also, a new auto-generated config variable named TENANTS_DEDICATED_QUEUES has been set to determine whether a tenant runs its jobs in a
dedicated queue or not.