### PR TITLE
Option to match GitHub emails to usernames

### DIFF
--- a/releases/unreleased/recommendations-based-on-github-generated-email-addresses.yml
+++ b/releases/unreleased/recommendations-based-on-github-generated-email-addresses.yml
@@ -1,0 +1,10 @@
+---
+title: Recommendations based on GitHub-generated email addresses
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 867
+notes: >
+  Merge recommendations can now match GitHub profiles to
+  GitHub-generated emails (<username>@users.noreply.github.com).
+  Individuals can also be automatically unified with this
+  criteria.

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -241,6 +241,7 @@ def recommend_matches(ctx, source_uuids,
                       target_uuids, criteria,
                       exclude=True, verbose=False,
                       strict=True, match_source=False,
+                      guess_github_user=False,
                       last_modified=MIN_PERIOD_DATE):
     """Generate a list of affiliation recommendations from a set of individuals.
 
@@ -268,6 +269,7 @@ def recommend_matches(ctx, source_uuids,
     :param verbose: if set to `True`, the match results will be composed by individual
         identities (even belonging to the same individual).
     :param match_source: only unify individuals that share the same source
+    :param guess_github_user: match GitHub-generated emails with usernames
     :param last_modified: generate recommendations only for individuals modified after
         this date
 
@@ -299,6 +301,7 @@ def recommend_matches(ctx, source_uuids,
                                        verbose,
                                        strict,
                                        match_source,
+                                       guess_github_user,
                                        last_modified)
     for rec in recommendations:
         results[rec.key] = list(rec.options)
@@ -471,7 +474,7 @@ def affiliate(ctx, uuids=None, last_modified=MIN_PERIOD_DATE):
 @django_rq.job
 @job_using_tenant
 def unify(ctx, criteria, source_uuids=None, target_uuids=None, exclude=True,
-          strict=True, match_source=False, last_modified=MIN_PERIOD_DATE):
+          strict=True, match_source=False, guess_github_user=False, last_modified=MIN_PERIOD_DATE):
     """Unify a set of individuals by merging them using matching recommendations.
 
     This function automates the identities unify process obtaining
@@ -496,6 +499,7 @@ def unify(ctx, criteria, source_uuids=None, target_uuids=None, exclude=True,
         if any value from the `email`, `name`, or `username` fields are found in the
         RecommenderExclusionTerm table. Otherwise, results will not ignore them.
     :param match_source: only unify individuals that share the same source
+    :param guess_github_user: match GitHub-generated emails with usernames
     :param last_modified: only unify individuals that have been modified after this date
 
     :returns: a list with the individuals resulting from merge operations
@@ -562,6 +566,7 @@ def unify(ctx, criteria, source_uuids=None, target_uuids=None, exclude=True,
                                 exclude=exclude,
                                 strict=strict,
                                 match_source=match_source,
+                                guess_github_user=guess_github_user,
                                 last_modified=last_modified):
         match_recs[rec.mk] = list(rec.options)
 

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1162,6 +1162,7 @@ class RecommendMatches(graphene.Mutation):
         strict = graphene.Boolean(required=False)
         match_source = graphene.Boolean(required=False)
         last_modified = graphene.DateTime(required=False)
+        guess_github_user = graphene.Boolean(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
 
@@ -1170,7 +1171,8 @@ class RecommendMatches(graphene.Mutation):
     def mutate(self, info, criteria,
                source_uuids=None, target_uuids=None,
                exclude=True, verbose=False, strict=True,
-               match_source=False, last_modified=MIN_PERIOD_DATE):
+               match_source=False, guess_github_user=False,
+               last_modified=MIN_PERIOD_DATE):
         user = info.context.user
         tenant = get_db_tenant()
         ctx = SortingHatContext(user=user, tenant=tenant)
@@ -1187,6 +1189,7 @@ class RecommendMatches(graphene.Mutation):
                                                verbose,
                                                strict,
                                                match_source,
+                                               guess_github_user,
                                                last_modified,
                                                job_timeout=-1,
                                                result_ttl=DEFAULT_JOB_RESULT_TTL,
@@ -1260,6 +1263,7 @@ class Unify(graphene.Mutation):
         exclude = graphene.Boolean(required=False)
         strict = graphene.Boolean(required=False)
         match_source = graphene.Boolean(required=False)
+        guess_github_user = graphene.Boolean(required=False)
         last_modified = graphene.DateTime(required=False)
 
     job_id = graphene.Field(lambda: graphene.String)
@@ -1270,6 +1274,7 @@ class Unify(graphene.Mutation):
                source_uuids=None, target_uuids=None,
                exclude=True, strict=True,
                match_source=False,
+               guess_github_user=False,
                last_modified=MIN_PERIOD_DATE):
         user = info.context.user
         tenant = get_db_tenant()
