### PR TITLE
[ui] Merge organizations on the edit modal

### DIFF
--- a/releases/unreleased/merge-organizations-when-adding-an-alias.yml
+++ b/releases/unreleased/merge-organizations-when-adding-an-alias.yml
@@ -1,0 +1,10 @@
+---
+title: Merge organizations when adding an alias
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  Users now have the option to merge the organizations
+  when adding an alias that already exists on the
+  "Edit organization" dialog. That option was only
+  previously available at the organization's detail page.

--- a/ui/src/components/OrganizationsTable.vue
+++ b/ui/src/components/OrganizationsTable.vue
@@ -120,6 +120,7 @@
       :aliases="modal.aliases"
       :add-alias="addAlias"
       :delete-alias="deleteAlias"
+      :merge="mergeItems"
       @updateOrganizations="getTableItems(page)"
     />
 


### PR DESCRIPTION
This PR adds the option to merge the organizations if the new alias already exists as an organization that was missing from the "Edit organization" modal.