### PR TITLE
Migrate files for branch rename from master to main

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -10,4 +10,4 @@ jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: bitergia/release-tools-check-changelog@master
+      - uses: bitergia/release-tools-check-changelog@main

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,7 +30,7 @@ jobs:
           yarn install
           yarn build
       - name: Build package using Poetry and store result
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: sortinghat-dist
           artifact-path: dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           yarn install
           yarn build
       - name: Build package using Poetry and store result
-        uses: chaoss/grimoirelab-github-actions/build@master
+        uses: chaoss/grimoirelab-github-actions/build@main
         with:
           artifact-name: sortinghat-dist
           artifact-path: dist
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create a new release on the repository
-        uses: chaoss/grimoirelab-github-actions/release@master
+        uses: chaoss/grimoirelab-github-actions/release@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish the package on PyPI
-        uses: chaoss/grimoirelab-github-actions/publish@master
+        uses: chaoss/grimoirelab-github-actions/publish@main
         with:
           artifact-name: sortinghat-dist
           artifact-path: dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to GrimoireLab Sorting Hat
 
 These are some general guidelines and information related to how we contribute to 
-GrimoireLab. You can read about it from the [CONTRIBUTING.md](https://github.com/chaoss/grimoirelab/blob/master/CONTRIBUTING.md).
+GrimoireLab. You can read about it from the [CONTRIBUTING.md](https://github.com/chaoss/grimoirelab/blob/main/CONTRIBUTING.md).
 
 ## Changelog Entries
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sorting Hat [![tests](https://github.com/chaoss/grimoirelab-sortinghat/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-sortinghat/actions?query=workflow:tests+branch:master+event:push) [![PyPI version](https://badge.fury.io/py/sortinghat.svg)](https://badge.fury.io/py/sortinghat)
+# Sorting Hat [![tests](https://github.com/chaoss/grimoirelab-sortinghat/workflows/tests/badge.svg)](https://github.com/chaoss/grimoirelab-sortinghat/actions?query=workflow:tests+branch:main+event:push) [![PyPI version](https://badge.fury.io/py/sortinghat.svg)](https://badge.fury.io/py/sortinghat)
 
 ## Description
 


### PR DESCRIPTION
Update files to support the migration of GrimoireLab repositories as part of the default branch transition from master to main.