### PR TITLE
[importer] Fix importer from-date on reschedule

### DIFF
--- a/releases/unreleased/importer-job-rescheduled-fixed.yml
+++ b/releases/unreleased/importer-job-rescheduled-fixed.yml
@@ -1,0 +1,10 @@
+---
+title: Importer job rescheduled fixed
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Fixes a bug that caused the importer to always use the same
+  start date when importing identities after being rescheduled.
+  It now uses the start date of the current job as from_date
+  for the next execution.

--- a/sortinghat/core/jobs.py
+++ b/sortinghat/core/jobs.py
@@ -947,12 +947,13 @@ def on_success_job(job, connection, result, *args, **kwargs):
     task.executions = task.executions + 1
     task.failed = False
 
-    # Detect if the importer backend uses 'update_from' argument and update it
+    # Detect if the importer backend uses 'from_date' argument and update it
     if task.job_type == 'import_identities':
         backends = find_import_identities_backends()
         backend_name = task.args['backend_name']
-        if 'update_from' in backends[backend_name]['args']:
-            task.args['params']['update_from'] = task.scheduled_datetime
+        if 'from_date' in backends[backend_name]['args']:
+            job.kwargs['from_date'] = task.scheduled_datetime
+            task.args['from_date'] = task.scheduled_datetime
 
     if not task.interval:
         logger.info("Interval not defined, not rescheduling task.")


### PR DESCRIPTION
Fix a bug that caused the importer to always use the same start date when importing identities after being rescheduled.

It now uses the start date of the current job as the `from_date` for the next execution.