### PR TITLE
[ui] Add LinkedIn profile on the individual's page

### DIFF
--- a/releases/unreleased/save-url-to-an-individuals-linkedin-profile.yml
+++ b/releases/unreleased/save-url-to-an-individuals-linkedin-profile.yml
@@ -1,0 +1,8 @@
+---
+title: Save URL to an individual's LinkedIn profile
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 817
+notes: >
+  Users can add a link to a LinkedIn profile on the individual's page.
+  This helps speed up the lookup of a contributor's  information. 

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -37,8 +37,12 @@ const DELETE_IDENTITY = gql`
   mutation DeleteIdentity($uuid: String!) {
     deleteIdentity(uuid: $uuid) {
       uuid
+      individual {
+        ...individual
+      }
     }
   }
+  ${FULL_INDIVIDUAL}
 `;
 
 const MERGE = gql`
@@ -426,6 +430,16 @@ const DELETE_ALIAS = gql`
       }
     }
   }
+`;
+const ADD_LINKEDIN_PROFILE = gql`
+  mutation addLinkedinProfile($uuid: String!, $username: String!) {
+    addIdentity(uuid: $uuid, username: $username, source: "linkedin") {
+      individual {
+        ...individual
+      }
+    }
+  }
+  ${FULL_INDIVIDUAL}
 `;
 
 const tokenAuth = (apollo, username, password) => {
@@ -830,6 +844,16 @@ const deleteAlias = (apollo, alias) => {
   });
 };
 
+const addLinkedinProfile = (apollo, uuid, username) => {
+  return apollo.mutate({
+    mutation: ADD_LINKEDIN_PROFILE,
+    variables: {
+      uuid,
+      username,
+    },
+  });
+};
+
 export {
   tokenAuth,
   lockIndividual,
@@ -863,4 +887,5 @@ export {
   updateTask,
   addAlias,
   deleteAlias,
+  addLinkedinProfile,
 };

--- a/ui/src/components/Identity.vue
+++ b/ui/src/components/Identity.vue
@@ -42,6 +42,15 @@
         {{ username }}
         <v-icon size="x-small" end>mdi-open-in-new</v-icon>
       </a>
+      <a
+        v-else-if="source?.toLowerCase() === 'linkedin'"
+        :href="`https://www.linkedin.com/in/${username}`"
+        class="link--underline font-weight-regular"
+        target="_blank"
+      >
+        {{ username }}
+        <v-icon size="x-small" end>mdi-open-in-new</v-icon>
+      </a>
       <span v-else class="text-break">{{ username }}</span>
     </v-col>
     <v-col class="ma-2" v-if="source !== null">

--- a/ui/src/utils/actions.js
+++ b/ui/src/utils/actions.js
@@ -42,6 +42,7 @@ const groupIdentities = (identities) => {
     { source: "gitlab", icon: "mdi-gitlab" },
     { source: "dockerhub", icon: "mdi-docker" },
     { source: "jira", icon: "mdi-jira" },
+    { source: "linkedin", icon: "mdi-linkedin" },
     { source: "rss", icon: "mdi-rss" },
     { source: "slack", icon: "mdi-slack" },
     { source: "stackexchange", icon: "mdi-stack-exchange" },


### PR DESCRIPTION
This PR adds a button to add or remove a LinkedIn identity on the individual's page actions menu. The link is displayed under the individual's name and affiliation on top of the page, along with the GitHub profile, to make them easier to access.

![imagen](https://github.com/user-attachments/assets/0e78d099-bd12-4bfd-9d40-974c8fb4a050)
