### PR TITLE
Update node version to 24.x in Docker workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node ${{ matrix.node-version }}


### PR DESCRIPTION
This change updates the Node.js version used in the Docker workflow from 20.x to 24.x.