### PR TITLE
Fix change password form

### DIFF
--- a/releases/unreleased/change-password-form-fixed.yml
+++ b/releases/unreleased/change-password-form-fixed.yml
@@ -1,0 +1,10 @@
+---
+title: Change password form fixed
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  An unused header in the UI made the attempts
+  to change the password fail. It tried to guess
+  the user from an invalid JWT token when multitenancy
+  was enabled.

--- a/ui/src/views/ChangePassword.vue
+++ b/ui/src/views/ChangePassword.vue
@@ -96,10 +96,8 @@ export default {
     },
     headers() {
       const csrftoken = Cookies.get("csrftoken");
-      const authtoken = Cookies.get("sh_authtoken");
       const headers = {
         "X-CSRFToken": csrftoken,
-        Authorization: `JWT ${authtoken}`,
       };
 
       return headers;


### PR DESCRIPTION
This PR removes an unused header in the UI causing attempts to guess the user by an invalid JWT token when multitenancy was enabled.