### PR TITLE
Fix error for existing identities found during importing process

### DIFF
--- a/releases/unreleased/error-of-duplicated-identities-fixed-during-the-import.yml
+++ b/releases/unreleased/error-of-duplicated-identities-fixed-during-the-import.yml
@@ -1,0 +1,9 @@
+---
+title: Error of duplicated identities fixed during the import
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  Duplicated identities found during the import process
+  weren't property handled which made the process to
+  stop with an exception.

--- a/sortinghat/core/importer/backend.py
+++ b/sortinghat/core/importer/backend.py
@@ -23,14 +23,14 @@ import logging
 
 import sortinghat.core.importer.backends
 from grimoirelab_toolkit.introspect import inspect_signature_parameters
-from .. import api, db
+from .. import api
 from ..errors import (LoadError,
                       InvalidValueError,
                       AlreadyExistsError,
                       NotFoundError,
                       DuplicateRangeError)
 from ..importer.utils import find_backends
-from ..models import MIN_PERIOD_DATE, MAX_PERIOD_DATE
+from ..models import MIN_PERIOD_DATE, MAX_PERIOD_DATE, Identity
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +152,10 @@ class IdentitiesImporter:
             except InvalidValueError as e:
                 logger.warning(str(e))
             except AlreadyExistsError as e:
-                stored_identity = db.find_identity(e.eid)
+                stored_identity = Identity.objects.get(source=identity.source,
+                                                       email=identity.email,
+                                                       name=identity.name,
+                                                       username=identity.username)
                 stored_uuid = stored_identity.individual.mk
 
                 if not uuid:


### PR DESCRIPTION
When an identity already stored in the database was found, the identity weren't property handled.

The code caught the exception but the database object of that identity couldn't be found. To find an identity we need the UUID but were using the value returned on the `AlreadyExistError` which is not the UUID, it's just the values of the duplicated entry (name, email, etc).

To fix the error, instead of using the function `find_identity_by_uuid`, we look for it using Django's ORM to look for the tuple (source, name, email, username) because we don't know the UUID of the identity already inserted.