@@ -1286,6 +1291,7 @@ class Unify(graphene.Mutation):
                                                exclude,
                                                strict,
                                                match_source,
+                                               guess_github_user,
                                                last_modified,
                                                job_timeout=-1,
                                                result_ttl=DEFAULT_JOB_RESULT_TTL,

--- a/tests/rec/test_matches.py
+++ b/tests/rec/test_matches.py
@@ -500,3 +500,59 @@ class TestRecommendMatches(TestCase):
         self.assertEqual(rec[0], self.jr2.uuid)
         self.assertEqual(rec[1], self.jr2.individual.mk)
         self.assertEqual(rec[2], sorted([self.jrae.individual.mk]))
+
+    def test_recommend_github_email(self):
+        """Test if GitHub username recommendations are created for identities with valid GitHub emails"""
+
+        github_user1 = api.add_identity(self.ctx,
+                                       username='github-user',
+                                       source='github')
+        github_email1 = api.add_identity(self.ctx,
+                                        email='github-user@users.noreply.github.com',
+                                        source='scm')
+        github_email_numbers1 = api.add_identity(self.ctx,
+                                                email='52891811+github-user@users.noreply.github.com',
+                                                source='scm')
+        github_user2 = api.add_identity(self.ctx,
+                                       username='githubuser2',
+                                       source='github')
+        github_email2 = api.add_identity(self.ctx,
+                                        email='githubuser2@users.noreply.github.com',
+                                        source='scm')
+        github_email_numbers2 = api.add_identity(self.ctx,
+                                                email='52891811+githubuser2@users.noreply.github.com',
+                                                source='scm')
+        invalid_github_email = api.add_identity(self.ctx,
+                                                email='52891811+@users.noreply.github.com',
+                                                source='scm')
+        empty_github_email = api.add_identity(self.ctx,
+                                              email='@users.noreply.github.com',
+                                              source='scm')
+
+        source_uuids = [github_user1.uuid, github_user2.uuid]
+        target_uuids = [github_email1.uuid, github_email_numbers1.uuid,
+                        github_email2.uuid, github_email_numbers2.uuid,
+                        invalid_github_email.uuid, empty_github_email.uuid]
+
+        criteria = ['email', 'name', 'username']
+
+        recs = list(recommend_matches(source_uuids,
+                                      target_uuids,
+                                      criteria,
+                                      verbose=True,
+                                      strict=False,
+                                      guess_github_user=True))
+
+        self.assertEqual(len(recs), 2)
+
+        rec = recs[0]
+        self.assertEqual(rec[0], github_user1.uuid)
+        self.assertEqual(rec[1], github_user1.individual.mk)
+        self.assertEqual(len(rec[2]), 2)
+        self.assertEqual(rec[2], sorted([github_email1.individual.mk, github_email_numbers1.individual.mk]))
+
+        rec = recs[1]
+        self.assertEqual(rec[0], github_user2.uuid)
+        self.assertEqual(rec[1], github_user2.individual.mk)
+        self.assertEqual(len(rec[2]), 2)
+        self.assertEqual(rec[2], sorted([github_email2.individual.mk, github_email_numbers2.individual.mk]))

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -331,12 +331,14 @@ const UNIFY = gql`
     $exclude: Boolean
     $strict: Boolean
     $matchSource: Boolean
+    $guessGithubUser: Boolean
   ) {
     unify(
       criteria: $criteria
       exclude: $exclude
       strict: $strict
       matchSource: $matchSource
+      guessGithubUser: $guessGithubUser
     ) {
       jobId
     }
@@ -361,6 +363,7 @@ const RECOMMEND_MATCHES = gql`
     $sourceUuids: [String]
     $strict: Boolean
     $matchSource: Boolean
