### PR TITLE
Include changelog for updated package

### DIFF
--- a/releases/unreleased/package-dependencies-updated.yml
+++ b/releases/unreleased/package-dependencies-updated.yml
@@ -1,0 +1,8 @@
+---
+title: Package dependencies updated
+category: dependency
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Update the version of django-cors-headers package to
+  the latest version available.


### PR DESCRIPTION
Include changelog to foce a new version after updating django-cors-headers package to the latest version available.