### PR TITLE
[ui] Rename recommendations view labels

### DIFF
--- a/releases/unreleased/renamed-recommendations-view-labels.yml
+++ b/releases/unreleased/renamed-recommendations-view-labels.yml
@@ -1,0 +1,8 @@
+---
+title: Renamed recommendations view labels
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 954
+notes: >
+  The text of the buttons on the recommendations view
+  was changed to make the actions to be performed clearer.

--- a/ui/src/components/Recommendations.vue
+++ b/ui/src/components/Recommendations.vue
@@ -127,21 +127,24 @@
 
         <v-card-actions class="px-0 mt-4">
           <v-btn
+            class="text-subtitle-2"
             color="primary darken-1"
             variant="text"
             @click.prevent="fetchItem(page + 1)"
           >
-            Skip
+            Ask again later
           </v-btn>
           <v-spacer></v-spacer>
           <v-btn
+            class="text-subtitle-2"
             color="primary darken-1"
-            variant="text"
+            variant="outlined"
             @click.prevent="applyRecommendation(false)"
           >
-            Dismiss
+            Keep separate
           </v-btn>
           <v-btn
+            class="text-subtitle-2"
             color="primary"
             variant="flat"
             @click.prevent="applyRecommendation(true)"


### PR DESCRIPTION
This PR renames the labels of the buttons on the recommendations view to make the actions clearer: `Skip` to `Ask again later` and `Dismiss` to `Keep separate`. The button text is too long to be in uppercase, so it is changed to lowercase.

![imagen](https://github.com/user-attachments/assets/86c8a6d3-ba3d-41d6-8e6e-912325fcff5c)

Fixes #954.