### PR TITLE
Enforce merge recommendation integrity

### DIFF
--- a/releases/unreleased/enforce-merge-recommendation-integrity.yml
+++ b/releases/unreleased/enforce-merge-recommendation-integrity.yml
@@ -1,0 +1,10 @@
+---
+title: Enforce merge recommendation integrity
+category: fixed
+author: null
+issue: 993
+notes: >
+  Ensure merge recommendations are unique between
+  individuals and prevent creating recommmendations
+  with the same individual.
+

--- a/sortinghat/core/models.py
+++ b/sortinghat/core/models.py
@@ -23,6 +23,7 @@
 import datetime
 
 import dateutil
+from django.db import IntegrityError
 
 from django.db.models import (CASCADE,
                               SET_NULL,
@@ -349,6 +350,15 @@ class MergeRecommendation(EntityBase):
     class Meta:
         db_table = 'merge_recommendations'
         unique_together = ('individual1', 'individual2')
+
+    def save(self, *args, **kwargs):
+        # Ensure individual1.mk is always less than individual2.mk
+        if self.individual1.mk > self.individual2.mk:
+            self.individual1, self.individual2 = self.individual2, self.individual1
+        elif self.individual1.mk == self.individual2.mk:
+            raise IntegrityError("Cannot create a MergeRecommendation with the same individual.")
+
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return '%s - %s' % (self.individual1.mk, self.individual2.mk)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -953,6 +953,34 @@ class TestMergeRecommendation(TransactionTestCase):
         self.assertGreaterEqual(merge_recom.last_modified, before_modified_dt)
         self.assertLessEqual(merge_recom.last_modified, after_modified_dt)
 
+    def test_individual_order_on_save(self):
+        """Check that individual1.mk is always less than individual2.mk"""
+
+        indiv1 = Individual.objects.create(mk='AAAA')
+        indiv2 = Individual.objects.create(mk='BBBB')
+
+        # Create with individual1 > individual2
+        rec = MergeRecommendation(individual1=indiv2, individual2=indiv1)
+        rec.save()
+        self.assertLessEqual(rec.individual1.mk, rec.individual2.mk)
+
+        rec.delete()
+
+        # Create with individual1 < individual2
+        rec2 = MergeRecommendation(individual1=indiv1, individual2=indiv2)
+        rec2.save()
+        self.assertLessEqual(rec2.individual1.mk, rec2.individual2.mk)
+
+    def test_individual_different_on_save(self):
+        """Check that individual1 and individual2 are different"""
+
+        indiv1 = Individual.objects.create(mk='AAAA')
+
+        # Create with individual1 == individual2
+        rec = MergeRecommendation(individual1=indiv1, individual2=indiv1)
+        with self.assertRaises(IntegrityError):
+            rec.save()
+
 
 class TestGenderRecommendation(TransactionTestCase):
     """Unit tests for GenderRecommendation class"""


### PR DESCRIPTION
Ensure that merge recommendations are unique between individuals and prevent creating recommendations with the same  individual.

Fixes https://github.com/chaoss/grimoirelab-sortinghat/issues/993