### PR TITLE
[ui] Option to merge LinkedIn identity

### DIFF
--- a/releases/unreleased/merge-identities-when-adding-a-linkedin-profile.yml
+++ b/releases/unreleased/merge-identities-when-adding-a-linkedin-profile.yml
@@ -1,0 +1,9 @@
+---
+title: Merge identities when adding a LinkedIn profile
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: 987
+notes: >
+  When a user tries to add a LinkedIn identity that already
+  exists to a profile, the user interface now offers the
+  option to merge the identities.

--- a/ui/src/apollo/mutations.js
+++ b/ui/src/apollo/mutations.js
@@ -59,10 +59,14 @@ const MERGE = gql`
       uuid
       individual {
         ...individual
+        changelog {
+          ...changelog
+        }
       }
     }
   }
   ${FULL_INDIVIDUAL}
+  ${CHANGELOG}
 `;
 
 const UNMERGE = gql`


### PR DESCRIPTION
This PR adds the option to merge both individuals when trying to add a LinkedIn identity that already exists to a profile.

<img width="542" height="427" alt="imagen" src="https://github.com/user-attachments/assets/d9e0e07e-6041-4c8c-9836-95fe6fb060a7" />

Fixes #987.