### PR TITLE
Add base image version argument to worker Dockerfile

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -117,6 +117,8 @@ jobs:
           file: "docker/worker.dockerfile"
           push: true
           tags: ${{ steps.meta-worker.outputs.tags }}
+          build-args: |
+            BASE_IMAGE_TAG=${{ inputs.version }}
 
       - name: Worker Sign the images with GitHub OIDC Token
         env:

--- a/docker/worker.dockerfile
+++ b/docker/worker.dockerfile
@@ -1,4 +1,6 @@
-FROM grimoirelab/sortinghat:latest
+ARG BASE_IMAGE_TAG=latest
+
+FROM grimoirelab/sortinghat:${BASE_IMAGE_TAG}
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 LABEL org.opencontainers.image.title="SortingHat worker"


### PR DESCRIPTION
Add an argument in the worker Dockerfile to define the base image of SortingHat to use for building the image.

This change lets users specify the desired base image version when building, and also resolves an issue where building a release candidate because the latest tag was not updated.