### PR TITLE
Add traceability to SortingHat profiles 

### DIFF
--- a/releases/unreleased/history-of-profile-changes.yml
+++ b/releases/unreleased/history-of-profile-changes.yml
@@ -1,0 +1,9 @@
+---
+title: History of profile changes
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 972
+notes: >
+  Individuals' profiles now include a history of changes
+  and whether the actions were performed by a user or an
+  automated process.

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -234,12 +234,19 @@ class CountryType(DjangoObjectType):
         model = Country
 
 
+class ChangeLogType(DjangoObjectType):
+    class Meta:
+        model = Transaction
+        fields = ('name', 'authored_by', 'created_at', 'tuid')
+
+
 class IndividualType(DjangoObjectType):
     class Meta:
         model = Individual
         exclude = ('match_recommendation_individual_1', 'match_recommendation_individual_2')
 
     match_recommendation_set = graphene.List(lambda: IndividualRecommendedMergeType)
+    changelog = graphene.List(lambda: ChangeLogType)
 
     @check_auth
     def resolve_match_recommendation_set(self, info):
@@ -250,6 +257,12 @@ class IndividualType(DjangoObjectType):
             indv = rec.individual1 if rec.individual1.mk != self.mk else rec.individual2
             indv_recs.append(IndividualRecommendedMergeType(id=rec.id, individual=indv))
         return indv_recs
+
+    @check_auth
+    def resolve_changelog(self, info):
+        query = Transaction.objects.order_by('-created_at').filter(operations__target=self.mk).distinct()[:10]
+
+        return query
 
 
 class IdentityType(DjangoObjectType):

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -237,7 +237,6 @@ class CountryType(DjangoObjectType):
 class ChangeLogType(DjangoObjectType):
     class Meta:
         model = Transaction
-        fields = ('name', 'authored_by', 'created_at', 'tuid')
 
 
 class IndividualType(DjangoObjectType):

--- a/ui/src/apollo/fragments.js
+++ b/ui/src/apollo/fragments.js
@@ -66,6 +66,10 @@ const CHANGELOG = gql`
     name
     authoredBy
     createdAt
+    operations {
+      entityType
+      args
+    }
   }
 `;
 

--- a/ui/src/apollo/fragments.js
+++ b/ui/src/apollo/fragments.js
@@ -61,9 +61,18 @@ const FULL_INDIVIDUAL = gql`
   ${INDIVIDUAL_IDENTITIES}
 `;
 
