### PR TITLE
Migrate user permissions from previous release

### DIFF
--- a/releases/unreleased/users-permissions-migrated.yml
+++ b/releases/unreleased/users-permissions-migrated.yml
@@ -1,0 +1,9 @@
+---
+title: Users permissions migrated
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 849
+notes: >
+  User permissions are stored in a separate table within
+  the database. These permissions will be automatically
+  migrated when running `sortinghat-admin upgrade`.

--- a/sortinghat/core/migrations/0009_tenant_perm_group.py
+++ b/sortinghat/core/migrations/0009_tenant_perm_group.py
@@ -13,6 +13,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='tenant',
             name='perm_group',
-            field=models.CharField(default='readonly', max_length=128),
+            field=models.CharField(default='user', max_length=128),
         ),
     ]


### PR DESCRIPTION
The previous release included the users' permissions in the Group Django model. In the new release, they are included in the Tenant model. This code migrates the permissions for all the users.

Related to https://github.com/chaoss/grimoirelab-sortinghat/issues/849 