### PR TITLE
Fix comparing offset-naive and offset-aware datetimes

### DIFF
--- a/releases/unreleased/table-for-jobs-failing-with-not-scheduled-jobs.yml
+++ b/releases/unreleased/table-for-jobs-failing-with-not-scheduled-jobs.yml
@@ -1,0 +1,8 @@
+---
+title: Table showing jobs failing for offset-naive datetimes
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Showing jobs in the table combining scheduled jobs and one-time
+  jobs failed.


### PR DESCRIPTION
Replaced `datetime.datetime.utcnow()` with `datetime_utcnow()` to ensure consistent offset-aware datetime comparisons when sorting jobs by `enqueued_at` to avoid this error:

<img width="1240" height="378" alt="image (3)" src="https://github.com/user-attachments/assets/928c97ce-d0ff-4b02-b90a-ce382ac56e3b" />


Replace all creations of utc datetime with the `grimoirelab_toolkit.datetime_utcnow` function for consistency.