### PR TITLE
[jobs] Handle ObjectDoesNotExist in recommendations

### DIFF
--- a/releases/unreleased/unavailable-individuals-in-recommendations.yml
+++ b/releases/unreleased/unavailable-individuals-in-recommendations.yml
@@ -1,0 +1,9 @@
+---
+title: Unavailable Individuals in Recommendations
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Recommendations now handle cases where an individual has been
+  removed or merged, preventing errors when creating new
+  recommendations.


### PR DESCRIPTION
When running unify or merging individuals while recommendations are in progress, an individual may no longer exist or may have already been merged.

Handle this scenario by checking whether the individual is missing before creating the recommendation.