### PR TITLE
Correct arrow direction when merging recommendations

### DIFF
--- a/releases/unreleased/wrong-arrong-direction-when-merging-recommendations.yml
+++ b/releases/unreleased/wrong-arrong-direction-when-merging-recommendations.yml
@@ -1,0 +1,11 @@
+---
+title: Wrong arrong direction when merging recommendations
+category: fixed
+author: Andre Klapper
+issue: 934
+notes: >
+  When recommendations were merged, the arrow showing the
+  direction of the merge was wrong. It showed `foo → bar`
+  but the resulting identity will be named `foo` instead
+  of `bar`. The arrow now points in the other direction
+  showing that `bar` will be merged on `foo`.

--- a/ui/src/components/Recommendations.vue
+++ b/ui/src/components/Recommendations.vue
@@ -97,7 +97,7 @@
             />
           </v-col>
           <v-col :cols="1" class="d-flex justify-center">
-            <v-icon>mdi-arrow-right</v-icon>
+            <v-icon>mdi-arrow-left</v-icon>
           </v-col>
           <v-col>
             <individual-card


### PR DESCRIPTION
Currently shows `foo → bar` but direction is inverted as the resulting entity will be named `foo` instead of `bar`.

Closes #934