+    $guessGithubUser: Boolean
   ) {
     recommendMatches(
       criteria: $criteria
@@ -368,6 +371,7 @@ const RECOMMEND_MATCHES = gql`
       sourceUuids: $sourceUuids
       strict: $strict
       matchSource: $matchSource
+      guessGithubUser: $guessGithubUser
     ) {
       jobId
     }
@@ -792,7 +796,14 @@ const genderize = (apollo, exclude, noStrictMatching, uuids) => {
   });
 };
 
-const unify = (apollo, criteria, exclude, strict, matchSource) => {
+const unify = (
+  apollo,
+  criteria,
+  exclude,
+  strict,
+  matchSource,
+  guessGithubUser
+) => {
   return apollo.mutate({
     mutation: UNIFY,
     variables: {
@@ -800,6 +811,7 @@ const unify = (apollo, criteria, exclude, strict, matchSource) => {
       exclude: exclude,
       strict: strict,
       matchSource: matchSource,
+      guessGithubUser: guessGithubUser,
     },
   });
 };
@@ -821,7 +833,8 @@ const recommendMatches = (
   exclude,
   strict,
   sourceUuids,
-  matchSource
+  matchSource,
+  guessGithubUser
 ) => {
   return apollo.mutate({
     mutation: RECOMMEND_MATCHES,
@@ -831,6 +844,7 @@ const recommendMatches = (
       sourceUuids: sourceUuids,
       strict: strict,
       matchSource: matchSource,
+      guessGithubUser: guessGithubUser,
     },
   });
 };

--- a/ui/src/components/JobModal.vue
+++ b/ui/src/components/JobModal.vue
@@ -54,6 +54,12 @@
                 density="comfortable"
                 hide-details
               />
+              <v-checkbox
+                v-model="forms.unify.guessGithubUser"
+                label="Match GitHub users to GitHub-generated emails"
+                density="comfortable"
+                hide-details
+              ></v-checkbox>
             </v-col>
           </v-row>
           <v-row class="ma-0">
@@ -109,6 +115,12 @@
                 density="comfortable"
                 hide-details
               />
+              <v-checkbox
+                v-model="forms.recommendMatches.guessGithubUser"
+                label="Match GitHub users to GitHub-generated emails"
+                density="comfortable"
+                hide-details
+              ></v-checkbox>
             </v-col>
           </v-row>
           <v-row class="ma-0">
@@ -204,12 +216,14 @@ const defaultForms = {
     exclude: true,
     strict: true,
     matchSource: false,
+    guessGithubUser: false,
   },
   recommendMatches: {
     criteria: ["name", "email", "username"],
     exclude: true,
     strict: true,
     matchSource: false,
+    guessGithubUser: false,
   },
 };
 

--- a/ui/src/components/MatchesModal.vue
+++ b/ui/src/components/MatchesModal.vue
@@ -7,7 +7,7 @@
           <p>
             Enqueued job <code>{{ jobId }}</code> to recommend matches.
           </p>
-          <router-link :to="{ name: 'Jobs' }" target="_blank">
+          <router-link :to="{ name: 'SettingsJobs' }" target="_blank">
             View jobs
           </router-link>
         </v-alert>
@@ -36,7 +36,14 @@
             label="Username"
             value="username"
             dense
+            hide-details=""
           ></v-checkbox>
+          <v-checkbox
+            class="ml-4"
+            v-model="form.matchSource"
+            label="Only recommend identities that share the same source"
+            dense
+          />
         </div>
         <v-divider></v-divider>
         <div class="my-4">
@@ -49,6 +56,12 @@
           <v-checkbox
             v-model="form.exclude"
             label="Exclude individuals in RecommenderExclusionTerm list"
+            dense
+            hide-details
+          ></v-checkbox>
+          <v-checkbox
+            v-model="form.guessGithubUser"
+            label="Match GitHub users to GitHub-generated emails"
             dense
             hide-details
           ></v-checkbox>
@@ -94,6 +107,8 @@ export default {
         criteria: ["name", "email", "username"],
         exclude: true,
         strict: true,
+        matchSource: false,
+        guessGithubUser: false,
       },
       jobId: null,
       error: null,
@@ -106,6 +121,7 @@ export default {
         criteria: ["name", "email", "username"],
         exclude: true,
         strict: true,
+        guessGithubUser: false,
       };
       this.error = null;
       this.jobId = null;
@@ -116,7 +132,9 @@ export default {
           this.form.criteria,
           this.form.exclude,
           this.form.strict,
-          [this.uuid]
+          [this.uuid],
+          this.form.matchSource,
+          this.form.guessGithubUser
         );
         this.jobId = response.data.recommendMatches.jobId;
       } catch (error) {

--- a/ui/src/views/Individual.vue
+++ b/ui/src/views/Individual.vue
@@ -768,13 +768,22 @@ export default {
         this.$logger.error(`Error applying recommendation ${id}: ${error}`);
       }
     },
-    async recommendMatches(criteria, exclude, strict, uuid) {
+    async recommendMatches(
+      criteria,
+      exclude,
+      strict,
+      uuid,
+      matchSource,
+      guessGithubUser
+    ) {
       const response = await recommendMatches(
         this.$apollo,
         criteria,
         exclude,
         strict,
-        uuid
+        uuid,
+        matchSource,
+        guessGithubUser
       );
       return response;
     },

--- a/ui/src/views/Jobs.vue
+++ b/ui/src/views/Jobs.vue
@@ -62,9 +62,16 @@ export default {
         });
       }
     },
-    async unify({ criteria, exclude, strict, matchSource }) {
+    async unify({ criteria, exclude, strict, matchSource, guessGithubUser }) {
       try {
-        await unify(this.$apollo, criteria, exclude, strict, matchSource);
+        await unify(
+          this.$apollo,
+          criteria,
+          exclude,
+          strict,
+          matchSource,
+          guessGithubUser
+        );
         this.$refs.table.getPaginatedJobs();
       } catch (error) {
         this.snackbar = Object.assign(this.snackbar, {
@@ -73,7 +80,13 @@ export default {
         });
       }
     },
-    async recommendMatches({ criteria, exclude, strict, matchSource }) {
+    async recommendMatches({
+      criteria,
+      exclude,
+      strict,
+      matchSource,
+      guessGithubUser,
+    }) {
       try {
         await recommendMatches(
           this.$apollo,
@@ -81,7 +94,8 @@ export default {
           exclude,
           strict,
           [],
-          matchSource
+          matchSource,
+          guessGithubUser
         );
         this.$refs.table.getPaginatedJobs();
       } catch (error) {

--- a/ui/src/views/SettingsGeneral.vue
+++ b/ui/src/views/SettingsGeneral.vue
@@ -146,6 +146,12 @@
                   density="comfortable"
                   hide-details
                 />
+                <v-checkbox
+                  v-model="tasks.unify.params.guessGithubUser"
+                  label="Match GitHub users to GitHub-generated emails"
+                  density="comfortable"
+                  hide-details
+                />
               </v-col>
             </v-row>
             <v-row class="ma-0 pl-2">
@@ -266,6 +272,7 @@ export default {
             exclude: true,
             strict: true,
             match_source: false,
+            guessGithubUser: false,
           },
         },
       },


### PR DESCRIPTION
This PR adds the option to enable matching GitHub-generated emails to usernames on merge recommendations and unify jobs.

Fixes #867.