### PR TITLE
Update version of django-cors-headers

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -227,19 +227,20 @@ bcrypt = ["bcrypt"]
 
 [[package]]
 name = "django-cors-headers"
-version = "3.14.0"
+version = "4.6.0"
 description = "django-cors-headers is a Django application for handling the server headers required for Cross-Origin Resource Sharing (CORS)."
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.9"
 groups = ["main"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
 files = [
-    {file = "django_cors_headers-3.14.0-py3-none-any.whl", hash = "sha256:684180013cc7277bdd8702b80a3c5a4b3fcae4abb2bf134dceb9f5dfe300228e"},
-    {file = "django_cors_headers-3.14.0.tar.gz", hash = "sha256:5fbd58a6fb4119d975754b2bc090f35ec160a8373f276612c675b00e8a138739"},
+    {file = "django_cors_headers-4.6.0-py3-none-any.whl", hash = "sha256:8edbc0497e611c24d5150e0055d3b178c6534b8ed826fb6f53b21c63f5d48ba3"},
+    {file = "django_cors_headers-4.6.0.tar.gz", hash = "sha256:14d76b4b4c8d39375baeddd89e4f08899051eeaf177cb02a29bd6eae8cf63aa8"},
 ]
 
 [package.dependencies]
-Django = ">=3.2"
+asgiref = ">=3.6"
+django = ">=4.2"
 
 [[package]]
 name = "django-graphql-jwt"
@@ -1692,4 +1693,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "3071a97484711e8f8b1332eeef3fac1f4b2a06d4df9d6b5c7c7f7093868f2d98"
+content-hash = "82b2727adc9cf02dd37dbc358db1930268427cc7af30e3fe7abd530d345891a9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ Jinja2 = "^3.1.1"
 rq = "^1.12.0"
 django-rq = "^2.3.2"
 pandas = "^2.2"
-django-cors-headers = "^3.7.0"
+django-cors-headers = "^4.6.0"
 PyJWT = "^2.4.0"
 uWSGI = "^2.0"
 django-treebeard = "^4.5.1"
@@ -73,7 +73,7 @@ grimoirelab-toolkit = { version = ">=0.3", allow-prereleases = true}
 django-storages = {extras = ["google"], version = "^1.13.2"}
 google-auth = "^2.18.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 fakeredis = "^2.0.0"
 httpretty = "^1.1.4"
 flake8 = "^7.1.1"


### PR DESCRIPTION
This commit updates the version of the `django-cors-headers` package to the latest version available.

This is needed to ensure compatibility with `grimoirelab-core`, which uses a newer version.