### PR TITLE
[importer] Add method to post-processing individuals

### DIFF
--- a/releases/unreleased/post-processing-of-imported-individuals.yml
+++ b/releases/unreleased/post-processing-of-imported-individuals.yml
@@ -1,0 +1,11 @@
+---
+title: Post processing of imported individuals
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  The new method `post_process_individual` allows to post-process
+  individuals after they are imported. For example, you might want
+  to merge the imported identities with others already existing using
+  custom criteria, or to set the profile of the new identities in
+  using specific values, or affiliate them to predefined organizations.


### PR DESCRIPTION
After individuals are imported they can be post-processed by implementing the new method 'post_process_individual'. This is useful for adding extra information to the individuals added using the data already available in the registry.