### PR TITLE
[api] Change task_id type to ID and cast interval to Int

### DIFF
--- a/releases/unreleased/graphql-task_id-type-changed-and-interval-value-conversion.yml
+++ b/releases/unreleased/graphql-task_id-type-changed-and-interval-value-conversion.yml
@@ -1,0 +1,14 @@
+---
+title: GraphQL task_id type changed and interval value conversion
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Updated task_id fields in DeleteScheduledTask and UpdateScheduledTask
+  to use graphene.ID() instead of graphene.Int(). In Graphene v3, this
+  caused type errors because a string value was being passed instead of
+  an integer.
+
+  Also converted interval values to numbers in the ImporterModal and
+  SettingsGeneral components to prevent similar type errors, since
+  Graphene v3 expects numeric values instead of strings.

--- a/sortinghat/core/schema.py
+++ b/sortinghat/core/schema.py
@@ -1550,7 +1550,7 @@ class ScheduleTask(graphene.Mutation):
 
 class DeleteScheduledTask(graphene.Mutation):
     class Arguments:
-        task_id = graphene.Int()
+        task_id = graphene.ID()
 
     deleted = graphene.Boolean()
 
@@ -1574,7 +1574,7 @@ class DeleteScheduledTask(graphene.Mutation):
 
 class UpdateScheduledTask(graphene.Mutation):
     class Arguments:
-        task_id = graphene.Int()
+        task_id = graphene.ID()
         data = ScheduledTaskInputType()
 
     task = graphene.Field(lambda: ScheduledTaskType)

--- a/ui/src/components/ImporterModal.vue
+++ b/ui/src/components/ImporterModal.vue
@@ -123,7 +123,7 @@ export default {
         });
         const response = await this.createTask(
           "import_identities",
-          interval,
+          Number(interval),
           params
         );
         if (response && !response.errors) {
@@ -145,7 +145,7 @@ export default {
           ...this.form.fields,
         });
         const data = {
-          interval: interval,
+          interval: Number(interval),
           params: params,
         };
         const response = await this.editTask(this.task.id, data);

--- a/ui/src/views/SettingsGeneral.vue
+++ b/ui/src/views/SettingsGeneral.vue
@@ -331,7 +331,7 @@ export default {
       const task = await scheduleTask(
         this.$apollo,
         job,
-        interval,
+        Number(interval),
         JSON.stringify(this.tasks[job].params)
       ).catch((error) => {
         this.openSnackbar(error);
@@ -367,7 +367,7 @@ export default {
           ? this.tasks[job].customInterval
           : this.tasks[job].interval;
       const data = {
-        interval: interval,
+        interval: Number(interval),
         params: JSON.stringify(this.tasks[job].params),
       };
 


### PR DESCRIPTION
Update `task_id` fields in `DeleteScheduledTask` and `UpdateScheduledTask` to use `graphene.ID()` instead of `graphene.Int()`. In Graphene v3, this was causing type errors because a string value was being passed instead of an integer.

Also converted `interval` values to numbers in the `ImporterModal` and `SettingsGeneral` components to prevent similar type errors, since Graphene v3 expects numeric values instead of strings.