### PR TITLE
Correct affiliate process to prevent overwriting

### DIFF
--- a/releases/unreleased/automatic-affiliation-fixed-and-reduced-results.yml
+++ b/releases/unreleased/automatic-affiliation-fixed-and-reduced-results.yml
@@ -1,0 +1,9 @@
+---
+title: Automatic affiliation fixed and reduced results
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 994
+notes: >
+  Fixes a bug that caused running the affiliate process to overwrite
+  existing affiliation dates. Now, the job result only includes
+  individuals who were newly affiliated.

--- a/sortinghat/core/db.py
+++ b/sortinghat/core/db.py
@@ -292,7 +292,7 @@ def find_alias(name):
 def search_enrollments_in_period(mk, group_name,
                                  parent_org=None,
                                  from_date=MIN_PERIOD_DATE,
-                                 to_date=MIN_PERIOD_DATE):
+                                 to_date=MAX_PERIOD_DATE):
     """Look for enrollments in a given period.
 
     Returns the enrollments of an individual for a given

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -202,6 +202,10 @@ def recommend_affiliations(ctx, uuids=None, last_modified=MIN_PERIOD_DATE):
     trxl = TransactionsLog.open('recommend_affiliations', job_ctx)
 
     for rec in engine.recommend('affiliation', uuids, last_modified):
+        # Avoid storing empty recommendations
+        if not rec.options:
+            continue
+
         results[rec.key] = rec.options
 
         for org_name in rec.options:
@@ -447,10 +451,11 @@ def affiliate(ctx, uuids=None, last_modified=MIN_PERIOD_DATE):
 
     for rec in engine.recommend('affiliation', uuids, last_modified):
         affiliated, errs = _affiliate_individual(job_ctx, rec.key, rec.options)
-        results[rec.key] = affiliated
+
         errors.extend(errs)
 
         if affiliated:
+            results[rec.key] = affiliated
             nsuccess += 1
 
     trxl.close()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -148,7 +148,6 @@ class TestRecommendAffiliations(TestCase):
         # Test
         expected = {
             'results': {
-                '0c1e1701bc819495acf77ef731023b7d789a9c71': [],
                 '17ab00ed3825ec2f50483e33c88df223264182ba': ['Bitergia', 'Example'],
                 'dc31d2afbee88a6d1dbc1ef05ec827b878067744': ['Example']
             }
@@ -364,7 +363,6 @@ class TestAffiliateIndividuals(TestCase):
         # Test
         expected = {
             'results': {
-                '0c1e1701bc819495acf77ef731023b7d789a9c71': [],
                 '17ab00ed3825ec2f50483e33c88df223264182ba': ['Bitergia', 'Example'],
                 'dc31d2afbee88a6d1dbc1ef05ec827b878067744': ['Example']
             },
@@ -508,9 +506,7 @@ class TestAffiliateIndividuals(TestCase):
 
         # Test
         expected = {
-            'results': {
-                'dc31d2afbee88a6d1dbc1ef05ec827b878067744': []
-            },
+            'results': {},
             'errors': [
                 "dc31d2afbee88a6d1dbc1ef05ec827b878067744 not found in the registry"
             ]
@@ -536,9 +532,7 @@ class TestAffiliateIndividuals(TestCase):
 
         # Test
         expected = {
-            'results': {
-                'dc31d2afbee88a6d1dbc1ef05ec827b878067744': []
-            },
+            'results': {},
             'errors': [
                 "range date '1900-01-01'-'2100-01-01' is part of an existing range for Example"
             ]


### PR DESCRIPTION
This change fixes a bug in the affiliate process. Previously, the process would overwrite existing affiliation dates, leading to incorrect results. Now, it only includes individuals who are newly affiliated, ensuring accurate data retention.

Fixes https://github.com/chaoss/grimoirelab-sortinghat/issues/994