### PR TITLE
Fix unify individuals with the same username and source

### DIFF
--- a/config/settings/devel.py
+++ b/config/settings/devel.py
@@ -179,3 +179,5 @@ RQ_QUEUES = {
         'DB': 0
     }
 }
+
+MULTI_TENANT = os.environ.get('SORTINGHAT_MULTI_TENANT', 'False').lower() in ('true', '1')

--- a/releases/unreleased/match-source-parameter-fixed-in-recommendations.yml
+++ b/releases/unreleased/match-source-parameter-fixed-in-recommendations.yml
@@ -1,0 +1,11 @@
+---
+title: Match source parameter fixed in recommendations
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 875
+notes: >
+  Resolve an issue where the "match source" option in unify and recommendation
+  jobs was being applied to both emails and names. With this update, this option
+  will now only apply to usernames. Additionally, users can utilize name and email
+  simultaneously without the constraint of applying the "match source" option across
+  all parameters.

--- a/sortinghat/core/recommendations/matching.py
+++ b/sortinghat/core/recommendations/matching.py
@@ -196,7 +196,7 @@ def _find_matches(set_x, set_y, criteria, exclude, verbose, strict, match_source
     def _filter_criteria(df, c, strict=True, match_source=False):
         """Filter dataframe creating a basic subset including a given column"""
         cols = ['uuid', 'individual', c]
-        if match_source:
+        if match_source and c == 'username':
             cols += ['source']
             cdf = df[cols]
             cdf = cdf[cdf['source'].isin(MATCH_USERNAME_SOURCES)]
@@ -229,7 +229,7 @@ def _find_matches(set_x, set_y, criteria, exclude, verbose, strict, match_source
     for c in criteria:
         cdf_x = _filter_criteria(df_x, c, strict, match_source)
         cdf_y = _filter_criteria(df_y, c, strict, match_source)
-        if match_source:
+        if match_source and c == 'username':
             cdf = pandas.merge(cdf_x, cdf_y, on=[c, 'source'], how='inner')
         else:
             cdf = pandas.merge(cdf_x, cdf_y, on=c, how='inner')

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -66,7 +66,7 @@ from .api import (add_identity,
                   update_scheduled_task)
 from .context import SortingHatContext
 from .decorators import (check_auth, check_permissions)
-from .errors import InvalidFilterError, EqualIndividualError
+from .errors import InvalidFilterError, EqualIndividualError, InvalidValueError
 from .importer.backend import find_import_identities_backends
 from .jobs import (affiliate,
                    unify,
@@ -1141,6 +1141,9 @@ class RecommendMatches(graphene.Mutation):
         tenant = get_db_tenant()
         ctx = SortingHatContext(user=user, tenant=tenant)
 
+        if match_source and 'username' not in criteria:
+            raise InvalidValueError(msg='Match source requires username criteria.')
+
         job = get_tenant_queue(tenant).enqueue(recommend_matches,
                                                ctx,
                                                source_uuids,
@@ -1231,6 +1234,9 @@ class Unify(graphene.Mutation):
         user = info.context.user
         tenant = get_db_tenant()
         ctx = SortingHatContext(user=user, tenant=tenant)
+
+        if match_source and 'username' not in criteria:
+            raise InvalidValueError(msg='Match source requires username criteria.')
 
         job = get_tenant_queue(tenant).enqueue(unify,
                                                ctx,

--- a/tests/rec/test_matches.py
+++ b/tests/rec/test_matches.py
@@ -440,7 +440,7 @@ class TestRecommendMatches(TestCase):
         rec = recs[0]
         self.assertEqual(rec[0], self.john_smith.uuid)
         self.assertEqual(rec[1], self.john_smith.individual.mk)
-        self.assertEqual(rec[2], [])
+        self.assertEqual(rec[2], sorted([self.jsm3.individual.mk]))
 
         rec = recs[1]
         self.assertEqual(rec[0], self.jrae_no_name.uuid)
@@ -450,7 +450,7 @@ class TestRecommendMatches(TestCase):
         rec = recs[2]
         self.assertEqual(rec[0], self.jr2.uuid)
         self.assertEqual(rec[1], self.jr2.individual.mk)
-        self.assertEqual(rec[2], sorted([jrae_github.individual.mk]))
+        self.assertEqual(rec[2], sorted([jrae_github.individual.mk, self.jrae.individual.mk]))
 
     def test_recommend_same_source_not_trusted(self):
         """Matches are not created for ids with same source but not github or gitlab"""
@@ -489,7 +489,7 @@ class TestRecommendMatches(TestCase):
         rec = recs[0]
         self.assertEqual(rec[0], self.john_smith.uuid)
         self.assertEqual(rec[1], self.john_smith.individual.mk)
-        self.assertEqual(rec[2], [])
+        self.assertEqual(rec[2], sorted([self.jsm3.individual.mk]))
 
         rec = recs[1]
         self.assertEqual(rec[0], self.jrae_no_name.uuid)
@@ -499,4 +499,4 @@ class TestRecommendMatches(TestCase):
         rec = recs[2]
         self.assertEqual(rec[0], self.jr2.uuid)
         self.assertEqual(rec[1], self.jr2.individual.mk)
-        self.assertEqual(rec[2], [])
+        self.assertEqual(rec[2], sorted([self.jrae.individual.mk]))

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1020,14 +1020,17 @@ class TestRecommendMatches(TestCase):
         # Test
         expected = {
             'results': {
-                self.john_smith.uuid: [],
-                self.jrae_no_name.uuid: [],
-                self.jr2.uuid: sorted([jrae_github.individual.mk])
+                self.john_smith.uuid: sorted([self.jsm3.individual.mk]),
+                self.jrae_no_name.uuid: sorted([self.jrae2.individual.mk]),
+                self.jr2.uuid: sorted([jrae_github.individual.mk, self.jrae.individual.mk])
             }
         }
 
         recommendations_expected = [
-            sorted([self.jr2.individual.mk, jrae_github.individual.mk])
+            sorted([self.john_smith.individual.mk, self.jsm3.individual.mk]),
+            sorted([self.jrae_no_name.individual.mk, self.jrae2.individual.mk]),
+            sorted([self.jr2.individual.mk, jrae_github.individual.mk]),
+            sorted([self.jr2.individual.mk, self.jrae.individual.mk])
         ]
 
         source_uuids = [self.john_smith.uuid, self.jrae_no_name.uuid, self.jr2.uuid]
@@ -1055,7 +1058,7 @@ class TestRecommendMatches(TestCase):
 
         self.assertDictEqual(result, expected)
 
-        self.assertEqual(MergeRecommendation.objects.count(), 1)
+        self.assertEqual(MergeRecommendation.objects.count(), 4)
 
         for rec in recommendations_expected:
             self.assertTrue(
@@ -1419,7 +1422,7 @@ class TestUnify(TestCase):
 
         # Test
         expected = {
-            'results': [jrae_github.uuid],
+            'results': [jrae_github.uuid, self.jsmith.uuid],
             'errors': []
         }
 
@@ -1439,7 +1442,11 @@ class TestUnify(TestCase):
 
         individual = Individual.objects.get(mk=jrae_github.uuid)
         identities = individual.identities.all()
-        self.assertEqual(len(identities), 4)
+        self.assertEqual(len(identities), 7)
+
+        individual = Individual.objects.get(mk=self.jsmith.uuid)
+        identities = individual.identities.all()
+        self.assertEqual(len(identities), 6)
 
     def test_unify_last_modified(self):
         """Check if unify is applied only for individuals updated after a given date"""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10249,7 +10249,7 @@ class TestUnifyMutation(django.test.TestCase):
                             self.js_alt3.uuid, self.js_alt4.uuid,
                             self.jrae.uuid, self.jrae2.uuid, self.jrae3.uuid,
                             jrae_github.uuid],
-            'criteria': ['email', 'name', 'username'],
+            'criteria': ['username'],
             'strict': False,
             'matchSource': True
         }

--- a/ui/src/components/JobModal.vue
+++ b/ui/src/components/JobModal.vue
@@ -54,12 +54,6 @@
                 density="comfortable"
                 hide-details
               />
-              <v-checkbox
-                v-model="forms.unify.matchSource"
-                label="Only unify identities that share the same source"
-                density="comfortable"
-                hide-details
-              />
             </v-col>
           </v-row>
           <v-row class="ma-0">
@@ -89,6 +83,13 @@
                   density="comfortable"
                   hide-details
                 />
+                <v-checkbox
+                  class="ml-4"
+                  v-model="forms.unify.matchSource"
+                  label="Only unify identities that share the same source"
+                  density="comfortable"
+                  hide-details
+                />
               </fieldset>
             </v-col>
           </v-row>
@@ -105,12 +106,6 @@
               <v-checkbox
                 v-model="forms.recommendMatches.strict"
                 label="Exclude individuals with invalid email adresses and names"
-                density="comfortable"
-                hide-details
-              />
-              <v-checkbox
-                v-model="forms.recommendMatches.matchSource"
-                label="Only recommend identities that share the same source"
                 density="comfortable"
                 hide-details
               />
@@ -140,6 +135,13 @@
                   v-model="forms.recommendMatches.criteria"
                   label="Username"
                   value="username"
+                  density="comfortable"
+                  hide-details
+                />
+                <v-checkbox
+                  class="ml-4"
+                  v-model="forms.recommendMatches.matchSource"
+                  label="Only recommend identities that share the same source"
                   density="comfortable"
                   hide-details
                 />

--- a/ui/src/views/SettingsGeneral.vue
+++ b/ui/src/views/SettingsGeneral.vue
@@ -146,12 +146,6 @@
                   density="comfortable"
                   hide-details
                 />
-                <v-checkbox
-                  v-model="tasks.unify.params.match_source"
-                  label="Only unify identities that share the same source"
-                  density="comfortable"
-                  hide-details
-                />
               </v-col>
             </v-row>
             <v-row class="ma-0 pl-2">
@@ -177,6 +171,13 @@
                   v-model="tasks.unify.params.criteria"
                   label="Username"
                   value="username"
+                  density="comfortable"
+                  hide-details
+                />
+                <v-checkbox
+                  class="ml-4"
+                  v-model="tasks.unify.params.match_source"
+                  label="Only unify identities that share the same source"
                   density="comfortable"
                   hide-details
                 />


### PR DESCRIPTION
This PR resolves an issue where the "match source" option was being applied to emails and names. With this update, this option will now only apply to usernames. Additionally, users can use email and name simultaneously.

Fixes #875