### PR TITLE
Fix profile view recommendations display

### DIFF
--- a/releases/unreleased/profile-shows-dismissed-recommendations.yml
+++ b/releases/unreleased/profile-shows-dismissed-recommendations.yml
@@ -1,0 +1,8 @@
+---
+title: Profile view displays correct recommendations
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 864
+notes: >
+  The profile view now correctly displays all recommendations
+  for an individual, excluding those that have been dismissed.

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -241,7 +241,8 @@ class IndividualType(DjangoObjectType):
     @check_auth
     def resolve_match_recommendation_set(self, info):
         indv_recs = []
-        recs = self.match_recommendation_individual_1.all() | self.match_recommendation_individual_2.all()
+        recs = (self.match_recommendation_individual_1.filter(applied=None) |
+                self.match_recommendation_individual_2.filter(applied=None))
         for rec in recs:
             indv = rec.individual1 if rec.individual1.mk != self.mk else rec.individual2
             indv_recs.append(IndividualRecommendedMergeType(id=rec.id, individual=indv))


### PR DESCRIPTION
Resolved issue where the profile view erroneously displayed dismissed recommendations along with availables ones. Now, only active recommendations are shown.

Closes #864 