### PR TITLE
Fix jobs missing from results

### DIFF
--- a/docker/worker-entrypoint.sh
+++ b/docker/worker-entrypoint.sh
@@ -34,7 +34,7 @@ set -e
 export SORTINGHAT_CONFIG=sortinghat.config.settings
 
 # Build the command to run
-set - sortinghatw
+set - sortinghatw "$@"
 
 # Run the worker
 exec "$@"

--- a/releases/unreleased/job-results-in-sortinghat.yml
+++ b/releases/unreleased/job-results-in-sortinghat.yml
@@ -1,0 +1,8 @@
+---
+title: Job results in SortingHat
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fixed a bug that caused jobs to be missing in SortingHat.
+  Job results will be kept in SortingHat for one week.

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -51,6 +51,7 @@ from .recommendations.engine import RecommendationEngine
 
 
 MAX_CHUNK_SIZE = 2000
+DEFAULT_JOB_RESULT_TTL = 60 * 60 * 24 * 7  # seconds
 
 
 logger = logging.getLogger(__name__)
@@ -866,6 +867,8 @@ def schedule_task(ctx, fn, task, scheduled_datetime=None, **kwargs):
                                                   on_success=on_success_job,
                                                   on_failure=on_failed_job,
                                                   job_timeout=-1,
+                                                  result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                                  failure_ttl=DEFAULT_JOB_RESULT_TTL,
                                                   **kwargs)
     task.scheduled_datetime = scheduled_datetime
     task.job_id = job.id

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -104,21 +104,31 @@ def get_jobs(tenant):
     logger.debug("Retrieving list of jobs ...")
 
     queue = get_tenant_queue(tenant)
-    started_jobs = [find_job(id, tenant)
-                    for id
-                    in queue.started_job_registry.get_job_ids()]
-    deferred_jobs = [find_job(id, tenant)
-                     for id
-                     in queue.deferred_job_registry.get_job_ids()]
-    finished_jobs = [find_job(id, tenant)
-                     for id
-                     in queue.finished_job_registry.get_job_ids()]
-    failed_jobs = [find_job(id, tenant)
-                   for id
-                   in queue.failed_job_registry.get_job_ids()]
-    scheduled_jobs = [find_job(id, tenant)
-                      for id
-                      in queue.scheduled_job_registry.get_job_ids()]
+    started_jobs = django_rq.utils.get_jobs(
+        queue,
+        queue.started_job_registry.get_job_ids(),
+        queue.started_job_registry
+    )
+    deferred_jobs = django_rq.utils.get_jobs(
+        queue,
+        queue.deferred_job_registry.get_job_ids(),
+        queue.deferred_job_registry
+    )
+    finished_jobs = django_rq.utils.get_jobs(
+        queue,
+        queue.finished_job_registry.get_job_ids(),
+        queue.finished_job_registry
+    )
+    failed_jobs = django_rq.utils.get_jobs(
+        queue,
+        queue.failed_job_registry.get_job_ids(),
+        queue.failed_job_registry
+    )
+    scheduled_jobs = django_rq.utils.get_jobs(
+        queue,
+        queue.scheduled_job_registry.get_job_ids(),
+        queue.scheduled_job_registry
+    )
     jobs = (queue.jobs + started_jobs + deferred_jobs + finished_jobs + failed_jobs + scheduled_jobs)
     jobs = (job for job in jobs if job_in_tenant(job, tenant))
 

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -102,6 +102,7 @@ from .recommendations.exclusion import delete_recommend_exclusion_term, add_reco
 
 
 DEFAULT_IMPORT_IDENTITIES_INTERVAL = 60 * 24 * 7  # minutes
+DEFAULT_JOB_RESULT_TTL = 60 * 60 * 24 * 7  # seconds
 
 
 @convert_django_field.register(JSONField)
@@ -1109,7 +1110,9 @@ class RecommendAffiliations(graphene.Mutation):
 
         job = get_tenant_queue(tenant).enqueue(recommend_affiliations,
                                                ctx, uuids, last_modified,
-                                               job_timeout=-1)
+                                               job_timeout=-1,
+                                               result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                               failure_ttl=DEFAULT_JOB_RESULT_TTL)
 
         return RecommendAffiliations(
             job_id=job.id
@@ -1154,7 +1157,9 @@ class RecommendMatches(graphene.Mutation):
                                                strict,
                                                match_source,
                                                last_modified,
-                                               job_timeout=-1)
+                                               job_timeout=-1,
+                                               result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                               failure_ttl=DEFAULT_JOB_RESULT_TTL)
 
         return RecommendMatches(
             job_id=job.id
@@ -1179,7 +1184,9 @@ class RecommendGender(graphene.Mutation):
         job = get_tenant_queue(tenant).enqueue(recommend_gender,
                                                ctx, uuids,
                                                exclude, no_strict_matching,
-                                               job_timeout=-1)
+                                               job_timeout=-1,
+                                               result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                               failure_ttl=DEFAULT_JOB_RESULT_TTL)
 
         return RecommendGender(
             job_id=job.id
@@ -1203,7 +1210,9 @@ class Affiliate(graphene.Mutation):
 
         job = get_tenant_queue(tenant).enqueue(affiliate, ctx, uuids,
                                                last_modified,
-                                               job_timeout=-1)
+                                               job_timeout=-1,
+                                               result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                               failure_ttl=DEFAULT_JOB_RESULT_TTL)
 
         return Affiliate(
             job_id=job.id
@@ -1247,7 +1256,9 @@ class Unify(graphene.Mutation):
                                                strict,
                                                match_source,
                                                last_modified,
-                                               job_timeout=-1)
+                                               job_timeout=-1,
+                                               result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                               failure_ttl=DEFAULT_JOB_RESULT_TTL)
 
         return Unify(
             job_id=job.id
@@ -1271,7 +1282,9 @@ class Genderize(graphene.Mutation):
 
         job = get_tenant_queue(tenant).enqueue(genderize, ctx, uuids,
                                                exclude, no_strict_matching,
-                                               job_timeout=-1)
+                                               job_timeout=-1,
+                                               result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                               failure_ttl=DEFAULT_JOB_RESULT_TTL)
 
         return Genderize(
             job_id=job.id
@@ -1431,7 +1444,9 @@ class ImportIdentities(graphene.Mutation):
 
         job = get_tenant_queue(tenant).enqueue(import_identities, ctx,
                                                backend, url, params,
-                                               job_timeout=-1)
+                                               job_timeout=-1,
+                                               result_ttl=DEFAULT_JOB_RESULT_TTL,
+                                               failure_ttl=DEFAULT_JOB_RESULT_TTL)
 
         return ImportIdentities(
             job_id=job.id
@@ -1529,7 +1544,6 @@ class UpdateScheduledTask(graphene.Mutation):
             new_dt = datetime.datetime.now(datetime.timezone.utc) \
                 + datetime.timedelta(minutes=task.interval)
             if task.scheduled_datetime and task.scheduled_datetime > new_dt:
-                find_job(task.job_id, tenant)
                 if task.job_id:
                     job = find_job(task.job_id, tenant)
                     if job:


### PR DESCRIPTION
This PR fixes a bug that caused an empty list of job results when one of them was missing in Redis. This PR also updates the time the job results are kept to one week.

This also updates the worker entry point to receive parameters when a container runs.