### PR TITLE
Add readonly and read/write permission groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ Options:
   --no-interactive  Run the command in no interactive mode.
 ```
 
+## Assign users to permission groups
+A user in a group automatically has the permissions granted to that group. To assign users to a permission group use the following command:
+```
+$ sortinghat-admin set-user-group username group
+```
+
+The list of groups can be customized using the configuration file `sortinghat/config/permission_groups.json`. You can use a different json file using the environment variable `SORTINGHAT_PERMISSION_GROUPS_LIST_PATH`.
+
+
 ## Compatibility between versions
 SortingHat 0.7.x is no longer supported. Any database using this version will not work.
 

--- a/releases/unreleased/create-and-assign-users-to-permission-groups.yml
+++ b/releases/unreleased/create-and-assign-users-to-permission-groups.yml
@@ -1,0 +1,9 @@
+---
+title: Assign users to permission groups
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 849
+notes: |
+  Users can be assigned to a permission group using the command
+  `$ sortinghat-admin set-user-group username group`. A user in
+  a group automatically has the permissions granted to that group.

--- a/sortinghat/config/permission_groups.json
+++ b/sortinghat/config/permission_groups.json
@@ -1,0 +1,62 @@
+{
+  "groups": {
+    "admin": {
+      "core": {
+        "affiliationrecommendation": ["add", "change", "delete", "view"],
+        "alias": ["add", "change", "delete", "view"],
+        "country": ["add", "change", "delete", "view"],
+        "domain": ["add", "change", "delete", "view"],
+        "enrollment": ["add", "change", "delete", "view"],
+        "genderrecommendation": ["add", "change", "delete", "view"],
+        "group": ["add", "change", "delete", "view"],
+        "identity": ["add", "change", "delete", "view"],
+        "individual": ["add", "change", "delete", "view"],
+        "mergerecommendation": ["add", "change", "delete", "view"],
+        "organization": ["add", "change", "delete", "view"],
+        "profile": ["add", "change", "delete", "view"],
+        "recommenderexclusionterm": ["add", "change", "delete", "view"],
+        "scheduledtask": ["add", "change", "delete", "view"],
+        "team": ["add", "change", "delete", "view"],
+        "custompermissions": ["execute_job"]
+      }
+    },
+    "user": {
+      "core": {
+        "affiliationrecommendation": ["add", "change", "delete", "view"],
+        "alias": ["add", "change", "delete", "view"],
+        "country": ["add", "change", "delete", "view"],
+        "domain": ["add", "change", "delete", "view"],
+        "enrollment": ["add", "change", "delete", "view"],
+        "genderrecommendation": ["add", "change", "delete", "view"],
+        "group": ["add", "change", "delete", "view"],
+        "identity": ["add", "change", "delete", "view"],
+        "individual": ["add", "change", "delete", "view"],
+        "mergerecommendation": ["add", "change", "delete", "view"],
+        "organization": ["add", "change", "delete", "view"],
+        "profile": ["add", "change", "delete", "view"],
+        "recommenderexclusionterm": ["add", "change", "delete", "view"],
+        "scheduledtask": ["view"],
+        "team": ["add", "change", "delete", "view"]
+      }
+    },
+    "readonly": {
+      "core": {
+        "affiliationrecommendation": ["view"],
+        "alias": ["view"],
+        "country": ["view"],
+        "domain": ["view"],
+        "enrollment": ["view"],
+        "genderrecommendation": ["view"],
+        "group": ["view"],
+        "identity": ["view"],
+        "individual": ["view"],
+        "mergerecommendation": ["view"],
+        "organization": ["view"],
+        "profile": ["view"],
+        "recommenderexclusionterm": ["view"],
+        "scheduledtask": ["view"],
+        "team": ["view"]
+      }
+    }
+  }
+}

--- a/sortinghat/config/settings.py
+++ b/sortinghat/config/settings.py
@@ -364,3 +364,12 @@ SORTINGHAT_API_PAGE_SIZE = 10
 #
 
 SORTINGHAT_GENDERIZE_API_KEY = os.environ.get('SORTINGHAT_GENDERIZE_API_KEY', None)
+
+#
+# Path of the permission groups configuration file
+#
+# https://docs.djangoproject.com/en/5.0/topics/auth/default/#groups
+#
+
+PERMISSION_GROUPS_LIST_PATH = os.environ.get('SORTINGHAT_PERMISSION_GROUPS_LIST_PATH',
+                                            os.path.join(BASE_DIR, 'config', 'permission_groups.json'))

--- a/sortinghat/core/management/commands/set_group.py
+++ b/sortinghat/core/management/commands/set_group.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Eva Millán <evamillan@bitergia.com>
+#
+
+from django.core.management import BaseCommand, CommandError
+from django.core import exceptions
+from django.contrib.auth.models import Group
+from django.contrib.auth import get_user_model
+from django.db import DEFAULT_DB_ALIAS
+
+
+class Command(BaseCommand):
+    help = "Assign a user to a permission group"
+
+    def add_arguments(self, parser):
+        parser.add_argument('username')
+        parser.add_argument('group_name')
+        parser.add_argument(
+            '--database',
+            default=DEFAULT_DB_ALIAS,
+            help='Specifies the database to use. Default is "default".',
+        )
+
+    def handle(self, *args, **options):
+        try:
+            group = Group.objects.using(options['database']).get(name=options['group_name'])
+            user = get_user_model().objects.get(username=options['username'])
+            user.groups.set([group.id])
+        except Group.DoesNotExist:
+            raise CommandError(f"Group '{options['group_name']}' not found")
+        except exceptions.ObjectDoesNotExist:
+            raise CommandError(f"User '{options['username']}' not found")

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -659,7 +659,7 @@ class AddOrganization(graphene.Mutation):
 
     organization = graphene.Field(lambda: OrganizationType)
 
-    @check_auth
+    @check_permissions(['core.add_organization'])
     def mutate(self, info, name):
         user = info.context.user
         tenant = get_db_tenant()
@@ -678,7 +678,7 @@ class DeleteOrganization(graphene.Mutation):
 
     organization = graphene.Field(lambda: OrganizationType)
 
-    @check_auth
+    @check_permissions(['core.delete_organization'])
     def mutate(self, info, name):
         user = info.context.user
         tenant = get_db_tenant()
@@ -699,7 +699,7 @@ class AddTeam(graphene.Mutation):
 
     team = graphene.Field(lambda: TeamType)
 
-    @check_auth
+    @check_permissions(['core.add_team'])
     def mutate(self, info, team_name, organization=None, parent_name=None):
         user = info.context.user
         tenant = get_db_tenant()
@@ -719,7 +719,7 @@ class DeleteTeam(graphene.Mutation):
 
     team = graphene.Field(lambda: TeamType)
 
-    @check_auth
+    @check_permissions(['core.delete_team'])
     def mutate(self, info, team_name, organization=None):
         user = info.context.user
         tenant = get_db_tenant()
@@ -740,7 +740,7 @@ class AddDomain(graphene.Mutation):
 
     domain = graphene.Field(lambda: DomainType)
 
-    @check_auth
+    @check_permissions(['core.add_domain'])
     def mutate(self, info, organization, domain, is_top_domain=False):
         user = info.context.user
         tenant = get_db_tenant()
@@ -762,7 +762,7 @@ class DeleteDomain(graphene.Mutation):
 
     domain = graphene.Field(lambda: DomainType)
 
-    @check_auth
+    @check_permissions(['core.delete_domain'])
     def mutate(self, info, domain):
         user = info.context.user
         tenant = get_db_tenant()
@@ -782,7 +782,7 @@ class AddAlias(graphene.Mutation):
 
     alias = graphene.Field(lambda: AliasType)
 
-    @check_auth
+    @check_permissions(['core.add_alias'])
     def mutate(self, info, organization, alias):
         user = info.context.user
         tenant = get_db_tenant()
@@ -803,7 +803,7 @@ class DeleteAlias(graphene.Mutation):
 
     alias = graphene.Field(lambda: AliasType)
 
-    @check_auth
+    @check_permissions(['core.delete_alias'])
     def mutate(self, info, alias):
         user = info.context.user
         tenant = get_db_tenant()
@@ -827,7 +827,7 @@ class AddIdentity(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.add_identity'])
     def mutate(self, info, source,
                name=None, email=None, username=None,
                uuid=None):
@@ -856,7 +856,7 @@ class DeleteIdentity(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.delete_identity'])
     def mutate(self, info, uuid):
         user = info.context.user
         tenant = get_db_tenant()
@@ -877,7 +877,7 @@ class Lock(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.change_profile'])
     def mutate(self, info, uuid):
         user = info.context.user
         tenant = get_db_tenant()
@@ -898,7 +898,7 @@ class Unlock(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.change_profile'])
     def mutate(self, info, uuid):
         user = info.context.user
         tenant = get_db_tenant()
@@ -920,7 +920,7 @@ class UpdateProfile(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.change_profile'])
     def mutate(self, info, uuid, data):
         user = info.context.user
         tenant = get_db_tenant()
@@ -942,7 +942,7 @@ class MoveIdentity(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.change_individual'])
     def mutate(self, info, from_uuid, to_uuid):
         user = info.context.user
         tenant = get_db_tenant()
@@ -964,7 +964,7 @@ class Merge(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.change_individual'])
     def mutate(self, info, from_uuids, to_uuid):
         user = info.context.user
         tenant = get_db_tenant()
@@ -985,7 +985,7 @@ class UnmergeIdentities(graphene.Mutation):
     uuids = graphene.Field(lambda: graphene.List(graphene.String))
     individuals = graphene.Field(lambda: graphene.List(IndividualType))
 
-    @check_auth
+    @check_permissions(['core.change_individual'])
     def mutate(self, info, uuids):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1012,7 +1012,7 @@ class Enroll(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.add_enrollment'])
     def mutate(self, info, uuid, group,
                parent_org=None,
                from_date=None, to_date=None,
@@ -1041,7 +1041,7 @@ class Withdraw(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.delete_enrollment'])
     def mutate(self, info, uuid, group, parent_org=None,
                from_date=None, to_date=None):
         user = info.context.user
@@ -1070,7 +1070,7 @@ class UpdateEnrollment(graphene.Mutation):
     uuid = graphene.Field(lambda: graphene.String)
     individual = graphene.Field(lambda: IndividualType)
 
-    @check_auth
+    @check_permissions(['core.change_enrollment'])
     def mutate(self, info, uuid, group,
                from_date, to_date,
                new_from_date=None, new_to_date=None,
@@ -1284,7 +1284,7 @@ class AddRecommenderExclusionTerm(graphene.Mutation):
 
     exclusion = graphene.Field(lambda: RecommenderExclusionTermType)
 
-    @check_auth
+    @check_permissions(['core.add_recommenderexclusionterm'])
     def mutate(self, info, term):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1303,7 +1303,7 @@ class DeleteRecommenderExclusionTerm(graphene.Mutation):
 
     exclusion = graphene.Field(lambda: RecommenderExclusionTermType)
 
-    @check_auth
+    @check_permissions(['core.delete_recommenderexclusionterm'])
     def mutate(self, info, term):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1323,7 +1323,7 @@ class ManageMergeRecommendation(graphene.Mutation):
 
     applied = graphene.Boolean()
 
-    @check_auth
+    @check_permissions(['core.change_mergerecommendation'])
     def mutate(self, info, recommendation_id, apply):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1368,7 +1368,7 @@ class ManageAffiliationRecommendation(graphene.Mutation):
 
     applied = graphene.Boolean()
 
-    @check_auth
+    @check_permissions(['core.change_affiliationrecommendation'])
     def mutate(self, info, recommendation_id, apply):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1393,7 +1393,7 @@ class ManageGenderRecommendation(graphene.Mutation):
 
     applied = graphene.Boolean()
 
-    @check_auth
+    @check_permissions(['core.change_genderrecommendation'])
     def mutate(self, info, recommendation_id, apply):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1423,7 +1423,7 @@ class ImportIdentities(graphene.Mutation):
 
     job_id = graphene.Field(lambda: graphene.String)
 
-    @check_auth
+    @check_permissions(['core.add_importidentitiestask'])
     def mutate(self, info, backend, url, params=None):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1445,7 +1445,7 @@ class MergeOrganizations(graphene.Mutation):
 
     organization = graphene.Field(lambda: OrganizationType)
 
-    @check_auth
+    @check_permissions(['core.change_organization'])
     def mutate(self, info, from_org, to_org):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1466,7 +1466,7 @@ class ScheduleTask(graphene.Mutation):
 
     task = graphene.Field(lambda: ScheduledTaskType)
 
-    @check_auth
+    @check_permissions(['core.add_scheduledtask'])
     def mutate(self, info, job, interval, params=None):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1485,7 +1485,7 @@ class DeleteScheduledTask(graphene.Mutation):
 
     deleted = graphene.Boolean()
 
-    @check_auth
+    @check_permissions(['core.delete_scheduledtask'])
     def mutate(self, info, task_id):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1510,7 +1510,7 @@ class UpdateScheduledTask(graphene.Mutation):
 
     task = graphene.Field(lambda: ScheduledTaskType)
 
-    @check_auth
+    @check_permissions(['core.change_scheduledtask'])
     def mutate(self, info, task_id, data):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1932,7 +1932,7 @@ class SortingHatQuery:
                                                                              page,
                                                                              page_size=page_size)
 
-    @check_auth
+    @check_permissions(['core.view_transaction'])
     def resolve_transactions(self, info, filters=None,
                              page=1,
                              page_size=settings.SORTINGHAT_API_PAGE_SIZE,
@@ -1956,7 +1956,7 @@ class SortingHatQuery:
                                                                 page,
                                                                 page_size=page_size)
 
-    @check_auth
+    @check_permissions(['core.view_operation'])
     def resolve_operations(self, info, filters=None,
                            page=1,
                            page_size=settings.SORTINGHAT_API_PAGE_SIZE,

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1423,7 +1423,7 @@ class ImportIdentities(graphene.Mutation):
 
     job_id = graphene.Field(lambda: graphene.String)
 
-    @check_permissions(['core.add_importidentitiestask'])
+    @check_permissions(['core.execute_job'])
     def mutate(self, info, backend, url, params=None):
         user = info.context.user
         tenant = get_db_tenant()

--- a/sortinghat/core/views.py
+++ b/sortinghat/core/views.py
@@ -111,6 +111,7 @@ def api_login(request):
         login(request, user)
         response = {
             'user': username,
-            'isAdmin': user.is_superuser
+            'isAdmin': user.is_superuser,
+            'groups': [group['name'] for group in user.groups.values('name')]
         }
         return JsonResponse(response)

--- a/sortinghat/server/sortinghat_admin.py
+++ b/sortinghat/server/sortinghat_admin.py
@@ -296,6 +296,22 @@ def create_user(username, is_admin, no_interactive):
         sys.exit(1)
 
 
+@click.command()
+@click.argument('username')
+@click.argument('permission_group')
+@click.option('--database', default='default')
+def set_user_group(username, permission_group, database):
+    """Assign a user to a specific permission group"""
+
+    try:
+        management.call_command('set_group', username, permission_group, database=database)
+    except management.CommandError as exc:
+        click.echo(exc)
+        sys.exit(1)
+
+    click.echo(f"User '{username}' assigned to '{permission_group}'.")
+
+
 def _create_database(database='default', db_name=None):
     """Create an empty database."""
 
@@ -396,3 +412,4 @@ sortinghat_admin.add_command(upgrade)
 sortinghat_admin.add_command(migrate_old_database)
 sortinghat_admin.add_command(create_user)
 sortinghat_admin.add_command(set_user_tenant)
+sortinghat_admin.add_command(set_user_group)

--- a/sortinghat/server/sortinghat_admin.py
+++ b/sortinghat/server/sortinghat_admin.py
@@ -167,6 +167,7 @@ def upgrade(no_database):
             _setup_database(database=database)
 
     _install_static_files()
+    _setup_group_permissions(database='default')
 
     click.secho("SortingHat upgrade completed", fg='bright_cyan')
 

--- a/tests/tenants/test_schema.py
+++ b/tests/tenants/test_schema.py
@@ -65,7 +65,7 @@ class TestTenantSchema(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = django.test.RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1263,7 +1263,7 @@ class TestQueryPagination(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -1484,7 +1484,7 @@ class TestQueryCountries(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -4026,7 +4026,7 @@ class TestQueryTransactions(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -4215,7 +4215,7 @@ class TestQueryOperations(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -5557,7 +5557,7 @@ class TestAddOrganizationMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -5642,7 +5642,7 @@ class TestDeleteOrganizationMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -5779,7 +5779,7 @@ class TestAddTeamMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -5938,7 +5938,7 @@ class TestDeleteTeamMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -6079,7 +6079,7 @@ class TestAddDomainMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -6187,7 +6187,7 @@ class TestDeleteDomainMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -6288,7 +6288,7 @@ class TestAddIdentityMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -6614,7 +6614,7 @@ class TestDeleteIdentityMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -6797,7 +6797,7 @@ class TestLockMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -6901,7 +6901,7 @@ class TestUnlockMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -7015,7 +7015,7 @@ class TestUpdateProfileMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -7189,7 +7189,7 @@ class TestMoveIdentityMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -7536,7 +7536,7 @@ class TestEnrollMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -7991,7 +7991,7 @@ class TestWithdrawMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -8307,7 +8307,7 @@ class TestUpdateEnrollmentMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -8787,7 +8787,7 @@ class TestMergeMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -9207,7 +9207,7 @@ class TestUnmergeIdentitiesMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -10655,7 +10655,7 @@ class TestAddRecommenderExclusionTermMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -10739,7 +10739,7 @@ class TestDeleteRecommenderExclusionTermMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -10811,7 +10811,7 @@ class TestManageRecommendationMergeMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -10917,7 +10917,7 @@ class TestManageRecommendationGenderMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -11015,7 +11015,7 @@ class TestManageRecommendationAffiliationMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -11132,7 +11132,7 @@ class TestMergeOrganizationsMutation(django.test.TestCase):
     def setUp(self):
         """Load initial dataset and set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -11506,7 +11506,7 @@ class TestAddAliasMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 
@@ -11611,7 +11611,7 @@ class TestDeleteAliasMutation(django.test.TestCase):
     def setUp(self):
         """Set queries context"""
 
-        self.user = get_user_model().objects.create(username='test')
+        self.user = get_user_model().objects.create(username='test', is_superuser=True)
         self.context_value = RequestFactory().get(GRAPHQL_ENDPOINT)
         self.context_value.user = self.user
 


### PR DESCRIPTION
This PR adds the `readonly` and `user` permission groups. The `user` group has add, change, delete and view permissions for all `core` models except for jobs and task scheduling. The `readonly` group only grants view permissions.
The groups and their permissions are moved to `sortinghat/config/permission_groups.json`. The location of the file can be changed with the `SORTINGHAT_PERMISSION_GROUPS_LIST_PATH` environment variable.

The PR also adds a command to assign a user to a group:
```
$ sortinghat-admin set-user-group username group
```