### PR TITLE
Close DB connection before job completion

### DIFF
--- a/releases/unreleased/connection-closed-when-job-is-executed.yml
+++ b/releases/unreleased/connection-closed-when-job-is-executed.yml
@@ -1,0 +1,12 @@
+---
+title: Connection closed when job is executed
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  RQ workers create a fork to run the jobs. The issue arises
+  when, after completing the job, the MariaDB logs display the
+  warning: `Aborted connection to db. Got an error reading
+  communication packets`. This change ensures the database
+  connection is closed before the fork ends, preventing the
+  warning from appearing.

--- a/sortinghat/config/settings.py
+++ b/sortinghat/config/settings.py
@@ -292,6 +292,10 @@ RQ_QUEUES = {
     }
 }
 
+RQ = {
+    'JOB_CLASS': 'sortinghat.core.jobs.SortingHatJob'
+}
+
 #
 # SortingHat Multi-tenant
 #


### PR DESCRIPTION
RQ workers create a fork to run the function. The issue arises when, after completing the job, the MariaDB logs display the warning: `Aborted connection to db. Got an error reading communication packets`. This change ensures the database connection is closed before the fork ends, preventing the warning from appearing.