### PR TITLE
[ui] Press Enter key to log in

### DIFF
--- a/releases/unreleased/press-enter-key-to-log-in.yml
+++ b/releases/unreleased/press-enter-key-to-log-in.yml
@@ -1,0 +1,8 @@
+---
+title: Press Enter key to log in
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 980
+notes: >
+  Users can now press the `Enter` key after entering
+  the username and password to log in.

--- a/ui/src/views/Login.vue
+++ b/ui/src/views/Login.vue
@@ -11,6 +11,7 @@
             id="username"
             outlined
             dense
+            @keyup.enter="submit"
           />
           <v-text-field
             v-model="password"
@@ -21,6 +22,7 @@
             outlined
             dense
             @click:append="showPassword = !showPassword"
+            @keyup.enter="submit"
           />
           <v-alert v-if="errorMessage" text type="error">
             {{ errorMessage }}


### PR DESCRIPTION
This PR allows users to press the `Enter` key after entering the username and password to log in.

Fixes #980 