### PR TITLE
[match] Add case-insensitive matching for criteria

### DIFF
--- a/releases/unreleased/case-insensitive-matching-for-criteria.yml
+++ b/releases/unreleased/case-insensitive-matching-for-criteria.yml
@@ -1,0 +1,9 @@
+---
+title: Case-insensitive matching for criteria
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Convert the matching criteria to lowercase.
+  This allows for case-insensitive comparisons,
+  improving the matching accuracy.

--- a/sortinghat/core/recommendations/matching.py
+++ b/sortinghat/core/recommendations/matching.py
@@ -194,6 +194,7 @@ def _find_matches(set_x, set_y, criteria, exclude, verbose, strict, match_source
         """Apply RecommenderExclusionTerm to returns the dataframes that do not match
         `name`, `username`, or `email` with this excluded list"""
         excluded = fetch_recommender_exclusion_list()
+        excluded = [term.lower() for term in excluded]
         df_excluded = df[~df['username'].isin(excluded) & ~df['email'].isin(excluded) & ~df['name'].isin(excluded)]
         return df_excluded
 
@@ -234,6 +235,11 @@ def _find_matches(set_x, set_y, criteria, exclude, verbose, strict, match_source
 
     df_x = _to_df(data_x)
     df_y = _to_df(data_y)
+
+    # Convert to lowercase for case-insensitive matching
+    for c in criteria:
+        df_x[c] = df_x[c].str.lower()
+        df_y[c] = df_y[c].str.lower()
 
     if exclude:
         df_x = _apply_recommender_exclusion_list(df_x)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -628,7 +628,7 @@ class TestRecommendMatches(TestCase):
                                        username='john_smith',
                                        source='scm')
         self.js_alt2 = api.add_identity(self.ctx,
-                                        email='JSmith@example.com',
+                                        email='J_Smith@example.com',
                                         username='john_smith',
                                         source='mls',
                                         uuid=self.js_alt.uuid)
@@ -637,7 +637,7 @@ class TestRecommendMatches(TestCase):
                                         source='mls',
                                         uuid=self.js_alt.uuid)
         self.js_alt4 = api.add_identity(self.ctx,
-                                        email='JSmith@example.com',
+                                        email='J_Smith@example.com',
                                         name='Smith. J',
                                         source='mls',
                                         uuid=self.js_alt.uuid)
@@ -1380,7 +1380,7 @@ class TestUnify(TestCase):
                                        username='john_smith',
                                        source='scm')
         self.js_alt2 = api.add_identity(self.ctx,
-                                        email='JSmith@example.com',
+                                        email='J_Smith@example.com',
                                         username='john_smith',
                                         source='mls',
                                         uuid=self.js_alt.uuid)
@@ -1389,7 +1389,7 @@ class TestUnify(TestCase):
                                         source='mls',
                                         uuid=self.js_alt.uuid)
         self.js_alt4 = api.add_identity(self.ctx,
-                                        email='JSmith@example.com',
+                                        email='J_Smith@example.com',
                                         name='Smith. J',
                                         source='mls',
                                         uuid=self.js_alt.uuid)
@@ -1745,16 +1745,16 @@ class TestUnify(TestCase):
         self.assertEqual(id2, self.js_alt)
 
         id3 = identities[2]
-        self.assertEqual(id3, self.js_alt4)
+        self.assertEqual(id3, self.js_alt3)
 
         id4 = identities[3]
-        self.assertEqual(id4, self.js_alt3)
+        self.assertEqual(id4, self.jsmith)
 
         id5 = identities[4]
-        self.assertEqual(id5, self.jsmith)
+        self.assertEqual(id5, self.jsm3)
 
         id6 = identities[5]
-        self.assertEqual(id6, self.jsm3)
+        self.assertEqual(id6, self.js_alt4)
 
         id7 = identities[6]
         self.assertEqual(id7, self.js_alt2)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -10233,7 +10233,7 @@ class TestUnifyMutation(django.test.TestCase):
                                        username='john_smith',
                                        source='scm')
         self.js_alt2 = api.add_identity(self.ctx,
-                                        email='JSmith@example.com',
+                                        email='J_Smith@example.com',
                                         username='john_smith',
                                         source='mls',
                                         uuid=self.js_alt.uuid)
@@ -10242,7 +10242,7 @@ class TestUnifyMutation(django.test.TestCase):
                                         source='mls',
                                         uuid=self.js_alt.uuid)
         self.js_alt4 = api.add_identity(self.ctx,
-                                        email='JSmith@example.com',
+                                        email='J_Smith@example.com',
                                         name='Smith. J',
                                         source='mls',
                                         uuid=self.js_alt.uuid)
@@ -10374,19 +10374,19 @@ class TestUnifyMutation(django.test.TestCase):
         self.assertEqual(id2, self.js_alt)
 
         id3 = identities[2]
-        self.assertEqual(id3, self.js_alt4)
+        self.assertEqual(id3, self.js_alt3)
 
         id4 = identities[3]
-        self.assertEqual(id4, self.js_alt3)
+        self.assertEqual(id4, self.jsmith)
 
         id5 = identities[4]
-        self.assertEqual(id5, self.jsmith)
+        self.assertEqual(id5, self.jsm3)
 
         id6 = identities[5]
-        self.assertEqual(id6, self.jsm3)
+        self.assertEqual(id6, new_identity)
 
         id7 = identities[6]
-        self.assertEqual(id7, new_identity)
+        self.assertEqual(id7, self.js_alt4)
 
         id8 = identities[7]
         self.assertEqual(id8, self.js_alt2)
@@ -10576,10 +10576,10 @@ class TestUnifyMutation(django.test.TestCase):
         self.assertEqual(id1, self.js_alt)
 
         id2 = identities[1]
-        self.assertEqual(id2, self.js_alt4)
+        self.assertEqual(id2, self.js_alt3)
 
         id3 = identities[2]
-        self.assertEqual(id3, self.js_alt3)
+        self.assertEqual(id3, self.js_alt4)
 
         id4 = identities[3]
         self.assertEqual(id4, self.js_alt2)


### PR DESCRIPTION
This change converts the criteria to lowercase for both sets before matching. This allows for case-insensitive comparisons, improving the matching accuracy.

Replace `JSmith@example.com` with `J_Smith@example.com` because it shares the same email (with uppercase letters) with another identity and shouldn’t match.