### PR TITLE
[ui] Fix affiliation date calendar

### DIFF
--- a/releases/unreleased/fix-unresponsive-affiliation-calendar.yml
+++ b/releases/unreleased/fix-unresponsive-affiliation-calendar.yml
@@ -1,0 +1,9 @@
+---
+title: Fixed unresponsive affiliation calendar
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 974
+notes: >
+  The calendar for affiliating didn't close after
+  selecting a date and updated the input box with
+  a wrong date.

--- a/ui/src/components/DateInput.vue
+++ b/ui/src/components/DateInput.vue
@@ -91,11 +91,17 @@ export default {
       if (date) {
         try {
           const dateObject = this.dateFormatter.date(date);
-          const dateString = this.dateFormatter.toISO(dateObject);
+          const timeZoneOffset = Math.abs(
+            dateObject.getTimezoneOffset() * -60000
+          );
+          const normalizedDate = new Date(
+            dateObject.getTime() + timeZoneOffset
+          );
+          const dateString = this.dateFormatter.toISO(normalizedDate);
           const dateTime = `${dateString}T00:00:00+00:00`;
 
           this.inputDate = dateString;
-          this.pickerDate = dateString;
+          this.pickerDate = normalizedDate;
           this.$emit("update:modelValue", dateTime);
         } catch {
           this.setError("Invalid date");

--- a/ui/tests/unit/dateInput.spec.js
+++ b/ui/tests/unit/dateInput.spec.js
@@ -8,20 +8,17 @@ describe("DateInput", () => {
       global: {
         plugins: [vuetify],
       },
-      props: {
-        label: "Label",
-      },
       ...options,
     });
   };
 
   test("Sets date in the right formats", async () => {
-    const wrapper = mountFunction({ props: { modelValue: "2020" } });
+    const wrapper = mountFunction({ props: { modelValue: "2020", label: "Label" } });
     wrapper.find("input").trigger("change");
 
     // YYYYYY-MM-DD format in the UI
     expect(wrapper.vm.inputDate).toBe("2020-01-01");
-    expect(wrapper.vm.pickerDate).toEqual("2020-01-01");
+    expect(wrapper.vm.pickerDate.toJSON()).toMatch("2020-01-01");
 
     // Emit ISO date for the v-model
     expect(wrapper.emitted("update:modelValue")[1]).toEqual([
@@ -30,7 +27,7 @@ describe("DateInput", () => {
   });
 
   test("Shows an error for an invalid date", async () => {
-    const wrapper = mountFunction({ props: { modelValue: "invalid date" } });
+    const wrapper = mountFunction({ props: { modelValue: "invalid date",label: "Label" } });
 
     expect(wrapper.vm.error).toBe("Invalid date");
     expect(wrapper.find('[role="alert"]').exists()).toBe(true);


### PR DESCRIPTION
This PR changes the `DateInput` component to pass the date to `VCalendar` in the format it expects, while accounting for the user's timezone. The wrong format caused the calendar component to crash.

Fixes #974 