### PR TITLE
Allow pasting LinkedIn URLs

### DIFF
--- a/releases/unreleased/allow-pasting-linkedin-url.yml
+++ b/releases/unreleased/allow-pasting-linkedin-url.yml
@@ -1,0 +1,8 @@
+---
+title: Allow pasting LinkedIn URL
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 967
+notes: >
+  The form to add a LinkedIn profile to a user now
+  allows entering the full URL.

--- a/sortinghat/core/aux.py
+++ b/sortinghat/core/aux.py
@@ -21,6 +21,8 @@
 
 import re
 
+from urllib.parse import urlparse
+
 from .models import MIN_PERIOD_DATE, MAX_PERIOD_DATE
 
 
@@ -128,3 +130,6 @@ def validate_field(name, value, allow_none=False):
     m = re.match(r"^\s+$", value)
     if m:
         raise ValueError("'{}' cannot be composed by whitespaces only".format(name))
+
+    if urlparse(value).scheme:
+        raise ValueError(f"'{name}' cannot be a URL")

--- a/tests/test_aux.py
+++ b/tests/test_aux.py
@@ -30,6 +30,7 @@ FIELD_NONE_ERROR = "'{name}' cannot be None"
 FIELD_EMPTY_ERROR = "'{name}' cannot be an empty string"
 FIELD_WHITESPACES_ERROR = "'{name}' cannot be composed by whitespaces only"
 FIELD_TYPE_ERROR = "field value must be a string; int given"
+FIELD_URL_ERROR = "'{name}' cannot be a URL"
 
 
 class TestMergeDatetimeRanges(TestCase):
@@ -398,6 +399,10 @@ class TestValidateField(TestCase):
         with self.assertRaisesRegex(ValueError, expected):
             validate_field('test_field', '  \t ')
 
+        expected = FIELD_URL_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', 'https://example.com')
+
     def test_allow_none(self):
         """Check valid and invalid fields allowing `None` values"""
 
@@ -414,6 +419,10 @@ class TestValidateField(TestCase):
         expected = FIELD_WHITESPACES_ERROR.format(name='test_field')
         with self.assertRaisesRegex(ValueError, expected):
             validate_field('test_field', ' \t ', allow_none=True)
+
+        expected = FIELD_URL_ERROR.format(name='test_field')
+        with self.assertRaisesRegex(ValueError, expected):
+            validate_field('test_field', 'https://example.com', allow_none=True)
 
     def test_no_string(self):
         """Check if an exception is raised when the value type is not a string"""

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -167,6 +167,7 @@
                   <v-divider inline></v-divider>
                   <v-list-item
                     :disabled="individual.isLocked"
+                    base-color="error"
                     @click="confirmDelete"
                   >
                     <v-list-item-title>Delete individual</v-list-item-title>
@@ -366,9 +367,8 @@
         <v-card-text>
           <v-text-field
             v-model="linkedinModal.username"
-            label="LinkedIn username"
-            prefix="https://www.linkedin.com/in/"
-            placeholder="username"
+            label="LinkedIn profile URL or username"
+            placeholder="https://www.linkedin.com/in/"
             autofocus
           ></v-text-field>
         </v-card-text>
@@ -800,6 +800,11 @@ export default {
     },
     async addLinkedInProfile() {
       try {
+        const linkedinURL = /(linkedin\.com\/in\/)(.*?)(\/|$|\?)(.*)/;
+        const match = this.linkedinModal.username.match(linkedinURL);
+        if (match) {
+          this.linkedinModal.username = match[2];
+        }
         const response = await addLinkedinProfile(
           this.$apollo,
           this.mk,


### PR DESCRIPTION
This PR allows users to enter a URL when they add a LinkedIn profile. The input value is cleaned and only the slug of the URL is saved. A server-side validation is also added to check that a URL was not passed.

Fixes #967.