### PR TITLE
 Fix "View jobs" link opening wrong page from recommend matches modal

### DIFF
--- a/ui/src/components/MatchesModal.vue
+++ b/ui/src/components/MatchesModal.vue
@@ -7,9 +7,9 @@
           <p>
             Enqueued job <code>{{ jobId }}</code> to recommend matches.
           </p>
-          <router-link :to="{ name: 'SettingsJobs' }" target="_blank">
+          <a :href="jobsUrl" target="_blank" rel="noopener noreferrer">
             View jobs
-          </router-link>
+          </a>
         </v-alert>
       </v-card-text>
       <v-card-text v-else>
@@ -114,6 +114,12 @@ export default {
       error: null,
     };
   },
+  computed: {
+    jobsUrl() {
+      return this.$router.resolve({ name: "SettingsJobs" }).href;
+    },
+  },
+
   methods: {
     closeModal() {
       this.$emit("update:isOpen", false);


### PR DESCRIPTION
## Summary

Fixes #865.

I looked into the frontend flow for the "View jobs" link shown after creating a recommended matches job. The current modal uses a `router-link` with `target="_blank"`.

In deployments using a base path such as `/identities/`, this can open the landing page instead of the jobs page.

## What changed

* Replaced the `router-link` with a normal anchor using the resolved `SettingsJobs` route URL
* Kept opening in a new tab
* Added `rel="noopener noreferrer"`

## Validation

* Built the UI locally with `npm run build`
* Confirmed the change is limited to the modal component
