### PR TITLE
[job] Fix recommend matches job

### DIFF
--- a/releases/unreleased/recommendation-job-fixed.yml
+++ b/releases/unreleased/recommendation-job-fixed.yml
@@ -1,0 +1,8 @@
+---
+title: Match recommendations job fixed
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fix the bug in recommend matches jobs that was causing it
+  not to recommend any matches.

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -80,6 +80,7 @@ export default {
           criteria,
           exclude,
           strict,
+          [],
           matchSource
         );
         this.$refs.table.getPaginatedJobs();


### PR DESCRIPTION
This PR fixes the recommend matches job when executed from the settings/job that was causing it not to recommend and match.