### PR TITLE
[ui] Fix dates different from input

### DIFF
--- a/releases/unreleased/affiliation-dates-different-from-input.yml
+++ b/releases/unreleased/affiliation-dates-different-from-input.yml
@@ -1,0 +1,9 @@
+---
+title: Affiliation dates different from input
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 966
+notes: >
+ Affiliation dates shown in the user interface were
+ sometimes different from the ones entered in the
+ edit form.

--- a/ui/src/components/DateInput.vue
+++ b/ui/src/components/DateInput.vue
@@ -95,7 +95,7 @@ export default {
           const dateTime = `${dateString}T00:00:00+00:00`;
 
           this.inputDate = dateString;
-          this.pickerDate = dateObject;
+          this.pickerDate = dateString;
           this.$emit("update:modelValue", dateTime);
         } catch {
           this.setError("Invalid date");
@@ -105,13 +105,6 @@ export default {
         this.$emit("update:modelValue", null);
         this.inputDate = "";
         this.pickerDate = null;
-      }
-    },
-  },
-  watch: {
-    modelValue(newValue, oldValue) {
-      if (newValue?.substring(0, 9) !== oldValue?.substring(0, 9)) {
-        this.formatDate(newValue);
       }
     },
   },

--- a/ui/tests/unit/dateInput.spec.js
+++ b/ui/tests/unit/dateInput.spec.js
@@ -16,12 +16,12 @@ describe("DateInput", () => {
   };
 
   test("Sets date in the right formats", async () => {
-    const wrapper = mountFunction();
-    await wrapper.setProps({ modelValue: "2020" });
+    const wrapper = mountFunction({ props: { modelValue: "2020" } });
+    wrapper.find("input").trigger("change");
 
     // YYYYYY-MM-DD format in the UI
     expect(wrapper.vm.inputDate).toBe("2020-01-01");
-    expect(wrapper.vm.pickerDate).toEqual(new Date("2020"));
+    expect(wrapper.vm.pickerDate).toEqual("2020-01-01");
 
     // Emit ISO date for the v-model
     expect(wrapper.emitted("update:modelValue")[1]).toEqual([
@@ -30,8 +30,7 @@ describe("DateInput", () => {
   });
 
   test("Shows an error for an invalid date", async () => {
-    const wrapper = mountFunction();
-    await wrapper.setProps({ modelValue: "invalid date" });
+    const wrapper = mountFunction({ props: { modelValue: "invalid date" } });
 
     expect(wrapper.vm.error).toBe("Invalid date");
     expect(wrapper.find('[role="alert"]').exists()).toBe(true);


### PR DESCRIPTION
This PR fixes the issue with the affiliation input dates being different from the saved value in some timezones.

Fixes #966.