+const CHANGELOG = gql`
+  fragment changelog on ChangeLogType {
+    name
+    authoredBy
+    createdAt
+  }
+`;
+
 export {
   FULL_INDIVIDUAL,
   INDIVIDUAL_ENROLLMENTS,
   INDIVIDUAL_IDENTITIES,
   INDIVIDUAL_PROFILE,
+  CHANGELOG,
 };

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import { FULL_INDIVIDUAL } from "./fragments";
+import { CHANGELOG, FULL_INDIVIDUAL } from "./fragments";
 
 const TOKEN_AUTH = gql`
   mutation tokenAuth($username: String!, $password: String!) {
@@ -15,10 +15,14 @@ const LOCK_INDIVIDUAL = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const UNLOCK_INDIVIDUAL = gql`
@@ -27,10 +31,14 @@ const UNLOCK_INDIVIDUAL = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const DELETE_IDENTITY = gql`
@@ -63,10 +71,14 @@ const UNMERGE = gql`
       uuids
       individuals {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const MOVE_IDENTITY = gql`
@@ -99,10 +111,14 @@ const ENROLL = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const ADD_ORGANIZATION = gql`
@@ -179,6 +195,9 @@ const UPDATE_PROFILE = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
         matchRecommendationSet {
           id
           individual {
@@ -189,6 +208,7 @@ const UPDATE_PROFILE = gql`
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const DELETE_DOMAIN = gql`
@@ -219,10 +239,14 @@ const WITHDRAW = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const DELETE_ORGANIZATION = gql`
@@ -267,10 +291,14 @@ const UPDATE_ENROLLMENT = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const AFFILIATE = gql`
@@ -450,10 +478,14 @@ const ADD_LINKEDIN_PROFILE = gql`
     addIdentity(uuid: $uuid, username: $username, source: "linkedin") {
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const DELETE_MERGE_RECOMMENDATIONS = gql`
@@ -470,6 +502,9 @@ const REVIEW_INDIVIDUAL = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
         matchRecommendationSet {
           id
           individual {
@@ -480,6 +515,7 @@ const REVIEW_INDIVIDUAL = gql`
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const tokenAuth = (apollo, username, password) => {

--- a/ui/src/apollo/queries.js
+++ b/ui/src/apollo/queries.js
@@ -1,5 +1,5 @@
 import gql from "graphql-tag";
-import { FULL_INDIVIDUAL } from "./fragments";
+import { CHANGELOG, FULL_INDIVIDUAL } from "./fragments";
 
 const GET_INDIVIDUAL_BYUUID = gql`
   query GetIndividual($uuid: String!) {
@@ -12,10 +12,14 @@ const GET_INDIVIDUAL_BYUUID = gql`
             ...individual
           }
         }
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const GET_INDIVIDUALS = gql`

--- a/ui/src/components/ChangeLog.stories.js
+++ b/ui/src/components/ChangeLog.stories.js
@@ -1,0 +1,34 @@
+import ChangeLog from "./ChangeLog.vue";
+
+export default {
+  title: "ChangeLog",
+  excludeStories: /.*Data$/,
+};
+
+const template = '<change-log :changes="items" />';
+
+export const Default = () => ({
+  components: { ChangeLog },
+  template: template,
+  props: {
+    items: {
+      default: [
+        {
+          authoredBy: "username",
+          createdAt:"2025-05-26T14:09:47.641485+00:00",
+          name: "enroll"
+        },
+        {
+          authoredBy: null,
+          createdAt: "2025-05-21T14:07:57.895366+00:00",
+          name: "merge-f95eb11f-974a-40b1-91bc-bb4060d5830a"
+        },
+        {
+          authoredBy: "username",
+          createdAt: "2024-07-29T13:52:05.116020+00:00",
+          name: "unmerge_identities"
+        }
+      ]
+    }
+  },
+});

--- a/ui/src/components/ChangeLog.stories.js
+++ b/ui/src/components/ChangeLog.stories.js
@@ -15,20 +15,31 @@ export const Default = () => ({
       default: [
         {
           authoredBy: "username",
-          createdAt:"2025-05-26T14:09:47.641485+00:00",
-          name: "enroll"
+          createdAt: "2025-05-26T14:09:47.641485+00:00",
+          name: "enroll",
+          operations: [
+            {
+              args: { group: "Hogwarts" },
+            },
+          ],
         },
         {
           authoredBy: null,
           createdAt: "2025-05-21T14:07:57.895366+00:00",
-          name: "merge-f95eb11f-974a-40b1-91bc-bb4060d5830a"
+          name: "merge-f95eb11f-974a-40b1-91bc-bb4060d5830a",
+          operations: [
+            {
+              entityType: "identity",
+              args: { identity: "4263b9a4f2e2cf5d2ec47f23ae4bec30d2e2d978" },
+            },
+          ],
         },
         {
           authoredBy: "username",
           createdAt: "2024-07-29T13:52:05.116020+00:00",
-          name: "unmerge_identities"
-        }
-      ]
-    }
+          name: "unmerge_identities",
+        },
+      ],
+    },
   },
 });

--- a/ui/src/components/ChangeLog.vue
+++ b/ui/src/components/ChangeLog.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="fit-content">
+    <v-list-subheader class="text-subtitle-2 mb-2"> Activity </v-list-subheader>
+    <v-timeline v-if="changes.length > 0" side="end">
+      <v-timeline-item
+        v-for="item in changes"
+        :key="item.tuid"
+        dot-color="on-surface-variant"
+        size="x-small"
+        line-thickness="1"
+      >
+        <span class="font-weight-medium">
+          {{
+            item.name.includes("-") ? "An automated process" : item.authoredBy
+          }}
+        </span>
+        {{ parseText(item) }}
+      </v-timeline-item>
+    </v-timeline>
+    <p v-else class="v-timeline">No recent activity for this profile</p>
+  </div>
+</template>
+<script>
+export default {
+  props: {
+    changes: {
+      type: Array,
+      required: true,
+    },
+  },
+  methods: {
+    parseText(item) {
+      const actions = {
+        add_identity: "added an identity",
+        enroll: "added an organization",
+        lock: "locked the profile",
+        merge: "merged identities",
+        unmerge_identities: "split identities",
+        unlock: "unlocked the profile",
+        update_profile: "updated profile data",
+        withdraw: "removed an organization",
+        review: "reviewed the profile",
+      };
+      const name = item.name.split("-")[0];
+
+      const action = actions[name] || name.replace("-", " ");
+      const date = this.$formatDate(item.createdAt, "YYYY-MM-DD");
+
+      return `${action} on ${date}`;
+    },
+  },
+};
+</script>
+<style lang="scss">
+.fit-content {
+  width: fit-content;
+}
+
+.v-timeline {
+  font-size: 0.875rem;
+  color: rgb(var(--v-theme-on-surface-variant));
+}
+
+.v-timeline-divider__dot--size-x-small {
+  height: 12px;
+  width: 12px;
+}
+
+.v-timeline--vertical .v-timeline-item:last-child .v-timeline-divider__after {
+  height: 0;
+}
+
+.v-timeline--vertical.v-timeline.v-timeline--side-end
+  .v-timeline-item
+  .v-timeline-item__opposite {
+  padding-inline-end: 20px;
+}
+</style>

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -267,7 +267,7 @@
             </v-container>
           </v-row>
 
-          <v-row class="section">
+          <v-row class="section mb-4">
             <v-container fluid>
               <enrollment-list
                 v-if="individual.enrollments"
@@ -278,6 +278,12 @@
                 @updateEnrollment="updateEnrollment"
                 @withdraw="withdraw"
               />
+            </v-container>
+          </v-row>
+
+          <v-row class="section mb-0">
+            <v-container>
+              <change-log :changes="changelog" />
             </v-container>
           </v-row>
         </v-col>
@@ -450,6 +456,7 @@ import TeamEnrollModal from "../components/TeamEnrollModal.vue";
 import MatchesModal from "../components/MatchesModal.vue";
 import EditDialog from "../components/EditDialog.vue";
 import LoadingSpinner from "../components/LoadingSpinner.vue";
+import ChangeLog from "../components/ChangeLog.vue";
 
 export default {
   name: "Individual",
@@ -463,6 +470,7 @@ export default {
     MatchesModal,
     EditDialog,
     LoadingSpinner,
+    ChangeLog,
   },
   mixins: [enrollMixin],
   apollo: {
@@ -473,6 +481,7 @@ export default {
         result(result) {
           if (result.data.individuals.entities.length === 1) {
             this.updateIndividual(result.data.individuals.entities);
+            // this.getChangelog(this.mk);
           } else if (result.errors) {
             this.error = this.$getErrorMessage(result.errors[0]);
           } else {
@@ -508,6 +517,7 @@ export default {
       socialProfiles: [],
       mk: this.$route.params.mk,
       error: null,
+      changelog: [],
     };
   },
   computed: {
@@ -724,6 +734,7 @@ export default {
 
       this.individual = formatIndividual(newData[0]);
       this.socialProfiles = this.getSocialProfiles(newData[0]);
+      this.changelog = newData[0].changelog;
 
       Object.assign(this.form, {
         name: this.individual.name,

--- a/ui/tests/unit/__snapshots__/individual.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/individual.spec.js.snap
@@ -1361,7 +1361,7 @@ exports[`Individual Matches snapshot 1`] = `
               </div>
             </div>
             <div
-              class="v-row section"
+              class="v-row section mb-4"
             >
               <div
                 class="v-container v-container--fluid v-locale--is-ltr"
@@ -1449,6 +1449,34 @@ exports[`Individual Matches snapshot 1`] = `
                   </div>
                   
                   
+                </div>
+              </div>
+            </div>
+            <div
+              class="v-row section mb-0"
+            >
+              <div
+                class="v-container v-locale--is-ltr"
+              >
+                <div
+                  class="fit-content"
+                >
+                  <div
+                    class="v-list-subheader text-subtitle-2 mb-2"
+                  >
+                    <div
+                      class="v-list-subheader__text"
+                    >
+                      
+                       Activity 
+                      
+                    </div>
+                  </div>
+                  <p
+                    class="v-timeline"
+                  >
+                    No recent activity for this profile
+                  </p>
                 </div>
               </div>
             </div>

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -82,6 +82,180 @@ exports[`Storybook Tests Avatar SingleInitial 1`] = `
 </div>
 `;
 
+exports[`Storybook Tests ChangeLog Default 1`] = `
+<div>
+  <div
+    class="fit-content"
+  >
+    <div
+      class="v-list-subheader text-subtitle-2 mb-2"
+    >
+      <div
+        class="v-list-subheader__text"
+      >
+        
+         Activity 
+        
+      </div>
+    </div>
+    <div
+      class="v-timeline v-timeline--vertical v-timeline--align-center v-timeline--justify-auto v-theme--light v-timeline--density-default v-timeline--side-end v-locale--is-ltr"
+      style="--v-timeline-line-thickness: 2px;"
+    >
+      
+      <div
+        class="v-timeline-item"
+        line-thickness="1"
+        style="--v-timeline-dot-size: 0px; --v-timeline-line-inset: 0px;"
+      >
+        <div
+          class="v-timeline-item__body"
+        >
+          
+          <span
+            class="font-weight-medium"
+          >
+            username
+          </span>
+           added an organization on 2025-05-26
+          
+        </div>
+        <div
+          class="v-timeline-divider"
+        >
+          <div
+            class="v-timeline-divider__before"
+          />
+          <div
+            class="v-timeline-divider__dot v-timeline-divider__dot--size-x-small"
+          >
+            <div
+              class="v-timeline-divider__inner-dot bg-on-surface-variant"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-theme--light v-icon--size-x-small"
+              >
+                
+                <!---->
+                
+              </i>
+            </div>
+          </div>
+          <div
+            class="v-timeline-divider__after"
+          />
+        </div>
+        <div
+          class="v-timeline-item__opposite"
+        >
+          <!---->
+        </div>
+      </div>
+      <div
+        class="v-timeline-item"
+        line-thickness="1"
+        style="--v-timeline-dot-size: 0px; --v-timeline-line-inset: 0px;"
+      >
+        <div
+          class="v-timeline-item__body"
+        >
+          
+          <span
+            class="font-weight-medium"
+          >
+            An automated process
+          </span>
+           merged identities on 2025-05-21
+          
+        </div>
+        <div
+          class="v-timeline-divider"
+        >
+          <div
+            class="v-timeline-divider__before"
+          />
+          <div
+            class="v-timeline-divider__dot v-timeline-divider__dot--size-x-small"
+          >
+            <div
+              class="v-timeline-divider__inner-dot bg-on-surface-variant"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-theme--light v-icon--size-x-small"
+              >
+                
+                <!---->
+                
+              </i>
+            </div>
+          </div>
+          <div
+            class="v-timeline-divider__after"
+          />
+        </div>
+        <div
+          class="v-timeline-item__opposite"
+        >
+          <!---->
+        </div>
+      </div>
+      <div
+        class="v-timeline-item"
+        line-thickness="1"
+        style="--v-timeline-dot-size: 0px; --v-timeline-line-inset: 0px;"
+      >
+        <div
+          class="v-timeline-item__body"
+        >
+          
+          <span
+            class="font-weight-medium"
+          >
+            username
+          </span>
+           split identities on 2024-07-29
+          
+        </div>
+        <div
+          class="v-timeline-divider"
+        >
+          <div
+            class="v-timeline-divider__before"
+          />
+          <div
+            class="v-timeline-divider__dot v-timeline-divider__dot--size-x-small"
+          >
+            <div
+              class="v-timeline-divider__inner-dot bg-on-surface-variant"
+            >
+              <i
+                aria-hidden="true"
+                class="v-icon notranslate v-theme--light v-icon--size-x-small"
+              >
+                
+                <!---->
+                
+              </i>
+            </div>
+          </div>
+          <div
+            class="v-timeline-divider__after"
+          />
+        </div>
+        <div
+          class="v-timeline-item__opposite"
+        >
+          <!---->
+        </div>
+      </div>
+      
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Storybook Tests DateInput Default 1`] = `
 <div>
   <div

--- a/ui/tests/unit/__snapshots__/storybook.spec.js.snap
+++ b/ui/tests/unit/__snapshots__/storybook.spec.js.snap
@@ -117,7 +117,7 @@ exports[`Storybook Tests ChangeLog Default 1`] = `
           >
             username
           </span>
-           added an organization on 2025-05-26
+           enrolled individual in Hogwarts on 2025-05-26
           
         </div>
         <div
@@ -166,7 +166,7 @@ exports[`Storybook Tests ChangeLog Default 1`] = `
           >
             An automated process
           </span>
-           merged identities on 2025-05-21
+           merged identity 4263b9a on 2025-05-21
           
         </div>
         <div
@@ -215,7 +215,7 @@ exports[`Storybook Tests ChangeLog Default 1`] = `
           >
             username
           </span>
-           split identities on 2024-07-29
+           split identity on 2024-07-29
           
         </div>
         <div

--- a/ui/tests/unit/individual.spec.js
+++ b/ui/tests/unit/individual.spec.js
@@ -44,6 +44,7 @@ describe("Individual", () => {
       ],
       enrollments: [],
       matchRecommendationSet: [],
+      changelog: [],
     },
   ];
 


### PR DESCRIPTION
This PR adds a `changelog` field to the `individuals` GraphQL query, which returns a list of their 10 latest related transactions. The UI shows this list as a timeline on each individual's profile view.

Fixes #972 