### PR TITLE
[docker] Set build image with node 20.x

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # 4.0.0
       - name: Setup Node ${{ matrix.node-version }}


### PR DESCRIPTION
We missed to update the version of node when the docker image is created.